### PR TITLE
feat(tests): add JWT authentication support for Airflow 3.x tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,44 +48,19 @@ jobs:
             -e AIRFLOW__CORE__LOAD_EXAMPLES=true \
             -e AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=sqlite:////tmp/airflow.db \
             -e AIRFLOW__WEBSERVER__SECRET_KEY=test-secret-key \
+            -e AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_USERS=airflow:admin \
             --entrypoint /bin/bash \
             apache/airflow:${{ matrix.airflow_version }} \
             -c "sleep infinity"
 
-      - name: Install FAB provider (v3.x only)
-        if: matrix.api_version == 'v2'
-        run: |
-          docker exec airflow python -m pip install apache-airflow-providers-fab
-
-      - name: Initialize Airflow database (v2.x)
-        if: matrix.api_version == 'v1'
+      - name: Initialize Airflow database
         run: |
           docker exec airflow airflow db migrate
 
-      - name: Initialize Airflow database (v3.x)
-        if: matrix.api_version == 'v2'
-        run: |
-          docker exec \
-            -e AIRFLOW__CORE__AUTH_MANAGER=airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager \
-            airflow airflow db migrate
-
-      - name: Create Airflow user (v2.x)
+      - name: Create Airflow user (v2.x only)
         if: matrix.api_version == 'v1'
         run: |
           docker exec airflow airflow users create \
-            --username airflow \
-            --password airflow \
-            --firstname Test \
-            --lastname User \
-            --role Admin \
-            --email test@example.com
-
-      - name: Create Airflow user (v3.x)
-        if: matrix.api_version == 'v2'
-        run: |
-          docker exec \
-            -e AIRFLOW__CORE__AUTH_MANAGER=airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager \
-            airflow airflow users create \
             --username airflow \
             --password airflow \
             --firstname Test \
@@ -102,10 +77,7 @@ jobs:
       - name: Start Airflow services (v3.x)
         if: matrix.api_version == 'v2'
         run: |
-          docker exec -d \
-            -e AIRFLOW__CORE__AUTH_MANAGER=airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager \
-            -e AIRFLOW__FAB__AUTH_BACKENDS=airflow.providers.fab.auth_manager.api.auth.backend.basic_auth \
-            airflow airflow api-server --port 8080
+          docker exec -d airflow airflow api-server --port 8080
           docker exec -d airflow airflow scheduler
           docker exec -d airflow airflow dag-processor
 
@@ -131,23 +103,30 @@ jobs:
           '
           echo "Airflow API is ready"
 
+      - name: Get Airflow 3.x password
+        if: matrix.api_version == 'v2'
+        id: airflow_password
+        run: |
+          # Wait for password file to be generated
+          sleep 5
+          PASSWORD=$(docker exec airflow cat /home/airflow/simple_auth_manager_passwords.json.generated 2>/dev/null | python3 -c "import sys, json; print(json.load(sys.stdin).get('airflow', ''))" || echo "")
+          if [ -z "$PASSWORD" ]; then
+            echo "Warning: Could not retrieve password, using default"
+            PASSWORD="airflow"
+          fi
+          echo "password=$PASSWORD" >> $GITHUB_OUTPUT
+          echo "Retrieved password for airflow user"
+
       - name: Wait for DAGs to load
         run: |
           echo "Waiting for scheduler to parse DAGs..."
           sleep 45
-          if [ "${{ matrix.api_version }}" = "v1" ]; then
-            echo "Checking DAGs via API v1..."
-            curl -sf -u airflow:airflow http://localhost:8080/api/v1/dags?limit=5 || echo "API call failed"
-          else
-            echo "Checking DAGs via API v2..."
-            curl -sf -u airflow:airflow http://localhost:8080/api/v2/dags?limit=5 || echo "API call failed"
-          fi
 
       - name: Run integration tests
         env:
           TEST_AIRFLOW_URL: http://localhost:8080
           TEST_AIRFLOW_USERNAME: airflow
-          TEST_AIRFLOW_PASSWORD: airflow
+          TEST_AIRFLOW_PASSWORD: ${{ matrix.api_version == 'v2' && steps.airflow_password.outputs.password || 'airflow' }}
           TEST_API_VERSION: ${{ matrix.api_version }}
         run: cargo test --test '*' -- --test-threads=1
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::sync::Arc;
 
 use flowrs_tui::airflow::client::create_client;
-use flowrs_tui::airflow::config::{AirflowAuth, AirflowConfig, AirflowVersion, BasicAuth};
+use flowrs_tui::airflow::config::{AirflowAuth, AirflowConfig, AirflowVersion, BasicAuth, TokenCmd};
 use flowrs_tui::airflow::traits::AirflowClient;
 
 /// Check if we should run tests for a specific API version.
