### PR TITLE
feat: add live log tailing with auto-scroll

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -148,17 +148,21 @@ where
                             dag_id,
                             dag_run_id,
                             task_id,
+                            task_try,
                             clear,
-                            ..
                         } => {
                             if *clear {
                                 app.logs.dag_id = Some(dag_id.clone());
                                 app.logs.dag_run_id = Some(dag_run_id.clone());
                                 app.logs.task_id = Some(task_id.clone());
+                                app.logs.tries = Some(*task_try);
+                                app.logs.current = 0;
+                                app.logs.follow_mode = true; // Start in follow mode for new logs
                                 // Sync cached data immediately
-                                app.logs.all = app
+                                let logs = app
                                     .environment_state
                                     .get_active_task_logs(dag_id, dag_run_id, task_id);
+                                app.logs.update_logs(logs);
                             }
                         }
                         WorkerMessage::UpdateTasks { dag_id } => {

--- a/src/app/model/dagruns.rs
+++ b/src/app/model/dagruns.rs
@@ -270,7 +270,6 @@ impl DagRunModel {
                         WorkerMessage::UpdateTaskInstances {
                             dag_id: dag_id.clone(),
                             dag_run_id: dag_run.dag_run_id.clone(),
-                            clear: true,
                         },
                     ])
                 } else {
@@ -303,7 +302,6 @@ impl Model for DagRunModel {
                 let worker_messages = if let Some(dag_id) = &self.dag_id {
                     vec![WorkerMessage::UpdateDagRuns {
                         dag_id: dag_id.clone(),
-                        clear: false,
                     }]
                 } else {
                     Vec::default()

--- a/src/app/model/dags.rs
+++ b/src/app/model/dags.rs
@@ -103,7 +103,6 @@ impl DagModel {
                     debug!("Selected dag: {}", dag.dag_id);
                     KeyResult::PassWith(vec![WorkerMessage::UpdateDagRuns {
                         dag_id: dag.dag_id.clone(),
-                        clear: true,
                     }])
                 } else {
                     self.popup

--- a/src/app/model/logs.rs
+++ b/src/app/model/logs.rs
@@ -89,7 +89,6 @@ impl Model for LogModel {
                             dag_run_id: dag_run_id.clone(),
                             task_id: task_id.clone(),
                             task_try: *tries,
-                            clear: false,
                         }],
                     );
                 }

--- a/src/app/model/taskinstances.rs
+++ b/src/app/model/taskinstances.rs
@@ -142,7 +142,6 @@ impl TaskInstanceModel {
                         dag_run_id: task_instance.dag_run_id.clone(),
                         task_id: task_instance.task_id.clone(),
                         task_try,
-                        clear: true,
                     }])
                 } else {
                     KeyResult::Consumed
@@ -179,7 +178,6 @@ impl Model for TaskInstanceModel {
                         vec![WorkerMessage::UpdateTaskInstances {
                             dag_id: dag_id.clone(),
                             dag_run_id: dag_run_id.clone(),
-                            clear: false,
                         }],
                     );
                 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -257,9 +257,10 @@ impl App {
                 if let (Some(dag_id), Some(dag_run_id), Some(task_id)) =
                     (&self.logs.dag_id, &self.logs.dag_run_id, &self.logs.task_id)
                 {
-                    self.logs.all = self
-                        .environment_state
-                        .get_active_task_logs(dag_id, dag_run_id, task_id);
+                    self.logs.update_logs(
+                        self.environment_state
+                            .get_active_task_logs(dag_id, dag_run_id, task_id),
+                    );
                 } else {
                     self.logs.all.clear();
                 }

--- a/src/app/worker/mod.rs
+++ b/src/app/worker/mod.rs
@@ -29,12 +29,10 @@ pub enum WorkerMessage {
     },
     UpdateDagRuns {
         dag_id: String,
-        clear: bool,
     },
     UpdateTaskInstances {
         dag_id: String,
         dag_run_id: String,
-        clear: bool,
     },
     GetDagCode {
         dag_id: String,
@@ -48,7 +46,6 @@ pub enum WorkerMessage {
         dag_run_id: String,
         task_id: String,
         task_try: u16,
-        clear: bool,
     },
     MarkDagRun {
         dag_run_id: String,


### PR DESCRIPTION
- Fix logs.tries not being set when entering logs panel, which prevented
  the automatic refresh from working
- Add follow_mode to LogModel that auto-scrolls to bottom when new content
  arrives, providing a tail-like experience
- Add F key to toggle follow mode, G to go to bottom and enable follow mode
- Display follow mode status indicator at bottom of log panel
- Scrolling up disables follow mode, scrolling to bottom re-enables it

https://claude.ai/code/session_0171RNDqojcFe2SLxKT9nT6B

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Follow mode for automatic log tailing (ON/OFF shown in UI); F toggles, G jumps to bottom.
  * Navigation keys: Down enables follow at bottom, Up disables, gg goes to top.

* **Bug Fixes / Improvements**
  * More consistent, reliable refresh of DAG runs, task instances, and task logs when switching contexts.
  * Log updates now preserve scroll/follow behavior to reduce flicker and improve live monitoring.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->