### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/jvanbuel/flowrs/compare/v0.4.0...v0.4.1) - 2025-10-22
+
+### Added
+
+- use HashMap for environments api resources and clients instead of swapping them at the App top-level
+
 ## [0.3.2](https://github.com/jvanbuel/flowrs/compare/v0.3.1...v0.3.2) - 2025-10-22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-tui"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-tui"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Flowrs is a Terminal User Interface (TUI) for Apache Airflow"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `flowrs-tui`: 0.4.0 -> 0.4.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/jvanbuel/flowrs/compare/v0.4.0...v0.4.1) - 2025-10-22

### Added

- use HashMap for environments api resources and clients instead of swapping them at the App top-level
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).