### PR TITLE
chore: release v0.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.16](https://github.com/jvanbuel/flowrs/compare/v0.1.15...v0.1.16) - 2025-10-08
+
+### Added
+
+- show error popup
+
 ## [0.1.15](https://github.com/jvanbuel/flowrs/compare/v0.1.14...v0.1.15) - 2025-10-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-tui"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-tui"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 description = "Flowrs is a Terminal User Interface (TUI) for Apache Airflow"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `flowrs-tui`: 0.1.15 -> 0.1.16

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.16](https://github.com/jvanbuel/flowrs/compare/v0.1.15...v0.1.16) - 2025-10-08

### Added

- show error popup
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Show an error popup to inform users when an issue occurs.
* Documentation
  * Updated changelog with an unreleased 0.1.16 entry noting the new error popup.
* Chores
  * Bumped package version from 0.1.15 to 0.1.16.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->