### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/jvanbuel/flowrs/compare/v0.4.1...v0.4.2) - 2025-10-23
+
+### Fixed
+
+- list all task instances of a DagRun
+
 ## [0.4.1](https://github.com/jvanbuel/flowrs/compare/v0.4.0...v0.4.1) - 2025-10-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-mwaa"
-version = "1.92.0"
+version = "1.93.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc8886dbc120e8237f92c9e3540a8e21562ceba7cb476f39473285fc02d6350"
+checksum = "5b5bd3f7806d7474868934d76de7091318d142870fea7dfd3593517f597a133e"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-tui"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -2419,9 +2419,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "8e0f6df8eaa422d97d72edcd152e1451618fed47fabbdbd5a8864167b1d4aff7"
 dependencies = [
  "unicode-ident",
 ]
@@ -3181,9 +3181,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.107"
+version = "2.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
+checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-tui"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Flowrs is a Terminal User Interface (TUI) for Apache Airflow"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `flowrs-tui`: 0.4.1 -> 0.4.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.2](https://github.com/jvanbuel/flowrs/compare/v0.4.1...v0.4.2) - 2025-10-23

### Fixed

- list all task instances of a DagRun
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with listing all task instances of a DagRun

<!-- end of auto-generated comment: release notes by coderabbit.ai -->