### PR TITLE
style: allow dead_code in test common module

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,6 @@
+// Functions are used across different test files but appear unused when compiling each test separately
+#![allow(dead_code)]
+
 use std::env;
 use std::sync::Arc;
 


### PR DESCRIPTION
Functions are used across different test files but appear unused when each test is compiled separately.

https://claude.ai/code/session_01Psk8tJEtaiS7KqzbADmyPh