### PR TITLE
feat: disable API calls when TUI is unfocused

### DIFF
--- a/docs/plans/2025-12-18-focus-tracking-design.md
+++ b/docs/plans/2025-12-18-focus-tracking-design.md
@@ -1,0 +1,104 @@
+# Focus Tracking Design
+
+## Overview
+
+Implement focus change tracking using crossterm's focus events. When the TUI loses focus, automatic API refreshes (Tick events) are paused to avoid unnecessary network calls while the user isn't watching.
+
+## Behavior
+
+- When focused: Normal operation, Tick events trigger API refreshes
+- When unfocused: Tick events are discarded, no automatic refreshes
+- On focus regain: Clean slate, refreshes resume normally (no queued messages to process)
+
+## Changes
+
+### 1. Terminal Setup (`src/main.rs`)
+
+Enable focus change reporting on startup, disable on shutdown:
+
+```rust
+// On startup (after entering raw mode):
+crossterm::terminal::enable_focus_change_reporting()?;
+
+// On shutdown (before leaving raw mode):
+crossterm::terminal::disable_focus_change_reporting()?;
+```
+
+The disable call must be in the cleanup path that runs even on panic/error.
+
+### 2. Event Types (`src/app/events/custom.rs`)
+
+Add two new variants to `FlowrsEvent`:
+
+```rust
+pub enum FlowrsEvent {
+    Tick,
+    Key(KeyEvent),
+    Mouse,
+    FocusGained,  // new
+    FocusLost,    // new
+}
+```
+
+Update `From<crossterm::event::Event>` to map:
+- `Event::FocusGained` -> `FlowrsEvent::FocusGained`
+- `Event::FocusLost` -> `FlowrsEvent::FocusLost`
+
+### 3. App State (`src/app/state.rs`)
+
+Add a boolean field to track focus:
+
+```rust
+pub struct App {
+    // ... existing fields ...
+    pub focused: bool,  // defaults to true
+}
+```
+
+### 4. Main Loop (`src/app.rs`)
+
+Handle focus events early in the event loop and filter Ticks when unfocused:
+
+```rust
+if let Some(event) = events.next().await {
+    // Handle focus changes first
+    match &event {
+        FlowrsEvent::FocusGained => {
+            app.lock().unwrap().focused = true;
+            continue;
+        }
+        FlowrsEvent::FocusLost => {
+            app.lock().unwrap().focused = false;
+            continue;
+        }
+        _ => {}
+    }
+
+    // Skip tick processing when unfocused
+    if let FlowrsEvent::Tick = &event {
+        if !app.lock().unwrap().focused {
+            continue;
+        }
+    }
+
+    // ... rest of existing event handling ...
+}
+```
+
+### 5. UI Indicator (Optional)
+
+Since `focused` is in App state, a visual indicator can be shown when paused (e.g., dimmed UI, "Paused" text in status bar, or different border color).
+
+## File Summary
+
+| File | Change |
+|------|--------|
+| `src/main.rs` | Enable/disable focus reporting in terminal setup/teardown |
+| `src/app/events/custom.rs` | Add `FocusGained`/`FocusLost` variants + From impl |
+| `src/app/state.rs` | Add `focused: bool` field to App |
+| `src/app.rs` | Handle focus events, skip Ticks when unfocused |
+| `src/ui.rs` (optional) | Show paused indicator |
+
+## Compatibility
+
+Most modern terminals support focus reporting (iTerm2, Kitty, Windows Terminal, Alacritty, etc.). Terminals that don't support it will simply ignore the escape sequences - the app continues to work normally, just without the pause-on-unfocus feature.

--- a/src/app/events/custom.rs
+++ b/src/app/events/custom.rs
@@ -5,6 +5,8 @@ pub enum FlowrsEvent {
     Tick,
     Key(KeyEvent),
     Mouse,
+    FocusGained,
+    FocusLost,
 }
 
 impl From<crossterm::event::Event> for FlowrsEvent {
@@ -12,6 +14,8 @@ impl From<crossterm::event::Event> for FlowrsEvent {
         match ev {
             crossterm::event::Event::Key(key) => FlowrsEvent::Key(key),
             crossterm::event::Event::Mouse(_) => FlowrsEvent::Mouse,
+            crossterm::event::Event::FocusGained => FlowrsEvent::FocusGained,
+            crossterm::event::Event::FocusLost => FlowrsEvent::FocusLost,
             _ => FlowrsEvent::Tick,
         }
     }

--- a/src/app/model/config.rs
+++ b/src/app/model/config.rs
@@ -133,7 +133,9 @@ impl Model for ConfigModel {
                 }
                 (None, vec![])
             }
