### PR TITLE
chore: release v0.1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/jvanbuel/flowrs/compare/v0.1.16...v0.1.17) - 2025-10-08
+
+### Fixed
+
+- only show rotating flowrs logo once
+
 ## [0.1.16](https://github.com/jvanbuel/flowrs/compare/v0.1.15...v0.1.16) - 2025-10-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-tui"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-tui"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 description = "Flowrs is a Terminal User Interface (TUI) for Apache Airflow"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `flowrs-tui`: 0.1.16 -> 0.1.17

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.17](https://github.com/jvanbuel/flowrs/compare/v0.1.16...v0.1.17) - 2025-10-08

### Fixed

- only show rotating flowrs logo once
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).