### PR TITLE
feat: create generic FilterableTable widget for Dags, DagRuns, and Ta…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-tui"
-version = "0.7.8"
+version = "0.8.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-tui"
-version = "0.7.8"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Flowrs is a Terminal User Interface (TUI) for Apache Airflow"

--- a/src/app.rs
+++ b/src/app.rs
@@ -123,7 +123,7 @@ where
                             if *clear {
                                 app.dagruns.dag_id = Some(dag_id.clone());
                                 // Sync cached data immediately
-                                app.dagruns.all = app.environment_state.get_active_dag_runs(dag_id);
+                                app.dagruns.table.all = app.environment_state.get_active_dag_runs(dag_id);
                                 app.dagruns.filter_dag_runs();
                             }
                         }
@@ -136,7 +136,7 @@ where
                                 app.task_instances.dag_id = Some(dag_id.clone());
                                 app.task_instances.dag_run_id = Some(dag_run_id.clone());
                                 // Sync cached data immediately
-                                app.task_instances.all = app
+                                app.task_instances.table.all = app
                                     .environment_state
                                     .get_active_task_instances(dag_id, dag_run_id);
                                 app.task_instances.filter_task_instances();

--- a/src/app.rs
+++ b/src/app.rs
@@ -140,7 +140,7 @@ where
                                 app.task_instances.table.all = app
                                     .environment_state
                                     .get_active_task_instances(dag_id, dag_run_id);
-                                app.task_instances.filter_task_instances();
+                                app.task_instances.table.apply_filter();
                             }
                         }
                         WorkerMessage::UpdateTaskLogs {

--- a/src/app.rs
+++ b/src/app.rs
@@ -123,7 +123,8 @@ where
                             if *clear {
                                 app.dagruns.dag_id = Some(dag_id.clone());
                                 // Sync cached data immediately
-                                app.dagruns.table.all = app.environment_state.get_active_dag_runs(dag_id);
+                                app.dagruns.table.all =
+                                    app.environment_state.get_active_dag_runs(dag_id);
                                 app.dagruns.filter_dag_runs();
                             }
                         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -125,7 +125,8 @@ where
                                 // Sync cached data immediately
                                 app.dagruns.table.all =
                                     app.environment_state.get_active_dag_runs(dag_id);
-                                app.dagruns.filter_dag_runs();
+                                app.dagruns.table.apply_filter();
+                                app.dagruns.sort_dag_runs();
                             }
                         }
                         WorkerMessage::UpdateTaskInstances {

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -13,6 +13,54 @@ pub mod taskinstances;
 
 pub use filterable_table::FilterableTable;
 
+/// Result of handling a key event in the chain of responsibility pattern.
+///
+/// Handlers return this to indicate whether they consumed the event and
+/// what messages/events should be produced.
+#[derive(Debug)]
+pub enum KeyResult {
+    /// Event was consumed, no further processing needed
+    Consumed,
+    /// Event was consumed and produced worker messages
+    ConsumedWith(Vec<WorkerMessage>),
+    /// Event was consumed but should pass through (for panel navigation)
+    PassThrough,
+    /// Event was consumed, pass through with messages
+    PassWith(Vec<WorkerMessage>),
+    /// Event was not handled by this handler, try next in chain
+    Ignored,
+}
+
+impl KeyResult {
+    /// Chain handlers: if this result is Ignored, try the next handler
+    pub fn or_else<F: FnOnce() -> KeyResult>(self, f: F) -> KeyResult {
+        match self {
+            KeyResult::Ignored => f(),
+            other => other,
+        }
+    }
+
+    /// Convert to the update() return type
+    pub fn into_result(self, event: &FlowrsEvent) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
+        match self {
+            KeyResult::Consumed => (None, vec![]),
+            KeyResult::ConsumedWith(msgs) => (None, msgs),
+            KeyResult::PassThrough => (Some(event.clone()), vec![]),
+            KeyResult::PassWith(msgs) => (Some(event.clone()), msgs),
+            KeyResult::Ignored => (Some(event.clone()), vec![]),
+        }
+    }
+
+    /// Create from a simple bool (true = consumed, false = ignored)
+    pub fn from_consumed(consumed: bool) -> Self {
+        if consumed {
+            KeyResult::Consumed
+        } else {
+            KeyResult::Ignored
+        }
+    }
+}
+
 pub trait Model {
     fn update(&mut self, event: &FlowrsEvent) -> (Option<FlowrsEvent>, Vec<WorkerMessage>);
 }

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -1,4 +1,3 @@
-use crossterm::event::KeyCode;
 use ratatui::widgets::TableState;
 
 use super::{events::custom::FlowrsEvent, worker::WorkerMessage};
@@ -13,28 +12,7 @@ pub mod popup;
 pub mod taskinstances;
 
 pub use filterable_table::FilterableTable;
