### PR TITLE
Add open commands for all listable Airflow entities (base server, dag, dagrun, task instance, log)

### DIFF
--- a/src/app/model/config.rs
+++ b/src/app/model/config.rs
@@ -8,7 +8,7 @@ use ratatui::widgets::{Block, BorderType, Borders, Row, StatefulWidget, Table, W
 
 use crate::airflow::config::AirflowConfig;
 use crate::app::events::custom::FlowrsEvent;
-use crate::app::worker::WorkerMessage;
+use crate::app::worker::{OpenItem, WorkerMessage};
 use crate::ui::constants::{ALTERNATING_ROW_COLOR, DEFAULT_STYLE};
 
 use super::popup::commands_help::CommandPopUp;
@@ -83,9 +83,12 @@ impl Model for ConfigModel {
                         KeyCode::Char('o') => {
                             let selected_config =
                                 self.filtered.state.selected().unwrap_or_default();
-                            let endpoint = &self.filtered.items[selected_config].endpoint;
-                            debug!("Selected config: {}", endpoint);
-                            webbrowser::open(endpoint).unwrap();
+                            let endpoint =
+                                self.filtered.items[selected_config].endpoint.to_string();
+                            return (
+                                Some(event.clone()),
+                                vec![WorkerMessage::OpenItem(OpenItem::Config(endpoint))],
+                            );
                         }
                         KeyCode::Char('?') => {
                             self.commands = Some(&*CONFIG_COMMAND_POP_UP);

--- a/src/app/model/dagruns.rs
+++ b/src/app/model/dagruns.rs
@@ -27,7 +27,7 @@ use super::popup::dagruns::DagRunPopUp;
 use super::popup::popup_area;
 use super::popup::{dagruns::clear::ClearDagRunPopup, dagruns::mark::MarkDagRunPopup};
 use super::{filter::Filter, Model, StatefulTable};
-use crate::app::worker::WorkerMessage;
+use crate::app::worker::{OpenItem, WorkerMessage};
 use anyhow::Error;
 
 pub struct DagRunModel {
@@ -287,6 +287,17 @@ impl Model for DagRunModel {
                                         dag_run_id: dag_run.dag_run_id.clone(),
                                         clear: true,
                                     }],
+                                );
+                            }
+                        }
+                        KeyCode::Char('o') => {
+                            if let (Some(dag_id), Some(dag_run)) = (&self.dag_id, &self.current()) {
+                                return (
+                                    Some(FlowrsEvent::Key(*key_event)),
+                                    vec![WorkerMessage::OpenItem(OpenItem::DagRun {
+                                        dag_id: dag_id.clone(),
+                                        dag_run_id: dag_run.dag_run_id.clone(),
+                                    })],
                                 );
                             }
                         }

--- a/src/app/model/dags.rs
+++ b/src/app/model/dags.rs
@@ -18,7 +18,7 @@ use crate::ui::constants::{AirflowStateColor, ALTERNATING_ROW_COLOR, DEFAULT_STY
 
 use super::popup::commands_help::CommandPopUp;
 use super::{filter::Filter, Model, StatefulTable};
-use crate::app::worker::WorkerMessage;
+use crate::app::worker::{OpenItem, WorkerMessage};
 use anyhow::Error;
 
 pub struct DagModel {
@@ -165,6 +165,20 @@ impl Model for DagModel {
                                 }
                             } else {
                                 self.event_buffer.push(FlowrsEvent::Key(*key_event));
+                            }
+                        }
+                        KeyCode::Char('o') => {
+                            if let Some(dag) = self.current() {
+                                debug!("Selected dag: {}", dag.dag_id);
+                                return (
+                                    Some(FlowrsEvent::Key(*key_event)),
+                                    vec![WorkerMessage::OpenItem(OpenItem::Dag {
+                                        dag_id: dag.dag_id.clone(),
+                                    })],
+                                );
+                            } else {
+                                self.errors
+                                    .push(Error::msg("No DAG selected to open in the browser"));
                             }
                         }
                         _ => return (Some(FlowrsEvent::Key(*key_event)), vec![]), // if no match, return the event

--- a/src/app/model/popup/commands_help.rs
+++ b/src/app/model/popup/commands_help.rs
@@ -62,6 +62,11 @@ impl DefaultCommands {
                 description: "Filter items",
             },
             Command {
+                name: "Open",
+                key_binding: "o",
+                description: "Open the selected item in the browser",
+            },
+            Command {
                 name: "Previous",
                 key_binding: "k / Up",
                 description: "Move to the previous item",

--- a/src/app/model/taskinstances.rs
+++ b/src/app/model/taskinstances.rs
@@ -21,7 +21,7 @@ use super::popup::taskinstances::clear::ClearTaskInstancePopup;
 use super::popup::taskinstances::mark::MarkTaskInstancePopup;
 use super::popup::taskinstances::TaskInstancePopUp;
 use super::{filter::Filter, Model, StatefulTable};
-use crate::app::worker::WorkerMessage;
+use crate::app::worker::{OpenItem, WorkerMessage};
 use anyhow::Error;
 
 pub struct TaskInstanceModel {
@@ -225,12 +225,25 @@ impl Model for TaskInstanceModel {
                             if let Some(task_instance) = self.current() {
                                 return (
                                     Some(FlowrsEvent::Key(*key_event)),
-                                    vec![WorkerMessage::GetTaskLogs {
+                                    vec![WorkerMessage::UpdateTaskLogs {
                                         dag_id: task_instance.dag_id.clone(),
                                         dag_run_id: task_instance.dag_run_id.clone(),
                                         task_id: task_instance.task_id.clone(),
                                         task_try: task_instance.try_number as u16,
+                                        clear: true,
                                     }],
+                                );
+                            }
+                        }
+                        KeyCode::Char('o') => {
+                            if let Some(task_instance) = self.current() {
+                                return (
+                                    Some(FlowrsEvent::Key(*key_event)),
+                                    vec![WorkerMessage::OpenItem(OpenItem::TaskInstance {
+                                        dag_id: task_instance.dag_id.clone(),
+                                        dag_run_id: task_instance.dag_run_id.clone(),
+                                        task_id: task_instance.task_id.clone(),
+                                    })],
                                 );
                             }
                         }


### PR DESCRIPTION
Fixes #287 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new "Open" command to open selected items in the browser
	- Introduced keyboard shortcut 'o' to open configurations, DAGs, DAG runs, task instances, and logs

- **Bug Fixes**
	- Improved error handling for opening items when no selection is available

- **Refactor**
	- Implemented a message-passing mechanism for opening items
	- Updated worker message processing to support new open functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->