### PR TITLE
fix(ci): remove --user flag for virtualenv pip install

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install FAB provider (v3.x only)
         if: matrix.api_version == 'v2'
         run: |
-          docker exec airflow python -m pip install --user apache-airflow-providers-fab
+          docker exec airflow python -m pip install apache-airflow-providers-fab
 
       - name: Initialize Airflow database
         run: |


### PR DESCRIPTION
The Airflow container uses a virtualenv where --user installs don't work. Regular pip install should work within the virtualenv.

https://claude.ai/code/session_01Psk8tJEtaiS7KqzbADmyPh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to use global package installation method for Apache Airflow dependencies, replacing per-user installation approach.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->