### PR TITLE
chore: release v0.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.6](https://github.com/jvanbuel/flowrs/compare/v0.8.5...v0.8.6) - 2026-01-31
+
+### Added
+
+- *(tests)* add JWT authentication support for Airflow 3.x tests
+
+### Fixed
+
+- *(tests)* relax dag_stats assertion for empty run history
+- *(ci)* improve password file retrieval for Airflow 3.x
+- *(ci)* pass FAB env vars via docker exec after FAB is installed
+- *(ci)* remove --user flag for virtualenv pip install
+- *(ci)* use python -m pip to avoid PATH issues
+- *(ci)* use pip install --user instead of root
+- *(ci)* run pip install as root in Airflow container
+- *(ci)* update integration tests for Airflow 2.x and 3.x
+- *(ci)* replace service container with manual docker run
+
+### Other
+
+- allow dead_code in test common module
+- fix clippy uninlined_format_args lint
+
 ## [0.8.5](https://github.com/jvanbuel/flowrs/compare/v0.8.4...v0.8.5) - 2026-01-31
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-tui"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -2390,9 +2390,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -3073,9 +3073,9 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-tui"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Flowrs is a Terminal User Interface (TUI) for Apache Airflow"


### PR DESCRIPTION



## 🤖 New release

* `flowrs-tui`: 0.8.5 -> 0.8.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.6](https://github.com/jvanbuel/flowrs/compare/v0.8.5...v0.8.6) - 2026-01-31

### Added

- *(tests)* add JWT authentication support for Airflow 3.x tests

### Fixed

- *(tests)* relax dag_stats assertion for empty run history
- *(ci)* improve password file retrieval for Airflow 3.x
- *(ci)* pass FAB env vars via docker exec after FAB is installed
- *(ci)* remove --user flag for virtualenv pip install
- *(ci)* use python -m pip to avoid PATH issues
- *(ci)* use pip install --user instead of root
- *(ci)* run pip install as root in Airflow container
- *(ci)* update integration tests for Airflow 2.x and 3.x
- *(ci)* replace service container with manual docker run

### Other

- allow dead_code in test common module
- fix clippy uninlined_format_args lint
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).