### PR TITLE
Add workflow_dispatch trigger and job dependency to release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   release-plz-release:
@@ -32,6 +33,7 @@ jobs:
   release-plz-pr:
     name: Release-plz PR
     runs-on: ubuntu-latest
+    needs: release-plz-release
     concurrency:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false


### PR DESCRIPTION
## Summary
Enhanced the release-plz workflow to support manual triggering and ensure proper job execution order.

## Key Changes
- Added `workflow_dispatch` trigger to allow manual workflow execution from the GitHub Actions UI
- Added `needs: release-plz-release` dependency to the `release-plz-pr` job to ensure the release job completes before the PR job runs

## Implementation Details
These changes improve the workflow's flexibility and reliability:
- The `workflow_dispatch` trigger enables developers to manually run the release workflow without waiting for a push to the main branch
- The job dependency ensures sequential execution, preventing the PR job from running concurrently with the release job and avoiding potential race conditions or conflicts

https://claude.ai/code/session_011Fmb1f3EZr4hoQHc5efPK1