### PR TITLE
fix: allow using Left/Right keys for switching between TaskInstance logs

### DIFF
--- a/src/app/model/logs.rs
+++ b/src/app/model/logs.rs
@@ -86,12 +86,22 @@ impl Model for LogModel {
                 return (Some(FlowrsEvent::Tick), vec![]);
             }
             FlowrsEvent::Key(key) => match key.code {
-                KeyCode::Char('l') => {
-                    self.current += 1;
+                KeyCode::Char('l') | KeyCode::Right => {
+                    if !self.all.is_empty() {
+                        if self.current == self.all.len() - 1 {
+                            self.current = 0;
+                        } else {
+                            self.current += 1;
+                        }
+                    }
                 }
-                KeyCode::Char('h') => {
-                    if self.current > 0 {
-                        self.current -= 1;
+                KeyCode::Char('h') | KeyCode::Left => {
+                    if !self.all.is_empty() {
+                        if self.current == 0 {
+                            self.current = self.all.len() - 1;
+                        } else {
+                            self.current -= 1;
+                        }
                     }
                 }
                 KeyCode::Down | KeyCode::Char('j') => {


### PR DESCRIPTION
fixes #308 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced log navigation with additional keyboard controls
	- Added support for right and left arrow keys to navigate through logs
	- Improved wrapping behavior for log navigation when reaching the beginning or end of the log list
<!-- end of auto-generated comment: release notes by coderabbit.ai -->