### PR TITLE
fix(ci): use python -m pip to avoid PATH issues

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install FAB provider (v3.x only)
         if: matrix.api_version == 'v2'
         run: |
-          docker exec airflow pip install --user apache-airflow-providers-fab
+          docker exec airflow python -m pip install --user apache-airflow-providers-fab
 
       - name: Initialize Airflow database
         run: |


### PR DESCRIPTION
The container's PATH includes /root/bin which the airflow user can't access. Using python -m pip avoids the PATH lookup issue.

https://claude.ai/code/session_01Psk8tJEtaiS7KqzbADmyPh