-            FlowrsEvent::Mouse => (Some(event.clone()), vec![]),
+            FlowrsEvent::Mouse
+            | FlowrsEvent::FocusGained
+            | FlowrsEvent::FocusLost => (Some(event.clone()), vec![]),
         }
     }
 }

--- a/src/app/model/dagruns.rs
+++ b/src/app/model/dagruns.rs
@@ -471,7 +471,9 @@ impl Model for DagRunModel {
                     }
                 }
             }
-            FlowrsEvent::Mouse => {}
+            FlowrsEvent::Mouse
+            | FlowrsEvent::FocusGained
+            | FlowrsEvent::FocusLost => {}
         }
         (Some(event.clone()), vec![])
     }

--- a/src/app/model/dags.rs
+++ b/src/app/model/dags.rs
@@ -200,7 +200,9 @@ impl Model for DagModel {
                 }
                 (None, vec![])
             }
-            FlowrsEvent::Mouse => (Some(event.clone()), vec![]),
+            FlowrsEvent::Mouse
+            | FlowrsEvent::FocusGained
+            | FlowrsEvent::FocusLost => (Some(event.clone()), vec![]),
         }
     }
 }

--- a/src/app/model/logs.rs
+++ b/src/app/model/logs.rs
@@ -138,7 +138,9 @@ impl Model for LogModel {
                     _ => return (Some(FlowrsEvent::Key(*key)), vec![]), // if no match, return the event
                 }
             }
-            FlowrsEvent::Mouse => (),
+            FlowrsEvent::Mouse
+            | FlowrsEvent::FocusGained
+            | FlowrsEvent::FocusLost => (),
         }
 
         (None, vec![])

--- a/src/app/model/taskinstances.rs
+++ b/src/app/model/taskinstances.rs
@@ -324,7 +324,9 @@ impl Model for TaskInstanceModel {
                 }
                 (None, vec![])
             }
-            FlowrsEvent::Mouse => (Some(event.clone()), vec![]),
+            FlowrsEvent::Mouse
+            | FlowrsEvent::FocusGained
+            | FlowrsEvent::FocusLost => (Some(event.clone()), vec![]),
         }
     }
 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -30,6 +30,8 @@ pub struct App {
     pub throbber_state: ThrobberState,
     /// Global warning popup shown on startup (e.g., legacy config conflict)
     pub warning_popup: Option<WarningPopup>,
+    /// Whether the terminal window has focus (used to pause refreshes when unfocused)
+    pub focused: bool,
 }
 
 #[derive(Clone, PartialEq)]
@@ -82,6 +84,7 @@ impl App {
             startup: true,
             throbber_state: ThrobberState::default(),
             warning_popup,
+            focused: true,
         }
     }
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use clap::Parser;
+use crossterm::event::{DisableFocusChange, EnableFocusChange};
+use crossterm::ExecutableCommand;
 use log::{info, LevelFilter};
 use simplelog::{Config, WriteLogger};
 
@@ -48,12 +50,15 @@ impl RunCommand {
 
         // setup terminal (includes panic hooks) and run app
         let mut terminal = ratatui::init();
+        std::io::stdout().execute(EnableFocusChange)?;
+
         let app = App::new_with_errors_and_warnings(config, errors, warnings);
-        run_app(&mut terminal, Arc::new(Mutex::new(app))).await?;
+        let result = run_app(&mut terminal, Arc::new(Mutex::new(app))).await;
 
         info!("Shutting down the terminal...");
+        std::io::stdout().execute(DisableFocusChange)?;
         ratatui::restore();
-        Ok(())
+        result
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal now tracks focus state to pause automatic API refreshes when the terminal loses focus
  * Automatic refreshes resume when the terminal regains focus
  * Added optional UI indicator to display paused state

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->