### PR TITLE
chore: release v0.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.6](https://github.com/jvanbuel/flowrs/compare/v0.7.5...v0.7.6) - 2025-12-21
+
+### Other
+
+- [WIP] Update help commands popup text color for better visibility ([#494](https://github.com/jvanbuel/flowrs/pull/494))
+
 ## [0.7.5](https://github.com/jvanbuel/flowrs/compare/v0.7.4...v0.7.5) - 2025-12-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-tui"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-tui"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Flowrs is a Terminal User Interface (TUI) for Apache Airflow"


### PR DESCRIPTION



## 🤖 New release

* `flowrs-tui`: 0.7.5 -> 0.7.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.6](https://github.com/jvanbuel/flowrs/compare/v0.7.5...v0.7.6) - 2025-12-21

### Other

- [WIP] Update help commands popup text color for better visibility ([#494](https://github.com/jvanbuel/flowrs/pull/494))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text color visibility in the help commands popup for better readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->