### PR TITLE
Add gg and G keybindings to logs panel

### DIFF
--- a/src/app/model/logs.rs
+++ b/src/app/model/logs.rs
@@ -100,6 +100,10 @@ impl Model for LogModel {
                     }
                     return (None, vec![]);
                 }
+                // Clear event buffer on any key that is not 'g' to ensure gg requires consecutive presses
+                if key.code != KeyCode::Char('g') {
+                    self.event_buffer.clear();
+                }
                 match key.code {
                     KeyCode::Char('l') | KeyCode::Right => {
                         if !self.all.is_empty() && self.current < self.all.len() - 1 {

--- a/src/app/model/logs.rs
+++ b/src/app/model/logs.rs
@@ -153,16 +153,13 @@ impl Model for LogModel {
                     }
                     KeyCode::Char('g') => {
                         // gg: go to top of log
-                        if let Some(last_key) = self.event_buffer.pop() {
-                            if last_key == KeyCode::Char('g') {
-                                self.vertical_scroll = 0;
-                                self.vertical_scroll_state =
-                                    self.vertical_scroll_state.position(self.vertical_scroll);
-                            } else {
-                                self.event_buffer.push(last_key);
-                                self.event_buffer.push(KeyCode::Char('g'));
-                            }
+                        if self.event_buffer.pop().is_some() {
+                            // Second consecutive 'g' - go to top
+                            self.vertical_scroll = 0;
+                            self.vertical_scroll_state =
+                                self.vertical_scroll_state.position(self.vertical_scroll);
                         } else {
+                            // First 'g' - buffer it for potential gg
                             self.event_buffer.push(KeyCode::Char('g'));
                         }
                     }


### PR DESCRIPTION
Add vim-style navigation keybindings for the logs panel:
- gg: scroll to the top of the current log
- G: scroll to the bottom of the current log

This follows the same pattern used in FilterableTable for consistent vim-style navigation across the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard navigation for logs: press G to jump to the end and press g twice (gg) to jump to the beginning.

* **Improvements**
  * More reliable multi-key sequence handling so single vs. consecutive key presses are detected correctly.
  * Normalized log parsing and rendering for more consistent display of different log formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->