### PR TITLE
fix(ci): use pip install --user instead of root

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install FAB provider (v3.x only)
         if: matrix.api_version == 'v2'
         run: |
-          docker exec --user root airflow pip install apache-airflow-providers-fab
+          docker exec airflow pip install --user apache-airflow-providers-fab
 
       - name: Initialize Airflow database
         run: |


### PR DESCRIPTION
The Airflow image blocks pip from running as root. Use --user flag to install to the airflow user's local site-packages instead.

https://claude.ai/code/session_01Psk8tJEtaiS7KqzbADmyPh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to modify Docker execution context for the FAB provider installation step.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->