### PR TITLE
fix: list all task instances of a DagRun

### DIFF
--- a/src/airflow/client/v1/taskinstance.rs
+++ b/src/airflow/client/v1/taskinstance.rs
@@ -3,10 +3,12 @@ use async_trait::async_trait;
 use log::{debug, info};
 use reqwest::{Method, Response};
 
-use crate::airflow::{model::common::TaskInstanceList, traits::TaskInstanceOperations};
 use super::model;
+use crate::airflow::{model::common::TaskInstanceList, traits::TaskInstanceOperations};
 
 use super::V1Client;
+
+const PAGE_SIZE: usize = 100;
 
 #[async_trait]
 impl TaskInstanceOperations for V1Client {
@@ -15,33 +17,96 @@ impl TaskInstanceOperations for V1Client {
         dag_id: &str,
         dag_run_id: &str,
     ) -> Result<TaskInstanceList> {
-        let response: Response = self
-            .base_api(
-                Method::GET,
-                &format!("dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances"),
-            )?
-            .send()
-            .await?
-            .error_for_status()?;
-        let daglist: model::taskinstance::TaskInstanceCollectionResponse = response
-            .json::<model::taskinstance::TaskInstanceCollectionResponse>()
-            .await?;
-        info!("TaskInstances: {daglist:?}");
-        Ok(daglist.into())
+        let mut all_task_instances = Vec::new();
+        let mut offset = 0;
+        let limit = PAGE_SIZE;
+        let mut total_entries;
+
+        loop {
+            let response: Response = self
+                .base_api(
+                    Method::GET,
+                    &format!("dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances"),
+                )?
+                .query(&[("limit", limit.to_string()), ("offset", offset.to_string())])
+                .send()
+                .await?
+                .error_for_status()?;
+
+            let page: model::taskinstance::TaskInstanceCollectionResponse = response
+                .json::<model::taskinstance::TaskInstanceCollectionResponse>()
+                .await?;
+
+            total_entries = page.total_entries;
+            let fetched_count = page.task_instances.len();
+            all_task_instances.extend(page.task_instances);
+
+            debug!(
+                "Fetched {fetched_count} task instances, offset: {offset}, total: {total_entries}"
+            );
+
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            if fetched_count < limit || all_task_instances.len() >= total_entries as usize {
+                break;
+            }
+
+            offset += limit;
+        }
+
+        info!(
+            "Fetched total {} task instances out of {}",
+            all_task_instances.len(),
+            total_entries
+        );
+
+        Ok(TaskInstanceList {
+            task_instances: all_task_instances.into_iter().map(Into::into).collect(),
+            total_entries,
+        })
     }
 
     async fn list_all_taskinstances(&self) -> Result<TaskInstanceList> {
-        let response: Response = self
-            .base_api(Method::GET, "dags/~/dagRuns/~/taskInstances")?
-            .send()
-            .await?
-            .error_for_status()?;
+        let mut all_task_instances = Vec::new();
+        let mut offset = 0;
+        let limit = 100;
+        let mut total_entries;
 
-        debug!("list_all_taskinstances response: {response:?}");
-        let daglist: model::taskinstance::TaskInstanceCollectionResponse = response
-            .json::<model::taskinstance::TaskInstanceCollectionResponse>()
-            .await?;
-        Ok(daglist.into())
+        loop {
+            let response: Response = self
+                .base_api(Method::GET, "dags/~/dagRuns/~/taskInstances")?
+                .query(&[("limit", limit.to_string()), ("offset", offset.to_string())])
+                .send()
+                .await?
+                .error_for_status()?;
+
+            let page: model::taskinstance::TaskInstanceCollectionResponse = response
+                .json::<model::taskinstance::TaskInstanceCollectionResponse>()
+                .await?;
+
+            total_entries = page.total_entries;
+            let fetched_count = page.task_instances.len();
+            all_task_instances.extend(page.task_instances);
+
+            debug!("Fetched {fetched_count} task instances (all), offset: {offset}, total: {total_entries}");
+
+            let total_usize = usize::try_from(total_entries).unwrap_or(usize::MAX);
+            if fetched_count < limit || all_task_instances.len() >= total_usize {
+                break;
+            }
+
+            offset += fetched_count;
+        }
+
+        info!(
+            "Fetched total {} task instances (all) out of {}",
+            all_task_instances.len(),
+            total_entries
+        );
+
+        Ok(TaskInstanceList {
+            task_instances: all_task_instances.into_iter().map(Into::into).collect(),
+            total_entries,
+        })
     }
 
     async fn mark_task_instance(

--- a/src/app/model/dagruns.rs
+++ b/src/app/model/dagruns.rs
@@ -84,16 +84,18 @@ impl DagRunModel {
 
     pub fn filter_dag_runs(&mut self) {
         let prefix = &self.filter.prefix;
-        let filtered_dag_runs = match prefix {
-            Some(prefix) => &self
+        let mut filtered_dag_runs = match prefix {
+            Some(prefix) => self
                 .all
                 .iter()
                 .filter(|dagrun| dagrun.dag_run_id.contains(prefix))
                 .cloned()
                 .collect::<Vec<DagRun>>(),
-            None => &self.all,
+            None => self.all.clone(),
         };
-        self.filtered.items = filtered_dag_runs.clone();
+        // Sort by start_date in descending order (most recent first)
+        filtered_dag_runs.sort_by(|a, b| b.start_date.cmp(&a.start_date));
+        self.filtered.items = filtered_dag_runs;
     }
 
     pub fn current(&self) -> Option<&DagRun> {


### PR DESCRIPTION
fixes #415 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task instance list queries now automatically paginate and aggregate all available results into a single complete response.
* **Other Changes**
  * Filtered DAG run lists are now explicitly sorted by start date (newest first).
  * Improved pagination debug logging to show progress and totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->