### PR TITLE
fix(ci): run pip install as root in Airflow container

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install FAB provider (v3.x only)
         if: matrix.api_version == 'v2'
         run: |
-          docker exec airflow pip install apache-airflow-providers-fab
+          docker exec --user root airflow pip install apache-airflow-providers-fab
 
       - name: Initialize Airflow database
         run: |


### PR DESCRIPTION
The Airflow container runs as the airflow user which doesn't have permission to install packages system-wide. Use --user root for pip.

https://claude.ai/code/session_01Psk8tJEtaiS7KqzbADmyPh