### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/jvanbuel/flowrs/compare/v0.5.0...v0.5.1) - 2025-12-14
+
+### Fixed
+
+- readd dist profile
+
 ## [0.4.5](https://github.com/jvanbuel/flowrs/compare/v0.4.4...v0.4.5) - 2025-12-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-tui"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-tui"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Flowrs is a Terminal User Interface (TUI) for Apache Airflow"


### PR DESCRIPTION



## 🤖 New release

* `flowrs-tui`: 0.5.0 -> 0.5.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.1](https://github.com/jvanbuel/flowrs/compare/v0.5.0...v0.5.1) - 2025-12-14

### Fixed

- readd dist profile
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).