### PR TITLE
chore: release v0.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.7](https://github.com/jvanbuel/flowrs/compare/v0.7.6...v0.7.7) - 2025-12-29
+
+### Other
+
+- update dependencies
+- *(deps)* bump serde_json from 1.0.145 to 1.0.148 ([#501](https://github.com/jvanbuel/flowrs/pull/501))
+- *(deps)* bump reqwest from 0.12.26 to 0.12.28 ([#502](https://github.com/jvanbuel/flowrs/pull/502))
+
 ## [0.7.6](https://github.com/jvanbuel/flowrs/compare/v0.7.5...v0.7.6) - 2025-12-21
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-tui"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -3920,9 +3920,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-tui"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Flowrs is a Terminal User Interface (TUI) for Apache Airflow"


### PR DESCRIPTION



## 🤖 New release

* `flowrs-tui`: 0.7.6 -> 0.7.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.7](https://github.com/jvanbuel/flowrs/compare/v0.7.6...v0.7.7) - 2025-12-29

### Other

- update dependencies
- *(deps)* bump serde_json from 1.0.145 to 1.0.148 ([#501](https://github.com/jvanbuel/flowrs/pull/501))
- *(deps)* bump reqwest from 0.12.26 to 0.12.28 ([#502](https://github.com/jvanbuel/flowrs/pull/502))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.7.7
  * Dependency updates: serde_json and reqwest

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->