### PR TITLE
fix: only show rotating flowrs logo once

### DIFF
--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -15,6 +15,7 @@ pub struct App {
     pub ticks: u32,
     pub active_panel: Panel,
     pub loading: bool,
+    pub startup: bool,
 }
 
 #[derive(Clone, PartialEq)]
@@ -47,6 +48,7 @@ impl App {
             },
             ticks: 0,
             loading: true,
+            startup: true,
         })
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -12,10 +12,11 @@ pub const TIME_FORMAT: &str = "[year]-[month]-[day] [hour]:[minute]:[second]";
 
 pub fn draw_ui(f: &mut Frame, app: &Arc<Mutex<App>>) {
     let mut app = app.lock().unwrap();
-    if app.ticks <= 10 {
+    if app.startup && app.ticks <= 10 {
         render_init_screen(f, app.ticks);
         return;
     }
+    app.startup = false;
     app.loading = false;
     // Only frame has the ability to set the cursor position, so we need to control the cursor filter from here
     // Not very elegant, and quite some duplication... Should be refactored


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured the initial startup view only appears on first launch, preventing repeated intro states during runtime.
  - Reduced flicker and unintended re-initialization on subsequent renders for a smoother experience.

- **User Experience**
  - Improved first-load behavior with a cleaner, more predictable initial screen.
  - Streamlined transition from launch to regular UI after the first render.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->