### PR TITLE
chore: release v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5](https://github.com/jvanbuel/flowrs/compare/v0.4.4...v0.4.5) - 2025-12-12
+
+### Fixed
+
+- new cargo-dist version
+
 ## [0.4.4](https://github.com/jvanbuel/flowrs/compare/v0.4.3...v0.4.4) - 2025-12-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-tui"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-tui"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 description = "Flowrs is a Terminal User Interface (TUI) for Apache Airflow"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `flowrs-tui`: 0.4.4 -> 0.4.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.5](https://github.com/jvanbuel/flowrs/compare/v0.4.4...v0.4.5) - 2025-12-12

### Fixed

- new cargo-dist version
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved compatibility issue with cargo-dist

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->