@@ -15,6 +15,36 @@ pub fn should_run_for_api_version(version: &str) -> bool {
 
     let test_version = env::var("TEST_API_VERSION").unwrap_or_default();
     test_version.is_empty() || test_version == version
+}
+
+/// Get a JWT token from Airflow 3's /auth/token endpoint
+async fn get_jwt_token(url: &str, username: &str, password: &str) -> anyhow::Result<String> {
+    let client = reqwest::Client::new();
+    let token_url = format!("{}/auth/token", url.trim_end_matches('/'));
+
+    let response = client
+        .post(&token_url)
+        .header("Content-Type", "application/json")
+        .json(&serde_json::json!({
+            "username": username,
+            "password": password
+        }))
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("Failed to get JWT token: {} - {}", status, body);
+    }
+
+    let token_response: serde_json::Value = response.json().await?;
+    let token = token_response["access_token"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("No access_token in response"))?
+        .to_string();
+
+    Ok(token)
 }
 
 /// Create a test client from environment variables
@@ -35,6 +65,30 @@ pub fn create_test_client() -> anyhow::Result<Arc<dyn AirflowClient>> {
         auth: AirflowAuth::Basic(BasicAuth { username, password }),
         managed: None,
         version,
+        timeout_secs: 30,
+    };
+
+    create_client(&config)
+}
+
+/// Create a test client for Airflow 3.x using JWT authentication
+pub async fn create_test_client_v3() -> anyhow::Result<Arc<dyn AirflowClient>> {
+    let url = env::var("TEST_AIRFLOW_URL").expect("TEST_AIRFLOW_URL must be set");
+    let username = env::var("TEST_AIRFLOW_USERNAME").unwrap_or_else(|_| "airflow".to_string());
+    let password = env::var("TEST_AIRFLOW_PASSWORD").unwrap_or_else(|_| "airflow".to_string());
+
+    // Get JWT token from Airflow 3's auth endpoint
+    let jwt_token = get_jwt_token(&url, &username, &password).await?;
+
+    let config = AirflowConfig {
+        name: "test".to_string(),
+        endpoint: url,
+        auth: AirflowAuth::Token(TokenCmd {
+            cmd: None,
+            token: Some(jwt_token),
+        }),
+        managed: None,
+        version: AirflowVersion::V3,
         timeout_secs: 30,
     };
 

--- a/tests/v2_api_test.rs
+++ b/tests/v2_api_test.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{create_test_client, should_run_for_api_version};
+use common::{create_test_client_v3, should_run_for_api_version};
 
 #[tokio::test]
 async fn test_v2_list_dags() {
@@ -9,7 +9,9 @@ async fn test_v2_list_dags() {
         return;
     }
 
-    let client = create_test_client().expect("Failed to create test client");
+    let client = create_test_client_v3()
+        .await
+        .expect("Failed to create test client");
     let result = client.list_dags().await;
 
     assert!(result.is_ok(), "Failed to list DAGs: {:?}", result.err());
@@ -28,7 +30,9 @@ async fn test_v2_dag_has_required_fields() {
         return;
     }
 
-    let client = create_test_client().expect("Failed to create test client");
+    let client = create_test_client_v3()
+        .await
+        .expect("Failed to create test client");
     let dag_list = client.list_dags().await.expect("Failed to list DAGs");
 
     if let Some(dag) = dag_list.dags.first() {
@@ -43,7 +47,9 @@ async fn test_v2_get_dag_code() {
         return;
     }
 
-    let client = create_test_client().expect("Failed to create test client");
+    let client = create_test_client_v3()
+        .await
+        .expect("Failed to create test client");
     let dag_list = client.list_dags().await.expect("Failed to list DAGs");
 
     if let Some(dag) = dag_list.dags.first() {
@@ -61,7 +67,9 @@ async fn test_v2_list_dagruns() {
         return;
     }
 
-    let client = create_test_client().expect("Failed to create test client");
+    let client = create_test_client_v3()
+        .await
+        .expect("Failed to create test client");
     let dag_list = client.list_dags().await.expect("Failed to list DAGs");
 
     if let Some(dag) = dag_list.dags.first() {
@@ -81,7 +89,9 @@ async fn test_v2_dag_stats() {
         return;
     }
 
-    let client = create_test_client().expect("Failed to create test client");
+    let client = create_test_client_v3()
+        .await
+        .expect("Failed to create test client");
     let dag_list = client.list_dags().await.expect("Failed to list DAGs");
 
     if !dag_list.dags.is_empty() {
@@ -112,7 +122,9 @@ async fn test_v2_list_task_instances() {
         return;
     }
 
-    let client = create_test_client().expect("Failed to create test client");
+    let client = create_test_client_v3()
+        .await
+        .expect("Failed to create test client");
     let dag_list = client.list_dags().await.expect("Failed to list DAGs");
 
     if let Some(dag) = dag_list.dags.first() {


### PR DESCRIPTION
- Add create_test_client_v3() that fetches JWT token from /auth/token
- Update v2 API tests to use JWT authentication
- Simplify CI workflow to use simple auth manager instead of FAB
- Retrieve auto-generated password from password file in CI

Airflow 3.x uses JWT-only authentication by default with the simple auth manager. This change makes the tests authenticate via the /auth/token endpoint to get a JWT token, then use it for API calls.

https://claude.ai/code/session_01Psk8tJEtaiS7KqzbADmyPh