### PR TITLE
chore: release v0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.5](https://github.com/jvanbuel/flowrs/compare/v0.7.4...v0.7.5) - 2025-12-21
+
+### Added
+
+- add DAG trigger to DAG  panel ([#493](https://github.com/jvanbuel/flowrs/pull/493))
+- topological sort for tasks ([#489](https://github.com/jvanbuel/flowrs/pull/489))
+- improve dagstats handling ([#486](https://github.com/jvanbuel/flowrs/pull/486))
+
+### Fixed
+
+- missing indentation in DAG code popup ([#492](https://github.com/jvanbuel/flowrs/pull/492))
+
+### Other
+
+- small refactorings ([#488](https://github.com/jvanbuel/flowrs/pull/488))
+
 ## [0.7.4](https://github.com/jvanbuel/flowrs/compare/v0.7.3...v0.7.4) - 2025-12-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-tui"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -1804,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "7ee5b5339afb4c41626dde77b7a611bd4f2c202b897852b4bcf5d03eddc61010"
 
 [[package]]
 name = "jiff"
@@ -2769,9 +2769,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "62049b2877bf12821e8f9ad256ee38fdc31db7387ec2d3b3f403024de2034aea"
 
 [[package]]
 name = "same-file"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-tui"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Flowrs is a Terminal User Interface (TUI) for Apache Airflow"


### PR DESCRIPTION



## 🤖 New release

* `flowrs-tui`: 0.7.4 -> 0.7.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.5](https://github.com/jvanbuel/flowrs/compare/v0.7.4...v0.7.5) - 2025-12-21

### Added

- add DAG trigger to DAG  panel ([#493](https://github.com/jvanbuel/flowrs/pull/493))
- topological sort for tasks ([#489](https://github.com/jvanbuel/flowrs/pull/489))
- improve dagstats handling ([#486](https://github.com/jvanbuel/flowrs/pull/486))

### Fixed

- missing indentation in DAG code popup ([#492](https://github.com/jvanbuel/flowrs/pull/492))

### Other

- small refactorings ([#488](https://github.com/jvanbuel/flowrs/pull/488))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).