-
-/// Dismiss an error popup if visible. Returns Consumed if popup was shown, Ignored otherwise.
-pub fn dismiss_error_popup<T>(popup: &mut Option<T>, key_code: KeyCode) -> KeyResult {
-    if popup.is_none() {
-        return KeyResult::Ignored;
-    }
-    if matches!(key_code, KeyCode::Char('q') | KeyCode::Esc) {
-        *popup = None;
-    }
-    KeyResult::Consumed
-}
-
-/// Dismiss a commands popup if visible. Returns Consumed if popup was shown, Ignored otherwise.
-pub fn dismiss_commands_popup<T>(popup: &mut Option<T>, key_code: KeyCode) -> KeyResult {
-    if popup.is_none() {
-        return KeyResult::Ignored;
-    }
-    if matches!(key_code, KeyCode::Char('q' | '?') | KeyCode::Esc | KeyCode::Enter) {
-        *popup = None;
-    }
-    KeyResult::Consumed
-}
+pub use popup::Popup;
 
 /// Result of handling a key event in the chain of responsibility pattern.
 ///

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -34,6 +34,7 @@ pub enum KeyResult {
 
 impl KeyResult {
     /// Chain handlers: if this result is Ignored, try the next handler
+    #[must_use]
     pub fn or_else<F: FnOnce() -> KeyResult>(self, f: F) -> KeyResult {
         match self {
             KeyResult::Ignored => f(),
@@ -41,7 +42,8 @@ impl KeyResult {
         }
     }
 
-    /// Convert to the update() return type
+    /// Convert to the `update()` return type
+    #[allow(clippy::match_same_arms)] // PassThrough and Ignored are semantically different
     pub fn into_result(self, event: &FlowrsEvent) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
         match self {
             KeyResult::Consumed => (None, vec![]),

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -6,9 +6,12 @@ pub mod config;
 pub mod dagruns;
 pub mod dags;
 pub mod filter;
+pub mod filterable_table;
 pub mod logs;
 pub mod popup;
 pub mod taskinstances;
+
+pub use filterable_table::FilterableTable;
 
 pub trait Model {
     fn update(&mut self, event: &FlowrsEvent) -> (Option<FlowrsEvent>, Vec<WorkerMessage>);

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -1,3 +1,4 @@
+use crossterm::event::KeyCode;
 use ratatui::widgets::TableState;
 
 use super::{events::custom::FlowrsEvent, worker::WorkerMessage};
@@ -12,6 +13,28 @@ pub mod popup;
 pub mod taskinstances;
 
 pub use filterable_table::FilterableTable;
+
+/// Dismiss an error popup if visible. Returns Consumed if popup was shown, Ignored otherwise.
+pub fn dismiss_error_popup<T>(popup: &mut Option<T>, key_code: KeyCode) -> KeyResult {
+    if popup.is_none() {
+        return KeyResult::Ignored;
+    }
+    if matches!(key_code, KeyCode::Char('q') | KeyCode::Esc) {
+        *popup = None;
+    }
+    KeyResult::Consumed
+}
+
+/// Dismiss a commands popup if visible. Returns Consumed if popup was shown, Ignored otherwise.
+pub fn dismiss_commands_popup<T>(popup: &mut Option<T>, key_code: KeyCode) -> KeyResult {
+    if popup.is_none() {
+        return KeyResult::Ignored;
+    }
+    if matches!(key_code, KeyCode::Char('q' | '?') | KeyCode::Esc | KeyCode::Enter) {
+        *popup = None;
+    }
+    KeyResult::Consumed
+}
 
 /// Result of handling a key event in the chain of responsibility pattern.
 ///

--- a/src/app/model/config.rs
+++ b/src/app/model/config.rs
@@ -86,7 +86,10 @@ impl Model for ConfigModel {
                     .table
                     .handle_filter_key(key_event)
                     .or_else(|| self.popup.handle_dismiss(key_event.code))
-                    .or_else(|| self.table.handle_navigation(key_event.code, &mut self.event_buffer))
+                    .or_else(|| {
+                        self.table
+                            .handle_navigation(key_event.code, &mut self.event_buffer)
+                    })
                     .or_else(|| self.handle_keys(key_event));
 
                 result.into_result(event)

--- a/src/app/model/config.rs
+++ b/src/app/model/config.rs
@@ -48,21 +48,27 @@ impl ConfigModel {
     fn handle_keys(&mut self, key_event: &KeyEvent) -> KeyResult {
         match key_event.code {
             KeyCode::Char('o') => {
-                let selected_config = self.table.filtered.state.selected().unwrap_or_default();
-                let endpoint = self.table.filtered.items[selected_config].endpoint.clone();
-                KeyResult::PassWith(vec![WorkerMessage::OpenItem(OpenItem::Config(endpoint))])
+                if let Some(idx) = self.table.filtered.state.selected() {
+                    if let Some(item) = self.table.filtered.items.get(idx) {
+                        return KeyResult::PassWith(vec![WorkerMessage::OpenItem(
+                            OpenItem::Config(item.endpoint.clone()),
+                        )]);
+                    }
+                }
+                KeyResult::PassThrough
             }
             KeyCode::Char('?') => {
                 self.popup.show_commands(&CONFIG_COMMAND_POP_UP);
                 KeyResult::Consumed
             }
             KeyCode::Enter => {
-                let selected_config = self.table.filtered.state.selected().unwrap_or_default();
-                debug!(
-                    "Selected config: {}",
-                    self.table.filtered.items[selected_config].name
-                );
-                KeyResult::PassWith(vec![WorkerMessage::ConfigSelected(selected_config)])
+                if let Some(idx) = self.table.filtered.state.selected() {
+                    if let Some(item) = self.table.filtered.items.get(idx) {
+                        debug!("Selected config: {}", item.name);
+                        return KeyResult::PassWith(vec![WorkerMessage::ConfigSelected(idx)]);
+                    }
+                }
+                KeyResult::PassThrough
             }
             _ => KeyResult::PassThrough,
         }

--- a/src/app/model/config.rs
+++ b/src/app/model/config.rs
@@ -16,7 +16,7 @@ use crate::ui::theme::{
 use super::popup::commands_help::CommandPopUp;
 use super::popup::config::commands::CONFIG_COMMAND_POP_UP;
 use super::popup::error::ErrorPopup;
-use super::{FilterableTable, KeyResult, Model};
+use super::{dismiss_commands_popup, dismiss_error_popup, FilterableTable, KeyResult, Model};
 use crate::ui::common::create_headers;
 
 pub struct ConfigModel {
@@ -67,28 +67,6 @@ impl ConfigModel {
         self.table.apply_filter();
     }
 
-    /// Handle error popup dismissal
-    fn handle_error_popup(&mut self, key_code: KeyCode) -> KeyResult {
-        if self.error_popup.is_none() {
-            return KeyResult::Ignored;
-        }
-        if matches!(key_code, KeyCode::Char('q') | KeyCode::Esc) {
-            self.error_popup = None;
-        }
-        KeyResult::Consumed
-    }
-
-    /// Handle commands popup dismissal
-    fn handle_commands_popup(&mut self, key_code: KeyCode) -> KeyResult {
-        if self.commands.is_none() {
-            return KeyResult::Ignored;
-        }
-        if matches!(key_code, KeyCode::Char('q' | '?') | KeyCode::Esc | KeyCode::Enter) {
-            self.commands = None;
-        }
-        KeyResult::Consumed
-    }
-
     /// Handle model-specific keys
     fn handle_keys(&mut self, key_event: &KeyEvent) -> KeyResult {
         match key_event.code {
@@ -122,8 +100,8 @@ impl Model for ConfigModel {
                 let result = self
                     .table
                     .handle_filter_key(key_event)
-                    .or_else(|| self.handle_error_popup(key_event.code))
-                    .or_else(|| self.handle_commands_popup(key_event.code))
+                    .or_else(|| dismiss_error_popup(&mut self.error_popup, key_event.code))
+                    .or_else(|| dismiss_commands_popup(&mut self.commands, key_event.code))
                     .or_else(|| self.table.handle_navigation(key_event.code, &mut self.event_buffer))
                     .or_else(|| self.handle_keys(key_event));
 

--- a/src/app/model/config.rs
+++ b/src/app/model/config.rs
@@ -30,7 +30,7 @@ impl ConfigModel {
         let mut table = FilterableTable::new();
         table.set_items(configs.to_vec());
         let config_names: Vec<String> = configs.iter().map(|c| c.name.clone()).collect();
-        table.set_primary_values("name", config_names);
+        table.filter.set_primary_values("name", config_names);
 
         Self {
             table,
@@ -45,11 +45,6 @@ impl ConfigModel {
             model.popup.show_error(errors);
         }
         model
-    }
-
-    /// Apply filter to configs
-    pub fn filter_configs(&mut self) {
-        self.table.apply_filter();
     }
 
     /// Handle model-specific keys
@@ -103,7 +98,7 @@ impl Model for ConfigModel {
 
 impl Widget for &mut ConfigModel {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let rects = if self.table.is_filter_active() {
+        let rects = if self.table.filter.is_active() {
             let rects = Layout::default()
                 .constraints([Constraint::Fill(90), Constraint::Max(3)].as_ref())
                 .margin(0)

--- a/src/app/model/dagruns.rs
+++ b/src/app/model/dagruns.rs
@@ -31,7 +31,7 @@ use super::popup::dagruns::DagRunPopUp;
 use super::popup::error::ErrorPopup;
 use super::popup::popup_area;
 use super::popup::{dagruns::clear::ClearDagRunPopup, dagruns::mark::MarkDagRunPopup};
-use super::{filter::filter_items, FilterableTable, KeyResult, Model};
+use super::{dismiss_commands_popup, dismiss_error_popup, filter::filter_items, FilterableTable, KeyResult, Model};
 use crate::app::worker::{OpenItem, WorkerMessage};
 
 /// Model for the DAG Run panel, managing the list of DAG runs and their filtering.
@@ -205,28 +205,6 @@ impl DagRunModel {
 }
 
 impl DagRunModel {
-    /// Handle error popup dismissal
-    fn handle_error_popup(&mut self, key_code: KeyCode) -> KeyResult {
-        if self.error_popup.is_none() {
-            return KeyResult::Ignored;
-        }
-        if matches!(key_code, KeyCode::Char('q') | KeyCode::Esc) {
-            self.error_popup = None;
-        }
-        KeyResult::Consumed
-    }
-
-    /// Handle commands popup dismissal
-    fn handle_commands_popup(&mut self, key_code: KeyCode) -> KeyResult {
-        if self.commands.is_none() {
-            return KeyResult::Ignored;
-        }
-        if matches!(key_code, KeyCode::Char('q' | '?') | KeyCode::Esc) {
-            self.commands = None;
-        }
-        KeyResult::Consumed
-    }
-
     /// Handle dag code viewer navigation
     fn handle_dag_code_viewer(&mut self, key_code: KeyCode) -> KeyResult {
         if self.dag_code.cached_lines.is_none() {
@@ -393,9 +371,8 @@ impl Model for DagRunModel {
                 }
 
                 // Chain the remaining handlers
-                let result = self
-                    .handle_error_popup(key_event.code)
-                    .or_else(|| self.handle_commands_popup(key_event.code))
+                let result = dismiss_error_popup(&mut self.error_popup, key_event.code)
+                    .or_else(|| dismiss_commands_popup(&mut self.commands, key_event.code))
                     .or_else(|| self.handle_dag_code_viewer(key_event.code))
                     .or_else(|| self.table.handle_visual_mode_key(key_event.code))
                     .or_else(|| self.table.handle_navigation(key_event.code, &mut self.event_buffer))

--- a/src/app/model/dagruns.rs
+++ b/src/app/model/dagruns.rs
@@ -354,10 +354,6 @@ impl Model for DagRunModel {
                                 KeyCode::Char('?') => {
                                     self.commands = Some(&*DAGRUN_COMMAND_POP_UP);
                                 }
-                                KeyCode::Char('/') => {
-                                    self.table.activate_filter();
-                                    self.filter_dag_runs();
-                                }
                                 KeyCode::Char('v') => {
                                     if let Some(dag_id) = &self.dag_id {
                                         return (

--- a/src/app/model/dagruns.rs
+++ b/src/app/model/dagruns.rs
@@ -247,7 +247,8 @@ impl DagRunModel {
                     matches!(custom_popup, DagRunPopUp::Clear(_) | DagRunPopUp::Mark(_));
                 self.popup.close();
                 if exit_visual {
-                    self.table.exit_visual_mode();
+                    self.table.visual_mode = false;
+                    self.table.visual_anchor = None;
                 }
             }
         }
@@ -392,7 +393,7 @@ impl Model for DagRunModel {
 
 impl Widget for &mut DagRunModel {
     fn render(self, area: Rect, buf: &mut ratatui::prelude::Buffer) {
-        let rects = if self.table.is_filter_active() {
+        let rects = if self.table.filter.is_active() {
             let rects = Layout::default()
                 .constraints([Constraint::Fill(90), Constraint::Max(3)].as_ref())
                 .margin(0)

--- a/src/app/model/dags.rs
+++ b/src/app/model/dags.rs
@@ -23,7 +23,7 @@ use crate::ui::theme::{
 
 use super::popup::commands_help::CommandPopUp;
 use super::popup::error::ErrorPopup;
-use super::{FilterableTable, KeyResult, Model};
+use super::{dismiss_commands_popup, dismiss_error_popup, FilterableTable, KeyResult, Model};
 use crate::app::worker::{OpenItem, WorkerMessage};
 
 /// Model for the DAG panel, managing the list of DAGs and their filtering.
@@ -75,28 +75,6 @@ impl DagModel {
 }
 
 impl DagModel {
-    /// Handle error popup dismissal
-    fn handle_error_popup(&mut self, key_code: KeyCode) -> KeyResult {
-        if self.error_popup.is_none() {
-            return KeyResult::Ignored;
-        }
-        if matches!(key_code, KeyCode::Char('q') | KeyCode::Esc) {
-            self.error_popup = None;
-        }
-        KeyResult::Consumed
-    }
-
-    /// Handle commands popup dismissal
-    fn handle_commands_popup(&mut self, key_code: KeyCode) -> KeyResult {
-        if self.commands.is_none() {
-            return KeyResult::Ignored;
-        }
-        if matches!(key_code, KeyCode::Char('q' | '?') | KeyCode::Esc) {
-            self.commands = None;
-        }
-        KeyResult::Consumed
-    }
-
     /// Handle model-specific popup (returns messages from popup)
     fn handle_popup(&mut self, event: &FlowrsEvent) -> Option<Vec<WorkerMessage>> {
         let popup = self.popup.as_mut()?;
@@ -205,8 +183,8 @@ impl Model for DagModel {
                 let result = self
                     .table
                     .handle_filter_key(key_event)
-                    .or_else(|| self.handle_error_popup(key_event.code))
-                    .or_else(|| self.handle_commands_popup(key_event.code))
+                    .or_else(|| dismiss_error_popup(&mut self.error_popup, key_event.code))
+                    .or_else(|| dismiss_commands_popup(&mut self.commands, key_event.code))
                     .or_else(|| self.table.handle_navigation(key_event.code, &mut self.event_buffer))
                     .or_else(|| self.handle_keys(key_event.code));
 

--- a/src/app/model/dags.rs
+++ b/src/app/model/dags.rs
@@ -16,8 +16,7 @@ use crate::app::model::popup::dags::commands::DAG_COMMAND_POP_UP;
 use crate::ui::common::create_headers;
 use crate::ui::constants::AirflowStateColor;
 use crate::ui::theme::{
-    ACCENT, ALT_ROW_STYLE, BORDER_STYLE, DAG_ACTIVE, DEFAULT_STYLE, SELECTED_ROW_STYLE,
-    TABLE_HEADER_STYLE, TEXT_PRIMARY,
+    BORDER_STYLE, DAG_ACTIVE, SELECTED_ROW_STYLE, TABLE_HEADER_STYLE, TEXT_PRIMARY,
 };
 
 use super::popup::dags::DagPopUp;
@@ -185,20 +184,8 @@ impl Model for DagModel {
 
 impl Widget for &mut DagModel {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let rects = if self.table.filter.is_active() {
-            let rects = Layout::default()
-                .constraints([Constraint::Fill(90), Constraint::Max(3)].as_ref())
-                .margin(0)
-                .split(area);
+        let content_area = self.table.render_with_filter(area, buf);
 
-            self.table.filter.render_widget(rects[1], buf);
-            rects
-        } else {
-            Layout::default()
-                .constraints([Constraint::Percentage(100)].as_ref())
-                .margin(0)
-                .split(area)
-        };
         let headers = ["Active", "Name", "Owners", "Schedule", "Next Run", "Stats"];
         let header_row = create_headers(headers);
         let header = Row::new(header_row).style(TABLE_HEADER_STYLE);
@@ -256,11 +243,7 @@ impl Widget for &mut DagModel {
                             },
                         )),
                     ])
-                    .style(if (idx % 2) == 0 {
-                        DEFAULT_STYLE
-                    } else {
-                        ALT_ROW_STYLE
-                    })
+                    .style(self.table.row_style(idx))
                 });
         let t = Table::new(
             rows,
@@ -280,18 +263,15 @@ impl Widget for &mut DagModel {
                 .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
                 .border_style(BORDER_STYLE)
                 .title(" Press <?> to see available commands ");
-            if let Some(filter_text) = self.table.filter.filter_display() {
-                block.title_bottom(Line::from(Span::styled(
-                    format!(" Filter: {filter_text} "),
-                    Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
-                )))
+            if let Some(title) = self.table.status_title() {
+                block.title_bottom(title)
             } else {
                 block
             }
         })
         .row_highlight_style(SELECTED_ROW_STYLE);
 
-        StatefulWidget::render(t, rects[0], buf, &mut self.table.filtered.state);
+        StatefulWidget::render(t, content_area, buf, &mut self.table.filtered.state);
 
         // Render any active popup (error, commands, or custom)
         (&self.popup).render(area, buf);

--- a/src/app/model/dags.rs
+++ b/src/app/model/dags.rs
@@ -91,18 +91,20 @@ impl DagModel {
     /// Handle model-specific keys
     fn handle_keys(&mut self, key_code: KeyCode) -> KeyResult {
         match key_code {
-            KeyCode::Char('p') => if let Some(dag) = self.current() {
-                let current_state = dag.is_paused;
-                dag.is_paused = !current_state;
-                KeyResult::ConsumedWith(vec![WorkerMessage::ToggleDag {
-                    dag_id: dag.dag_id.clone(),
-                    is_paused: current_state,
-                }])
-            } else {
-                self.popup
-                    .show_error(vec!["No DAG selected to pause/resume".to_string()]);
-                KeyResult::Consumed
-            },
+            KeyCode::Char('p') => {
+                if let Some(dag) = self.current() {
+                    let current_state = dag.is_paused;
+                    dag.is_paused = !current_state;
+                    KeyResult::ConsumedWith(vec![WorkerMessage::ToggleDag {
+                        dag_id: dag.dag_id.clone(),
+                        is_paused: current_state,
+                    }])
+                } else {
+                    self.popup
+                        .show_error(vec!["No DAG selected to pause/resume".to_string()]);
+                    KeyResult::Consumed
+                }
+            }
             KeyCode::Char('?') => {
                 self.popup.show_commands(&DAG_COMMAND_POP_UP);
                 KeyResult::Consumed

--- a/src/app/model/dags.rs
+++ b/src/app/model/dags.rs
@@ -150,9 +150,6 @@ impl Model for DagModel {
                                 ]));
                             }
                         },
-                        KeyCode::Char('/') => {
-                            self.table.activate_filter();
-                        }
                         KeyCode::Char('?') => {
                             self.commands = Some(&*DAG_COMMAND_POP_UP);
                         }

--- a/src/app/model/dags.rs
+++ b/src/app/model/dags.rs
@@ -53,11 +53,6 @@ impl DagModel {
         Self::default()
     }
 
-    /// Apply filter to the DAGs
-    pub fn filter_dags(&mut self) {
-        self.table.apply_filter();
-    }
-
     /// Get the currently selected DAG (mutable)
     pub fn current(&mut self) -> Option<&mut Dag> {
         self.table.current_mut()
@@ -190,7 +185,7 @@ impl Model for DagModel {
 
 impl Widget for &mut DagModel {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let rects = if self.table.is_filter_active() {
+        let rects = if self.table.filter.is_active() {
             let rects = Layout::default()
                 .constraints([Constraint::Fill(90), Constraint::Max(3)].as_ref())
                 .margin(0)

--- a/src/app/model/filterable_table.rs
+++ b/src/app/model/filterable_table.rs
@@ -1,4 +1,4 @@
-//! Generic filterable table widget for use across Dags, DagRuns, and TaskInstances.
+//! Generic filterable table widget for use across Dags, `DagRuns`, and `TaskInstances`.
 //!
 //! This module provides a reusable `FilterableTable<T>` that encapsulates:
 //! - All items from the API
@@ -192,7 +192,11 @@ impl<T: Filterable + Clone> FilterableTable<T> {
     }
 
     /// Handle common navigation keys (j/k/G/gg pattern)
-    pub fn handle_navigation(&mut self, key_code: KeyCode, event_buffer: &mut Vec<KeyCode>) -> KeyResult {
+    pub fn handle_navigation(
+        &mut self,
+        key_code: KeyCode,
+        event_buffer: &mut Vec<KeyCode>,
+    ) -> KeyResult {
         match key_code {
             KeyCode::Down | KeyCode::Char('j') => {
                 self.next();

--- a/src/app/model/filterable_table.rs
+++ b/src/app/model/filterable_table.rs
@@ -10,9 +10,14 @@
 use std::ops::RangeInclusive;
 
 use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
 
 use super::filter::{filter_items, FilterStateMachine, Filterable};
 use super::{KeyResult, StatefulTable};
+use crate::ui::theme::{ACCENT, ALT_ROW_STYLE, DEFAULT_STYLE, MARKED_STYLE};
 
 /// A generic filterable table that combines data storage, filtering, and visual selection.
 ///
@@ -193,6 +198,72 @@ impl<T: Filterable + Clone> FilterableTable<T> {
                 }
             }
             _ => KeyResult::Ignored,
+        }
+    }
+
+    /// Renders the filter widget if active and returns the content area.
+    ///
+    /// This handles the common pattern of splitting the area for filter input.
+    pub fn render_with_filter(&mut self, area: Rect, buf: &mut Buffer) -> Rect {
+        if self.filter.is_active() {
+            let rects = Layout::default()
+                .constraints([Constraint::Fill(90), Constraint::Max(3)])
+                .split(area);
+            self.filter.render_widget(rects[1], buf);
+            rects[0]
+        } else {
+            area
+        }
+    }
+
+    /// Returns the style for a row based on its index and visual selection state.
+    ///
+    /// Uses `MARKED_STYLE` for visually selected rows, alternating `DEFAULT_STYLE`/`ALT_ROW_STYLE` otherwise.
+    pub fn row_style(&self, idx: usize) -> Style {
+        if self
+            .visual_selection()
+            .as_ref()
+            .is_some_and(|r| r.contains(&idx))
+        {
+            MARKED_STYLE
+        } else if idx.is_multiple_of(2) {
+            DEFAULT_STYLE
+        } else {
+            ALT_ROW_STYLE
+        }
+    }
+
+    /// Returns the bottom title line for table blocks, showing visual mode and/or filter status.
+    ///
+    /// Returns None if neither visual mode nor filter is active.
+    pub fn status_title(&self) -> Option<Line<'static>> {
+        let filter_text = self.filter.filter_display();
+        match (self.visual_mode, filter_text) {
+            (true, Some(filter)) => Some(Line::from(vec![
+                Span::raw(" -- VISUAL ("),
+                Span::styled(
+                    format!("{}", self.visual_selection_count()),
+                    Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(" selected) -- | "),
+                Span::styled(
+                    format!("Filter: {filter} "),
+                    Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
+                ),
+            ])),
+            (true, None) => Some(Line::from(vec![
+                Span::raw(" -- VISUAL ("),
+                Span::styled(
+                    format!("{}", self.visual_selection_count()),
+                    Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(" selected) -- "),
+            ])),
+            (false, Some(filter)) => Some(Line::from(Span::styled(
+                format!(" Filter: {filter} "),
+                Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
+            ))),
+            (false, None) => None,
         }
     }
 }

--- a/src/app/model/filterable_table.rs
+++ b/src/app/model/filterable_table.rs
@@ -1,0 +1,423 @@
+//! Generic filterable table widget for use across Dags, DagRuns, and TaskInstances.
+//!
+//! This module provides a reusable `FilterableTable<T>` that encapsulates:
+//! - All items from the API
+//! - Filtered items with table state for UI rendering
+//! - Filter state machine with autocomplete support
+//! - Visual mode selection
+//! - Common navigation operations
+
+use std::ops::RangeInclusive;
+
+use crossterm::event::{KeyCode, KeyEvent};
+
+use super::filter::{filter_items, FilterStateMachine, Filterable};
+use super::StatefulTable;
+
+/// A generic filterable table that combines data storage, filtering, and visual selection.
+///
+/// This widget is designed to work with any type that implements `Filterable + Clone`.
+#[derive(Clone, Default)]
+pub struct FilterableTable<T> {
+    /// All items from the API (unfiltered)
+    pub all: Vec<T>,
+    /// Filtered items with table state for rendering
+    pub filtered: StatefulTable<T>,
+    /// Filter state machine with autocomplete
+    pub filter: FilterStateMachine,
+    /// Whether visual mode (multi-select) is active
+    pub visual_mode: bool,
+    /// Anchor index for visual selection
+    pub visual_anchor: Option<usize>,
+}
+
+impl<T: Filterable + Clone> FilterableTable<T> {
+    /// Creates a new empty filterable table
+    pub fn new() -> Self {
+        Self {
+            all: Vec::new(),
+            filtered: StatefulTable::new(Vec::new()),
+            filter: FilterStateMachine::default(),
+            visual_mode: false,
+            visual_anchor: None,
+        }
+    }
+
+    /// Sets the items and applies the current filter
+    pub fn set_items(&mut self, items: Vec<T>) {
+        self.all = items;
+        self.apply_filter();
+    }
+
+    /// Applies the current filter conditions to the items
+    pub fn apply_filter(&mut self) {
+        let conditions = self.filter.active_conditions();
+        let filtered = filter_items(&self.all, &conditions);
+        self.filtered.items = filtered;
+    }
+
+    /// Activates filter mode
+    pub fn activate_filter(&mut self) {
+        self.filter.activate();
+        self.apply_filter();
+    }
+
+    /// Handles a key event for the filter, returns true if the event was consumed
+    pub fn handle_filter_key(&mut self, key_event: &KeyEvent) -> bool {
+        if self.filter.is_active() && self.filter.update(key_event, &T::filterable_fields()) {
+            self.apply_filter();
+            return true;
+        }
+        false
+    }
+
+    /// Returns whether the filter is active
+    pub fn is_filter_active(&self) -> bool {
+        self.filter.is_active()
+    }
+
+    /// Sets the primary field values for autocomplete
+    pub fn set_primary_values(&mut self, field_name: &str, values: Vec<String>) {
+        self.filter.set_primary_values(field_name, values);
+    }
+
+    /// Returns the currently selected item
+    pub fn current(&self) -> Option<&T> {
+        self.filtered
+            .state
+            .selected()
+            .and_then(|i| self.filtered.items.get(i))
+    }
+
+    /// Returns the currently selected item mutably
+    pub fn current_mut(&mut self) -> Option<&mut T> {
+        self.filtered
+            .state
+            .selected()
+            .and_then(|i| self.filtered.items.get_mut(i))
+    }
+
+    /// Moves selection to the next item (with wrapping)
+    pub fn next(&mut self) {
+        self.filtered.next();
+    }
+
+    /// Moves selection to the previous item (with wrapping)
+    pub fn previous(&mut self) {
+        self.filtered.previous();
+    }
+
+    /// Moves selection to the first item
+    pub fn select_first(&mut self) {
+        self.filtered.state.select_first();
+    }
+
+    /// Moves selection to the last item
+    pub fn select_last(&mut self) {
+        if !self.filtered.items.is_empty() {
+            self.filtered
+                .state
+                .select(Some(self.filtered.items.len() - 1));
+        }
+    }
+
+    /// Enters visual mode at the current cursor position
+    pub fn enter_visual_mode(&mut self) {
+        if let Some(cursor) = self.filtered.state.selected() {
+            self.visual_mode = true;
+            self.visual_anchor = Some(cursor);
+        }
+    }
+
+    /// Exits visual mode
+    pub fn exit_visual_mode(&mut self) {
+        self.visual_mode = false;
+        self.visual_anchor = None;
+    }
+
+    /// Returns the inclusive range of selected indices, if in visual mode
+    pub fn visual_selection(&self) -> Option<RangeInclusive<usize>> {
+        if !self.visual_mode {
+            return None;
+        }
+        let anchor = self.visual_anchor?;
+        let cursor = self.filtered.state.selected()?;
+        let (start, end) = if anchor <= cursor {
+            (anchor, cursor)
+        } else {
+            (cursor, anchor)
+        };
+        Some(start..=end)
+    }
+
+    /// Returns count of selected items (for bottom border display)
+    pub fn visual_selection_count(&self) -> usize {
+        self.visual_selection()
+            .map_or(0, |r| r.end() - r.start() + 1)
+    }
+
+    /// Returns selected item IDs based on a provided key extractor
+    /// In visual mode, returns all selected items; otherwise just the current item
+    pub fn selected_ids<F>(&self, key_fn: F) -> Vec<String>
+    where
+        F: Fn(&T) -> String,
+    {
+        match self.visual_selection() {
+            Some(range) => range
+                .filter_map(|i| self.filtered.items.get(i))
+                .map(&key_fn)
+                .collect(),
+            None => self
+                .filtered
+                .state
+                .selected()
+                .and_then(|i| self.filtered.items.get(i))
+                .map(|item| vec![key_fn(item)])
+                .unwrap_or_default(),
+        }
+    }
+
+    /// Returns whether there are any items in the filtered list
+    pub fn is_empty(&self) -> bool {
+        self.filtered.items.is_empty()
+    }
+
+    /// Returns the number of filtered items
+    pub fn len(&self) -> usize {
+        self.filtered.items.len()
+    }
+
+    /// Handle common navigation keys (j/k/G/gg pattern)
+    /// Returns true if the event was handled
+    pub fn handle_navigation(&mut self, key_code: KeyCode, event_buffer: &mut Vec<KeyCode>) -> bool {
+        match key_code {
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.next();
+                true
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.previous();
+                true
+            }
+            KeyCode::Char('G') => {
+                self.select_last();
+                true
+            }
+            KeyCode::Char('g') => {
+                if let Some(last_key) = event_buffer.pop() {
+                    if last_key == KeyCode::Char('g') {
+                        self.select_first();
+                    } else {
+                        event_buffer.push(last_key);
+                        event_buffer.push(key_code);
+                    }
+                } else {
+                    event_buffer.push(key_code);
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::model::filter::FilterableField;
+
+    #[derive(Clone, Default, Debug)]
+    struct TestItem {
+        id: String,
+        status: String,
+    }
+
+    impl Filterable for TestItem {
+        fn filterable_fields() -> Vec<FilterableField> {
+            vec![
+                FilterableField::primary("id"),
+                FilterableField::enumerated("status", vec!["running", "success", "failed"]),
+            ]
+        }
+
+        fn get_field_value(&self, field_name: &str) -> Option<String> {
+            match field_name {
+                "id" => Some(self.id.clone()),
+                "status" => Some(self.status.clone()),
+                _ => None,
+            }
+        }
+    }
+
+    #[test]
+    fn test_new_table_is_empty() {
+        let table: FilterableTable<TestItem> = FilterableTable::new();
+        assert!(table.is_empty());
+        assert_eq!(table.len(), 0);
+        assert!(table.current().is_none());
+    }
+
+    #[test]
+    fn test_set_items() {
+        let mut table: FilterableTable<TestItem> = FilterableTable::new();
+        let items = vec![
+            TestItem {
+                id: "item_1".to_string(),
+                status: "running".to_string(),
+            },
+            TestItem {
+                id: "item_2".to_string(),
+                status: "success".to_string(),
+            },
+        ];
+        table.set_items(items);
+        assert_eq!(table.len(), 2);
+        assert!(!table.is_empty());
+    }
+
+    #[test]
+    fn test_navigation() {
+        let mut table: FilterableTable<TestItem> = FilterableTable::new();
+        table.set_items(vec![
+            TestItem {
+                id: "1".to_string(),
+                status: "running".to_string(),
+            },
+            TestItem {
+                id: "2".to_string(),
+                status: "success".to_string(),
+            },
+            TestItem {
+                id: "3".to_string(),
+                status: "failed".to_string(),
+            },
+        ]);
+
+        // Start with no selection
+        assert!(table.current().is_none());
+
+        // Move next, should select first
+        table.next();
+        assert_eq!(table.current().map(|i| i.id.as_str()), Some("1"));
+
+        // Move next
+        table.next();
+        assert_eq!(table.current().map(|i| i.id.as_str()), Some("2"));
+
+        // Select last
+        table.select_last();
+        assert_eq!(table.current().map(|i| i.id.as_str()), Some("3"));
+
+        // Select first
+        table.select_first();
+        assert_eq!(table.current().map(|i| i.id.as_str()), Some("1"));
+    }
+
+    #[test]
+    fn test_visual_mode() {
+        let mut table: FilterableTable<TestItem> = FilterableTable::new();
+        table.set_items(vec![
+            TestItem {
+                id: "1".to_string(),
+                status: "running".to_string(),
+            },
+            TestItem {
+                id: "2".to_string(),
+                status: "success".to_string(),
+            },
+            TestItem {
+                id: "3".to_string(),
+                status: "failed".to_string(),
+            },
+        ]);
+
+        // Select first item
+        table.next();
+        assert!(table.visual_selection().is_none());
+
+        // Enter visual mode
+        table.enter_visual_mode();
+        assert!(table.visual_mode);
+        assert_eq!(table.visual_anchor, Some(0));
+        assert_eq!(table.visual_selection_count(), 1);
+
+        // Move down to expand selection
+        table.next();
+        table.next();
+        assert_eq!(table.visual_selection_count(), 3);
+
+        // Get selected IDs
+        let ids = table.selected_ids(|item| item.id.clone());
+        assert_eq!(ids, vec!["1", "2", "3"]);
+
+        // Exit visual mode
+        table.exit_visual_mode();
+        assert!(!table.visual_mode);
+        assert!(table.visual_selection().is_none());
+    }
+
+    #[test]
+    fn test_selected_ids_normal_mode() {
+        let mut table: FilterableTable<TestItem> = FilterableTable::new();
+        table.set_items(vec![
+            TestItem {
+                id: "1".to_string(),
+                status: "running".to_string(),
+            },
+            TestItem {
+                id: "2".to_string(),
+                status: "success".to_string(),
+            },
+        ]);
+
+        // No selection
+        assert!(table.selected_ids(|item| item.id.clone()).is_empty());
+
+        // Select first item
+        table.next();
+        let ids = table.selected_ids(|item| item.id.clone());
+        assert_eq!(ids, vec!["1"]);
+    }
+
+    #[test]
+    fn test_handle_navigation() {
+        let mut table: FilterableTable<TestItem> = FilterableTable::new();
+        table.set_items(vec![
+            TestItem {
+                id: "1".to_string(),
+                status: "running".to_string(),
+            },
+            TestItem {
+                id: "2".to_string(),
+                status: "success".to_string(),
+            },
+        ]);
+
+        let mut buffer = Vec::new();
+
+        // j key
+        assert!(table.handle_navigation(KeyCode::Char('j'), &mut buffer));
+        assert_eq!(table.current().map(|i| i.id.as_str()), Some("1"));
+
+        // k key
+        assert!(table.handle_navigation(KeyCode::Char('j'), &mut buffer));
+        assert!(table.handle_navigation(KeyCode::Char('k'), &mut buffer));
+        assert_eq!(table.current().map(|i| i.id.as_str()), Some("1"));
+
+        // G key (go to last)
+        assert!(table.handle_navigation(KeyCode::Char('G'), &mut buffer));
+        assert_eq!(table.current().map(|i| i.id.as_str()), Some("2"));
+
+        // gg (go to first) - first g
+        assert!(table.handle_navigation(KeyCode::Char('g'), &mut buffer));
+        assert_eq!(buffer, vec![KeyCode::Char('g')]);
+
+        // gg - second g
+        assert!(table.handle_navigation(KeyCode::Char('g'), &mut buffer));
+        assert!(buffer.is_empty());
+        assert_eq!(table.current().map(|i| i.id.as_str()), Some("1"));
+
+        // Unknown key
+        assert!(!table.handle_navigation(KeyCode::Char('x'), &mut buffer));
+    }
+}

--- a/src/app/model/filterable_table.rs
+++ b/src/app/model/filterable_table.rs
@@ -281,7 +281,10 @@ mod tests {
         assert_eq!(table.current().map(|i| i.id.as_str()), Some("2"));
 
         // Select last
-        table.filtered.state.select(Some(table.filtered.items.len() - 1));
+        table
+            .filtered
+            .state
+            .select(Some(table.filtered.items.len() - 1));
         assert_eq!(table.current().map(|i| i.id.as_str()), Some("3"));
 
         // Select first

--- a/src/app/model/filterable_table.rs
+++ b/src/app/model/filterable_table.rs
@@ -62,9 +62,13 @@ impl<T: Filterable + Clone> FilterableTable<T> {
         self.apply_filter();
     }
 
-    /// Handles a key event for the filter, returns true if the event was consumed
+    /// Handles a key event for the filter, returns true if the event was consumed.
+    /// This handles both:
+    /// - `/` key when filter is inactive (activates filter)
+    /// - All filter input keys when filter is active
     pub fn handle_filter_key(&mut self, key_event: &KeyEvent) -> bool {
-        if self.filter.is_active() && self.filter.update(key_event, &T::filterable_fields()) {
+        // Handle '/' to activate filter even when inactive
+        if self.filter.update(key_event, &T::filterable_fields()) {
             self.apply_filter();
             return true;
         }

--- a/src/app/model/popup/mod.rs
+++ b/src/app/model/popup/mod.rs
@@ -45,7 +45,6 @@ impl<T> Popup<T> {
     /// Handle common popup dismissal keys (error and commands popups)
     pub fn handle_dismiss(&mut self, key_code: KeyCode) -> KeyResult {
         match self {
-            Popup::None => KeyResult::Ignored,
             Popup::Error(_) => {
                 if matches!(key_code, KeyCode::Char('q') | KeyCode::Esc) {
                     *self = Popup::None;
@@ -61,7 +60,8 @@ impl<T> Popup<T> {
                 }
                 KeyResult::Consumed
             }
-            Popup::Custom(_) => KeyResult::Ignored, // Custom popups need custom handling
+            // None and Custom popups are not handled here (Custom needs custom handling)
+            Popup::None | Popup::Custom(_) => KeyResult::Ignored,
         }
     }
 
@@ -97,10 +97,10 @@ impl<T> Popup<T> {
 impl<T> Widget for &Popup<T> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         match self {
-            Popup::None => {}
             Popup::Error(e) => e.render(area, buf),
             Popup::Commands(c) => c.render(area, buf),
-            Popup::Custom(_) => {} // Custom popups rendered separately by the model
+            // None and Custom popups don't render here (Custom is rendered separately by the model)
+            Popup::None | Popup::Custom(_) => {}
         }
     }
 }

--- a/src/app/model/taskinstances.rs
+++ b/src/app/model/taskinstances.rs
@@ -59,11 +59,6 @@ impl TaskInstanceModel {
         Self::default()
     }
 
-    /// Apply filter to task instances
-    pub fn filter_task_instances(&mut self) {
-        self.table.apply_filter();
-    }
-
     /// Sort task instances by topological order (or timestamp fallback)
     pub fn sort_task_instances(&mut self) {
         if let Some(graph) = &self.task_graph {
@@ -112,7 +107,8 @@ impl TaskInstanceModel {
                 KeyCode::Enter | KeyCode::Esc | KeyCode::Char('q')
             ) {
                 self.popup.close();
-                self.table.exit_visual_mode();
+                self.table.visual_mode = false;
+                self.table.visual_anchor = None;
             }
         }
         Some(messages)
@@ -227,7 +223,7 @@ impl Model for TaskInstanceModel {
 }
 impl Widget for &mut TaskInstanceModel {
     fn render(self, area: Rect, buffer: &mut Buffer) {
-        let rects = if self.table.is_filter_active() {
+        let rects = if self.table.filter.is_active() {
             let rects = Layout::default()
                 .constraints([Constraint::Fill(90), Constraint::Max(3)].as_ref())
                 .margin(0)

--- a/src/app/model/taskinstances.rs
+++ b/src/app/model/taskinstances.rs
@@ -62,12 +62,6 @@ impl TaskInstanceModel {
         }
     }
 
-    /// Get the currently selected task instance (mutable)
-    #[allow(dead_code)]
-    pub fn current(&mut self) -> Option<&mut TaskInstance> {
-        self.table.current_mut()
-    }
-
     /// Mark a task instance with a new status (optimistic update)
     pub fn mark_task_instance(&mut self, task_id: &str, status: &str) {
         if let Some(task_instance) = self
@@ -140,7 +134,7 @@ impl TaskInstanceModel {
                 KeyResult::Consumed
             }
             KeyCode::Enter => {
-                if let Some(task_instance) = self.current() {
+                if let Some(task_instance) = self.table.current() {
                     #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
                     let task_try = task_instance.try_number as u16;
                     KeyResult::PassWith(vec![WorkerMessage::UpdateTaskLogs {
@@ -155,7 +149,7 @@ impl TaskInstanceModel {
                 }
             }
             KeyCode::Char('o') => {
-                if let Some(task_instance) = self.current() {
+                if let Some(task_instance) = self.table.current() {
                     KeyResult::PassWith(vec![WorkerMessage::OpenItem(OpenItem::TaskInstance {
                         dag_id: task_instance.dag_id.clone(),
                         dag_run_id: task_instance.dag_run_id.clone(),

--- a/src/app/model/taskinstances.rs
+++ b/src/app/model/taskinstances.rs
@@ -220,9 +220,6 @@ impl Model for TaskInstanceModel {
                                 KeyCode::Char('?') => {
                                     self.commands = Some(&*TASK_COMMAND_POP_UP);
                                 }
-                                KeyCode::Char('/') => {
-                                    self.table.activate_filter();
-                                }
                                 KeyCode::Enter => {
                                     if let Some(task_instance) = self.current() {
                                         return (

--- a/src/app/model/taskinstances.rs
+++ b/src/app/model/taskinstances.rs
@@ -26,7 +26,7 @@ use crate::ui::TIME_FORMAT;
 use super::popup::taskinstances::clear::ClearTaskInstancePopup;
 use super::popup::taskinstances::mark::MarkTaskInstancePopup;
 use super::popup::taskinstances::TaskInstancePopUp;
-use super::{FilterableTable, KeyResult, Model};
+use super::{dismiss_commands_popup, dismiss_error_popup, FilterableTable, KeyResult, Model};
 use crate::app::worker::{OpenItem, WorkerMessage};
 
 /// Model for the Task Instance panel, managing the list of task instances and their filtering.
@@ -102,28 +102,6 @@ impl TaskInstanceModel {
 }
 
 impl TaskInstanceModel {
-    /// Handle error popup dismissal
-    fn handle_error_popup(&mut self, key_code: KeyCode) -> KeyResult {
-        if self.error_popup.is_none() {
-            return KeyResult::Ignored;
-        }
-        if matches!(key_code, KeyCode::Char('q') | KeyCode::Esc) {
-            self.error_popup = None;
-        }
-        KeyResult::Consumed
-    }
-
-    /// Handle commands popup dismissal
-    fn handle_commands_popup(&mut self, key_code: KeyCode) -> KeyResult {
-        if self.commands.is_none() {
-            return KeyResult::Ignored;
-        }
-        if matches!(key_code, KeyCode::Char('q' | '?') | KeyCode::Esc) {
-            self.commands = None;
-        }
-        KeyResult::Consumed
-    }
-
     /// Handle model-specific popups (returns messages from popup)
     fn handle_popup(&mut self, event: &FlowrsEvent) -> Option<Vec<WorkerMessage>> {
         let popup = self.popup.as_mut()?;
@@ -236,8 +214,8 @@ impl Model for TaskInstanceModel {
                 let result = self
                     .table
                     .handle_filter_key(key_event)
-                    .or_else(|| self.handle_error_popup(key_event.code))
-                    .or_else(|| self.handle_commands_popup(key_event.code))
+                    .or_else(|| dismiss_error_popup(&mut self.error_popup, key_event.code))
+                    .or_else(|| dismiss_commands_popup(&mut self.commands, key_event.code))
                     .or_else(|| self.table.handle_visual_mode_key(key_event.code))
                     .or_else(|| self.table.handle_navigation(key_event.code, &mut self.event_buffer))
                     .or_else(|| self.handle_keys(key_event.code));

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -204,8 +204,8 @@ impl App {
                     .iter()
                     .map(|d| d.dag_id.clone())
                     .collect();
-                self.dags.table.set_primary_values("dag_id", dag_ids);
-                self.dags.filter_dags();
+                self.dags.table.filter.set_primary_values("dag_id", dag_ids);
+                self.dags.table.apply_filter();
             }
             Panel::DAGRun => {
                 if let Some(dag_id) = &self.dagruns.dag_id {
@@ -220,8 +220,9 @@ impl App {
                         .collect();
                     self.dagruns
                         .table
+                        .filter
                         .set_primary_values("dag_run_id", dag_run_ids);
-                    self.dagruns.filter_dag_runs();
+                    self.dagruns.table.apply_filter();
                 } else {
                     self.dagruns.table.all.clear();
                 }
@@ -244,8 +245,9 @@ impl App {
                         .collect();
                     self.task_instances
                         .table
+                        .filter
                         .set_primary_values("task_id", task_ids);
-                    self.task_instances.filter_task_instances();
+                    self.task_instances.table.apply_filter();
                 } else {
                     self.task_instances.table.all.clear();
                 }
@@ -270,7 +272,7 @@ impl App {
                     .iter()
                     .map(|c| c.name.clone())
                     .collect();
-                self.configs.table.set_primary_values("name", config_names);
+                self.configs.table.filter.set_primary_values("name", config_names);
             }
         }
     }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -197,7 +197,13 @@ impl App {
                 self.dags.table.all = self.environment_state.get_active_dags();
                 self.dags.dag_stats = self.environment_state.get_active_dag_stats();
                 // Set primary values for autocomplete (dag_id is the primary field)
-                let dag_ids: Vec<String> = self.dags.table.all.iter().map(|d| d.dag_id.clone()).collect();
+                let dag_ids: Vec<String> = self
+                    .dags
+                    .table
+                    .all
+                    .iter()
+                    .map(|d| d.dag_id.clone())
+                    .collect();
                 self.dags.table.set_primary_values("dag_id", dag_ids);
                 self.dags.filter_dags();
             }
@@ -257,8 +263,13 @@ impl App {
             }
             Panel::Config => {
                 // Set primary values for config filter (name is the primary field)
-                let config_names: Vec<String> =
-                    self.configs.table.all.iter().map(|c| c.name.clone()).collect();
+                let config_names: Vec<String> = self
+                    .configs
+                    .table
+                    .all
+                    .iter()
+                    .map(|c| c.name.clone())
+                    .collect();
                 self.configs.table.set_primary_values("name", config_names);
             }
         }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -272,7 +272,10 @@ impl App {
                     .iter()
                     .map(|c| c.name.clone())
                     .collect();
-                self.configs.table.filter.set_primary_values("name", config_names);
+                self.configs
+                    .table
+                    .filter
+                    .set_primary_values("name", config_names);
             }
         }
     }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -258,8 +258,8 @@ impl App {
             Panel::Config => {
                 // Set primary values for config filter (name is the primary field)
                 let config_names: Vec<String> =
-                    self.configs.all.iter().map(|c| c.name.clone()).collect();
-                self.configs.filter.set_primary_values("name", config_names);
+                    self.configs.table.all.iter().map(|c| c.name.clone()).collect();
+                self.configs.table.set_primary_values("name", config_names);
             }
         }
     }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -223,6 +223,7 @@ impl App {
                         .filter
                         .set_primary_values("dag_run_id", dag_run_ids);
                     self.dagruns.table.apply_filter();
+                    self.dagruns.sort_dag_runs();
                 } else {
                     self.dagruns.table.all.clear();
                 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -113,9 +113,9 @@ impl App {
         self.loading = true;
         // Clear view models but not environment_state
         // This clears UI state (filters, selections) but data persists in environment_state
-        self.dags.all.clear();
-        self.dagruns.all.clear();
-        self.task_instances.all.clear();
+        self.dags.table.all.clear();
+        self.dagruns.table.all.clear();
+        self.task_instances.table.all.clear();
         self.logs.all.clear();
     }
 
@@ -140,7 +140,7 @@ impl App {
         // Add DAG Run logical date if we're at TaskInstance or Logs panel
         if self.active_panel == Panel::TaskInstance || self.active_panel == Panel::Logs {
             // Get logical_date from the first task instance (they all share the same dag run)
-            if let Some(task_instance) = self.task_instances.filtered.items.first() {
+            if let Some(task_instance) = self.task_instances.table.filtered.items.first() {
                 if let Some(logical_date) = task_instance.logical_date {
                     let formatted = logical_date
                         .format(&BREADCRUMB_DATE_FORMAT)
@@ -194,52 +194,54 @@ impl App {
     pub fn sync_panel_data(&mut self) {
         match self.active_panel {
             Panel::Dag => {
-                self.dags.all = self.environment_state.get_active_dags();
+                self.dags.table.all = self.environment_state.get_active_dags();
                 self.dags.dag_stats = self.environment_state.get_active_dag_stats();
                 // Set primary values for autocomplete (dag_id is the primary field)
-                let dag_ids: Vec<String> = self.dags.all.iter().map(|d| d.dag_id.clone()).collect();
-                self.dags.filter.set_primary_values("dag_id", dag_ids);
+                let dag_ids: Vec<String> = self.dags.table.all.iter().map(|d| d.dag_id.clone()).collect();
+                self.dags.table.set_primary_values("dag_id", dag_ids);
                 self.dags.filter_dags();
             }
             Panel::DAGRun => {
                 if let Some(dag_id) = &self.dagruns.dag_id {
-                    self.dagruns.all = self.environment_state.get_active_dag_runs(dag_id);
+                    self.dagruns.table.all = self.environment_state.get_active_dag_runs(dag_id);
                     // Set primary values for autocomplete (dag_run_id is the primary field)
                     let dag_run_ids: Vec<String> = self
                         .dagruns
+                        .table
                         .all
                         .iter()
                         .map(|dr| dr.dag_run_id.clone())
                         .collect();
                     self.dagruns
-                        .filter
+                        .table
                         .set_primary_values("dag_run_id", dag_run_ids);
                     self.dagruns.filter_dag_runs();
                 } else {
-                    self.dagruns.all.clear();
+                    self.dagruns.table.all.clear();
                 }
             }
             Panel::TaskInstance => {
                 if let (Some(dag_id), Some(dag_run_id)) =
                     (&self.task_instances.dag_id, &self.task_instances.dag_run_id)
                 {
-                    self.task_instances.all = self
+                    self.task_instances.table.all = self
                         .environment_state
                         .get_active_task_instances(dag_id, dag_run_id);
                     self.task_instances.sort_task_instances();
                     // Set primary values for autocomplete (task_id is the primary field)
                     let task_ids: Vec<String> = self
                         .task_instances
+                        .table
                         .all
                         .iter()
                         .map(|ti| ti.task_id.clone())
                         .collect();
                     self.task_instances
-                        .filter
+                        .table
                         .set_primary_values("task_id", task_ids);
                     self.task_instances.filter_task_instances();
                 } else {
-                    self.task_instances.all.clear();
+                    self.task_instances.table.all.clear();
                 }
             }
             Panel::Logs => {

--- a/src/app/worker/config.rs
+++ b/src/app/worker/config.rs
@@ -3,7 +3,6 @@ use std::sync::{Arc, Mutex};
 use anyhow::Result;
 
 use crate::app::environment_state::EnvironmentData;
-use crate::app::model::popup::error::ErrorPopup;
 use crate::app::state::App;
 
 /// Handle configuration selection.
@@ -18,9 +17,9 @@ pub fn handle_config_selected(app: &Arc<Mutex<App>>, idx: usize) -> Result<()> {
             "Config index {idx} out of bounds (total: {})",
             app.configs.table.filtered.items.len()
         );
-        app.configs.error_popup = Some(ErrorPopup::from_strings(vec![format!(
-            "Configuration index {idx} not found"
-        )]));
+        app.configs
+            .popup
+            .show_error(vec![format!("Configuration index {idx} not found")]);
         app.loading = false;
         return Ok(());
     };
@@ -36,9 +35,9 @@ pub fn handle_config_selected(app: &Arc<Mutex<App>>, idx: usize) -> Result<()> {
             }
             Err(e) => {
                 log::error!("Failed to create client for '{env_name}': {e}");
-                app.configs.error_popup = Some(ErrorPopup::from_strings(vec![format!(
-                    "Failed to connect to '{env_name}': {e}"
-                )]));
+                app.configs
+                    .popup
+                    .show_error(vec![format!("Failed to connect to '{env_name}': {e}")]);
                 app.loading = false;
                 return Ok(());
             }

--- a/src/app/worker/config.rs
+++ b/src/app/worker/config.rs
@@ -13,10 +13,10 @@ pub fn handle_config_selected(app: &Arc<Mutex<App>>, idx: usize) -> Result<()> {
         .lock()
         .map_err(|_| anyhow::anyhow!("Failed to acquire app lock"))?;
 
-    let Some(selected_config) = app.configs.filtered.items.get(idx).cloned() else {
+    let Some(selected_config) = app.configs.table.filtered.items.get(idx).cloned() else {
         log::error!(
             "Config index {idx} out of bounds (total: {})",
-            app.configs.filtered.items.len()
+            app.configs.table.filtered.items.len()
         );
         app.configs.error_popup = Some(ErrorPopup::from_strings(vec![format!(
             "Configuration index {idx} not found"

--- a/src/app/worker/dagruns.rs
+++ b/src/app/worker/dagruns.rs
@@ -4,7 +4,6 @@ use log::debug;
 
 use crate::airflow::traits::AirflowClient;
 use crate::app::model::popup::dagruns::mark::MarkState;
-use crate::app::model::popup::error::ErrorPopup;
 use crate::app::state::App;
 
 /// Handle updating the list of DAG runs for a specific DAG.
@@ -27,7 +26,7 @@ pub async fn handle_update_dag_runs(
             app.sync_panel_data();
         }
         Err(e) => {
-            app.dagruns.error_popup = Some(ErrorPopup::from_strings(vec![e.to_string()]));
+            app.dagruns.popup.show_error(vec![e.to_string()]);
         }
     }
 }
@@ -44,7 +43,7 @@ pub async fn handle_clear_dag_run(
     if let Err(e) = dag_run {
         debug!("Error clearing dag_run: {e}");
         let mut app = app.lock().unwrap();
-        app.dagruns.error_popup = Some(ErrorPopup::from_strings(vec![e.to_string()]));
+        app.dagruns.popup.show_error(vec![e.to_string()]);
     }
 }
 
@@ -68,7 +67,7 @@ pub async fn handle_mark_dag_run(
     if let Err(e) = dag_run {
         debug!("Error marking dag_run: {e}");
         let mut app = app.lock().unwrap();
-        app.dagruns.error_popup = Some(ErrorPopup::from_strings(vec![e.to_string()]));
+        app.dagruns.popup.show_error(vec![e.to_string()]);
     }
 }
 
@@ -83,6 +82,6 @@ pub async fn handle_trigger_dag_run(
     if let Err(e) = dag_run {
         debug!("Error triggering dag_run: {e}");
         let mut app = app.lock().unwrap();
-        app.dagruns.error_popup = Some(ErrorPopup::from_strings(vec![e.to_string()]));
+        app.dagruns.popup.show_error(vec![e.to_string()]);
     }
 }

--- a/src/app/worker/dagruns.rs
+++ b/src/app/worker/dagruns.rs
@@ -79,9 +79,15 @@ pub async fn handle_trigger_dag_run(
 ) {
     debug!("Triggering dag_run: {dag_id}");
     let dag_run = client.trigger_dag_run(dag_id, None).await;
-    if let Err(e) = dag_run {
-        debug!("Error triggering dag_run: {e}");
-        let mut app = app.lock().unwrap();
-        app.dagruns.popup.show_error(vec![e.to_string()]);
+    match dag_run {
+        Ok(()) => {
+            // Refresh the dag runs list to show the newly triggered run
+            handle_update_dag_runs(app, client, dag_id).await;
+        }
+        Err(e) => {
+            debug!("Error triggering dag_run: {e}");
+            let mut app = app.lock().unwrap();
+            app.dagruns.popup.show_error(vec![e.to_string()]);
+        }
     }
 }

--- a/src/app/worker/dags.rs
+++ b/src/app/worker/dags.rs
@@ -1,7 +1,6 @@
 use std::sync::{Arc, Mutex};
 
 use crate::airflow::traits::AirflowClient;
-use crate::app::model::popup::error::ErrorPopup;
 use crate::app::state::App;
 
 /// Handle updating DAGs and their statistics from the Airflow server.
@@ -40,7 +39,7 @@ pub async fn handle_update_dags_and_stats(app: &Arc<Mutex<App>>, client: &Arc<dy
             }
         }
         Err(e) => {
-            app.dags.error_popup = Some(ErrorPopup::from_strings(vec![e.to_string()]));
+            app.dags.popup.show_error(vec![e.to_string()]);
         }
     }
 
@@ -73,7 +72,7 @@ pub async fn handle_toggle_dag(
     let dag = client.toggle_dag(dag_id, is_paused).await;
     if let Err(e) = dag {
         let mut app = app.lock().unwrap();
-        app.dags.error_popup = Some(ErrorPopup::from_strings(vec![e.to_string()]));
+        app.dags.popup.show_error(vec![e.to_string()]);
     }
 }
 
@@ -96,11 +95,11 @@ pub async fn handle_get_dag_code(
                 app.dagruns.dag_code.set_code(&dag_code);
             }
             Err(e) => {
-                app.dags.error_popup = Some(ErrorPopup::from_strings(vec![e.to_string()]));
+                app.dags.popup.show_error(vec![e.to_string()]);
             }
         }
     } else {
         let mut app = app.lock().unwrap();
-        app.dags.error_popup = Some(ErrorPopup::from_strings(vec!["DAG not found".to_string()]));
+        app.dags.popup.show_error(vec!["DAG not found".to_string()]);
     }
 }

--- a/src/app/worker/mod.rs
+++ b/src/app/worker/mod.rs
@@ -1,7 +1,6 @@
 use std::sync::{Arc, Mutex};
 
 use super::model::popup::dagruns::mark::MarkState;
-use super::model::popup::error::ErrorPopup;
 use super::model::popup::taskinstances::mark::MarkState as TaskMarkState;
 use super::state::App;
 use anyhow::Result;
@@ -153,9 +152,9 @@ async fn process_message(app: Arc<Mutex<App>>, message: WorkerMessage) -> Result
 
     let Some(client) = client else {
         let mut app = app.lock().unwrap();
-        app.dags.error_popup = Some(ErrorPopup::from_strings(vec![
-            "No active environment selected".into(),
-        ]));
+        app.dags
+            .popup
+            .show_error(vec!["No active environment selected".into()]);
         app.loading = false;
         return Ok(());
     };

--- a/src/app/worker/taskinstances.rs
+++ b/src/app/worker/taskinstances.rs
@@ -3,7 +3,6 @@ use std::sync::{Arc, Mutex};
 use log::debug;
 
 use crate::airflow::traits::AirflowClient;
-use crate::app::model::popup::error::ErrorPopup;
 use crate::app::model::popup::taskinstances::mark::MarkState;
 use crate::app::state::App;
 
@@ -29,7 +28,7 @@ pub async fn handle_update_task_instances(
         }
         Err(e) => {
             log::error!("Error getting task instances: {e:?}");
-            app.task_instances.error_popup = Some(ErrorPopup::from_strings(vec![e.to_string()]));
+            app.task_instances.popup.show_error(vec![e.to_string()]);
         }
     }
 }
@@ -49,7 +48,7 @@ pub async fn handle_clear_task_instance(
     if let Err(e) = task_instance {
         debug!("Error clearing task_instance: {e}");
         let mut app = app.lock().unwrap();
-        app.task_instances.error_popup = Some(ErrorPopup::from_strings(vec![e.to_string()]));
+        app.task_instances.popup.show_error(vec![e.to_string()]);
     }
 }
 
@@ -75,6 +74,6 @@ pub async fn handle_mark_task_instance(
     if let Err(e) = task_instance {
         debug!("Error marking task_instance: {e}");
         let mut app = app.lock().unwrap();
-        app.task_instances.error_popup = Some(ErrorPopup::from_strings(vec![e.to_string()]));
+        app.task_instances.popup.show_error(vec![e.to_string()]);
     }
 }

--- a/src/app/worker/tasks.rs
+++ b/src/app/worker/tasks.rs
@@ -22,7 +22,7 @@ pub async fn handle_update_tasks(
             let mut app = app.lock().unwrap();
             app.task_instances.task_graph = Some(graph);
             app.task_instances.sort_task_instances();
-            app.task_instances.filter_task_instances();
+            app.task_instances.table.apply_filter();
         }
         Err(e) => {
             // Graceful degradation: log warning but don't show error popup

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -102,20 +102,20 @@ pub fn draw_ui(f: &mut Frame, app: &Arc<Mutex<App>>) {
         }
         Panel::Dag => {
             app.dags.render(panel_area, f.buffer_mut());
-            if app.dags.filter.is_active() {
-                f.set_cursor_position(app.dags.filter.cursor_position);
+            if app.dags.table.filter.is_active() {
+                f.set_cursor_position(app.dags.table.filter.cursor_position);
             }
         }
         Panel::DAGRun => {
             app.dagruns.render(panel_area, f.buffer_mut());
-            if app.dagruns.filter.is_active() {
-                f.set_cursor_position(app.dagruns.filter.cursor_position);
+            if app.dagruns.table.filter.is_active() {
+                f.set_cursor_position(app.dagruns.table.filter.cursor_position);
             }
         }
         Panel::TaskInstance => {
             app.task_instances.render(panel_area, f.buffer_mut());
-            if app.task_instances.filter.is_active() {
-                f.set_cursor_position(app.task_instances.filter.cursor_position);
+            if app.task_instances.table.filter.is_active() {
+                f.set_cursor_position(app.task_instances.table.filter.cursor_position);
             }
         }
         Panel::Logs => app.logs.render(panel_area, f.buffer_mut()),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -96,8 +96,8 @@ pub fn draw_ui(f: &mut Frame, app: &Arc<Mutex<App>>) {
     match app.active_panel {
         Panel::Config => {
             app.configs.render(panel_area, f.buffer_mut());
-            if app.configs.filter.is_active() {
-                f.set_cursor_position(app.configs.filter.cursor_position);
+            if app.configs.table.filter.is_active() {
+                f.set_cursor_position(app.configs.table.filter.cursor_position);
             }
         }
         Panel::Dag => {


### PR DESCRIPTION
…skInstances

Implement issue #261 by introducing a generic FilterableTable<T> widget that consolidates the common filtering, navigation, and visual selection patterns across DagModel, DagRunModel, and TaskInstanceModel.

The new FilterableTable encapsulates:
- All items storage and filtered view with table state
- Filter state machine with autocomplete support
- Visual mode selection with anchor tracking
- Common navigation (j/k/G/gg) handled generically
- Primary value autocomplete population

Each model now uses a `table: FilterableTable<T>` field instead of separate `all`, `filtered`, `filter`, `visual_mode`, and `visual_anchor` fields, reducing code duplication while maintaining type-specific customization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Panels moved to a unified table-backed model for consistent filtering, selection, and navigation.

* **UI**
  * Panel filter cursor, breadcrumbs, sync, status titles, and rendering now follow table-backed views for steadier display.

* **New Features**
  * Centralized popup system for errors/commands; enhanced keyboard navigation including visual multi-select and filter autocomplete.

* **Bug Fixes**
  * Errors consistently shown via popups; selection, navigation, and filtering behavior made more reliable.

* **Tests**
  * Updated to reflect the table-centric model and new popup/keyboard flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->