### PR TITLE
perf: use run_after ordering for v2 dagrun listing

### DIFF
--- a/src/airflow/client/v2/dagrun.rs
+++ b/src/airflow/client/v2/dagrun.rs
@@ -13,7 +13,7 @@ impl DagRunOperations for V2Client {
     async fn list_dagruns(&self, dag_id: &str) -> Result<DagRunList> {
         let response: Response = self
             .base_api(Method::GET, &format!("dags/{dag_id}/dagRuns"))?
-            .query(&[("order_by", "-start_date"), ("limit", "50")])
+            .query(&[("order_by", "-run_after"), ("limit", "50")])
             .send()
             .await?
             .error_for_status()?;


### PR DESCRIPTION
Change the v2 client (Airflow 3) to order dag runs by `-run_after`
instead of `-start_date`. This improves performance because:

1. `start_date` can be NULL for queued runs, requiring Airflow to use
   a CASE expression in the ORDER BY clause which prevents index usage
2. `run_after` is always populated for all run types and can use
   database indexes directly

This aligns with how Airflow 3's UI fetches dag runs (see PRs #46739
and #46740 in apache/airflow).

https://claude.ai/code/session_016XkAdMxor9AV4zSN8wt3qJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the sorting order for listed DAG runs to improve result organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->