### PR TITLE
chore: release v0.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13](https://github.com/jvanbuel/flowrs/compare/v0.1.12...v0.1.13) - 2025-04-21
+
+### Other
+
+- Merge pull request #355 from jvanbuel/release-plz-2025-04-21T15-11-08Z
+
 ## [0.1.12](https://github.com/jvanbuel/flowrs/compare/v0.1.11...v0.1.12) - 2025-04-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-tui"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-tui"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 description = "Flowrs is a Terminal User Interface (TUI) for Apache Airflow"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `flowrs-tui`: 0.1.12 -> 0.1.13

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.13](https://github.com/jvanbuel/flowrs/compare/v0.1.12...v0.1.13) - 2025-04-21

### Other

- Merge pull request #355 from jvanbuel/release-plz-2025-04-21T15-11-08Z
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the changelog with a new entry for version 0.1.13.
  - Bumped the application version to 0.1.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->