### PR TITLE
Extract duration calculation logic into reusable module

### DIFF
--- a/src/airflow/model/common/dagrun.rs
+++ b/src/airflow/model/common/dagrun.rs
@@ -3,6 +3,8 @@ use crate::airflow::client::v2;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
+use super::duration::TimeBounded;
+
 /// Common `DagRun` model used by the application
 #[allow(clippy::struct_field_names)]
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -25,6 +27,16 @@ pub struct DagRun {
 pub struct DagRunList {
     pub dag_runs: Vec<DagRun>,
     pub total_entries: i64,
+}
+
+impl TimeBounded for DagRun {
+    fn start_date(&self) -> Option<OffsetDateTime> {
+        self.start_date
+    }
+
+    fn end_date(&self) -> Option<OffsetDateTime> {
+        self.end_date
+    }
 }
 
 // From trait implementations for v1 models

--- a/src/airflow/model/common/duration.rs
+++ b/src/airflow/model/common/duration.rs
@@ -1,0 +1,70 @@
+use time::OffsetDateTime;
+
+/// Trait for types that have start and end dates, enabling duration calculation.
+pub trait TimeBounded {
+    /// Returns the start date of the entity, if available.
+    fn start_date(&self) -> Option<OffsetDateTime>;
+    /// Returns the end date of the entity, if available.
+    fn end_date(&self) -> Option<OffsetDateTime>;
+}
+
+/// Calculate duration in seconds for any time-bounded entity.
+/// Returns None if `start_date` is not available.
+/// For running entities (no `end_date`), uses current time.
+pub fn calculate_duration<T: TimeBounded>(item: &T) -> Option<f64> {
+    let start = item.start_date()?;
+    let end = item.end_date().unwrap_or_else(OffsetDateTime::now_utc);
+    Some((end - start).as_seconds_f64())
+}
+
+/// Format duration as human-readable string (e.g., "2h 30m", "45s", "1d 3h").
+#[must_use]
+pub fn format_duration(seconds: f64) -> String {
+    if seconds < 60.0 {
+        format!("{seconds:.0}s")
+    } else if seconds < 3600.0 {
+        let minutes = (seconds / 60.0).floor();
+        let secs = (seconds % 60.0).floor();
+        if secs > 0.0 {
+            format!("{minutes:.0}m {secs:.0}s")
+        } else {
+            format!("{minutes:.0}m")
+        }
+    } else if seconds < 86400.0 {
+        let hours = (seconds / 3600.0).floor();
+        let minutes = ((seconds % 3600.0) / 60.0).floor();
+        if minutes > 0.0 {
+            format!("{hours:.0}h {minutes:.0}m")
+        } else {
+            format!("{hours:.0}h")
+        }
+    } else {
+        let days = (seconds / 86400.0).floor();
+        let hours = ((seconds % 86400.0) / 3600.0).floor();
+        if hours > 0.0 {
+            format!("{days:.0}d {hours:.0}h")
+        } else {
+            format!("{days:.0}d")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_duration() {
+        // Seconds
+        assert_eq!(format_duration(30.0), "30s");
+        // Minutes
+        assert_eq!(format_duration(90.0), "1m 30s");
+        assert_eq!(format_duration(120.0), "2m");
+        // Hours
+        assert_eq!(format_duration(5400.0), "1h 30m");
+        assert_eq!(format_duration(7200.0), "2h");
+        // Days
+        assert_eq!(format_duration(90000.0), "1d 1h");
+        assert_eq!(format_duration(172_800.0), "2d");
+    }
+}

--- a/src/airflow/model/common/duration.rs
+++ b/src/airflow/model/common/duration.rs
@@ -9,11 +9,14 @@ pub trait TimeBounded {
 }
 
 /// Calculate duration in seconds for any time-bounded entity.
-/// Returns None if `start_date` is not available.
+/// Returns None if `start_date` is not available or if `end_date` precedes `start_date`.
 /// For running entities (no `end_date`), uses current time.
 pub fn calculate_duration<T: TimeBounded>(item: &T) -> Option<f64> {
     let start = item.start_date()?;
     let end = item.end_date().unwrap_or_else(OffsetDateTime::now_utc);
+    if end < start {
+        return None;
+    }
     Some((end - start).as_seconds_f64())
 }
 

--- a/src/airflow/model/common/mod.rs
+++ b/src/airflow/model/common/mod.rs
@@ -1,6 +1,7 @@
 pub mod dag;
 pub mod dagrun;
 pub mod dagstats;
+pub mod duration;
 pub mod log;
 pub mod task;
 pub mod taskinstance;
@@ -9,6 +10,7 @@ pub mod taskinstance;
 pub use dag::{Dag, DagList};
 pub use dagrun::{DagRun, DagRunList};
 pub use dagstats::{DagStatistic, DagStatsResponse};
+pub use duration::{calculate_duration, format_duration};
 pub use log::Log;
 pub use task::{Task, TaskList};
 pub use taskinstance::{TaskInstance, TaskInstanceList};

--- a/src/airflow/model/common/taskinstance.rs
+++ b/src/airflow/model/common/taskinstance.rs
@@ -3,6 +3,8 @@ use crate::airflow::client::v2;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
+use super::duration::TimeBounded;
+
 /// Common `TaskInstance` model used by the application
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TaskInstance {
@@ -33,6 +35,16 @@ pub struct TaskInstance {
 pub struct TaskInstanceList {
     pub task_instances: Vec<TaskInstance>,
     pub total_entries: i64,
+}
+
+impl TimeBounded for TaskInstance {
+    fn start_date(&self) -> Option<OffsetDateTime> {
+        self.start_date
+    }
+
+    fn end_date(&self) -> Option<OffsetDateTime> {
+        self.end_date
+    }
 }
 
 // From trait implementations for v1 models

--- a/src/app/model/taskinstances.rs
+++ b/src/app/model/taskinstances.rs
@@ -10,7 +10,7 @@ use ratatui::widgets::{Block, BorderType, Borders, Row, StatefulWidget, Table, W
 use time::format_description;
 
 use crate::airflow::graph::{sort_task_instances, TaskGraph};
-use crate::airflow::model::common::TaskInstance;
+use crate::airflow::model::common::{calculate_duration, format_duration, TaskInstance};
 use crate::app::events::custom::FlowrsEvent;
 use crate::ui::common::{create_headers, state_to_colored_square};
 use crate::ui::constants::AirflowStateColor;
@@ -238,8 +238,7 @@ impl Widget for &mut TaskInstanceModel {
                         "None".to_string()
                     }),
                     Line::from(
-                        item.duration
-                            .map_or_else(|| "None".to_string(), |i| format!("{i}")),
+                        calculate_duration(item).map_or_else(|| "-".to_string(), format_duration),
                     ),
                     Line::from(if let Some(state) = &item.state {
                         match state.as_str() {


### PR DESCRIPTION
## Summary
Refactored duration calculation and formatting logic from `DagRunModel` into a new reusable `duration` module with a `TimeBounded` trait. This enables duration calculations for any entity with start and end dates, improving code reusability and maintainability.

## Key Changes
- **New `duration` module** (`src/airflow/model/common/duration.rs`):
  - Added `TimeBounded` trait for types with start/end dates
  - Extracted `calculate_duration()` function (generic over `TimeBounded` types)
  - Extracted `format_duration()` function with human-readable output
  - Moved unit tests from `DagRunModel` to the new module

- **Trait implementations**:
  - Implemented `TimeBounded` for `DagRun`
  - Implemented `TimeBounded` for `TaskInstance`

- **Updated consumers**:
  - `DagRunModel`: Removed duplicate duration methods, now uses module functions
  - `TaskInstanceModel`: Updated to use `calculate_duration()` instead of direct field access
  - Updated imports in `mod.rs` to expose new functions

## Implementation Details
- The `TimeBounded` trait provides a clean abstraction for any entity with temporal bounds
- `calculate_duration()` uses current UTC time for running entities (no end_date)
- `format_duration()` produces human-readable strings (e.g., "1d 3h", "45s")
- All existing tests preserved and relocated to the new module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Human-readable duration formatting across the UI (seconds, minutes, hours, days).

* **Improvements**
  * Standardized duration calculation and formatting for DAG Runs and Task Instances via shared helpers.
  * Missing/unknown durations now display "-" instead of "None" for clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->