### PR TITLE
fix: persist last selected config state when switching between configurations

### DIFF
--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -14,7 +14,7 @@ pub struct App {
     pub logs: LogModel,
     pub ticks: u32,
     pub active_panel: Panel,
-    pub loading: bool
+    pub loading: bool,
 }
 
 #[derive(Clone, PartialEq)]
@@ -68,5 +68,14 @@ impl App {
             Panel::TaskInstance => self.active_panel = Panel::DAGRun,
             Panel::Logs => self.active_panel = Panel::TaskInstance,
         }
+    }
+
+    pub fn clear_state(&mut self) {
+        self.ticks = 0;
+        self.loading = true;
+        self.dags.all.clear();
+        self.dagruns.all.clear();
+        self.task_instances.all.clear();
+        self.logs.all.clear();
     }
 }

--- a/src/app/worker.rs
+++ b/src/app/worker.rs
@@ -302,8 +302,7 @@ impl Worker {
 
         let mut app = self.app.lock().unwrap();
         app.config.active_server = Some(selected_config.name.clone());
-        app.ticks = 0;
-        *app = App::new(app.config.clone()).unwrap();
+        app.clear_state();
     }
 
     pub async fn run(&mut self) {


### PR DESCRIPTION
Fixes #283 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved application state management during Airflow client switching
- **Chores**
  - Enhanced debug logging for better runtime monitoring and error tracing
  - Refined state reset mechanism without recreating entire application instance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->