### PR TITLE
fix: prevent widget data corruption when switching between Airflow servers

### DIFF
--- a/src/app/environment_state.rs
+++ b/src/app/environment_state.rs
@@ -177,10 +177,22 @@ impl EnvironmentStateContainer {
             .and_then(|key| self.environments.get(key))
     }
 
-    pub fn get_active_environment_mut(&mut self) -> Option<&mut EnvironmentData> {
-        self.active_environment
-            .as_ref()
-            .and_then(|key| self.environments.get_mut(key))
+    /// Get a specific environment by name (immutable).
+    pub fn get_environment(&self, key: &str) -> Option<&EnvironmentData> {
+        self.environments.get(key)
+    }
+
+    /// Get a specific environment by name (mutable).
+    /// This targets a specific environment regardless of which one is currently
+    /// active, preventing data corruption when the active environment changes
+    /// during async operations.
+    pub fn get_environment_mut(&mut self, key: &str) -> Option<&mut EnvironmentData> {
+        self.environments.get_mut(key)
+    }
+
+    /// Check if the given environment name is the currently active one.
+    pub fn is_active_environment(&self, key: &str) -> bool {
+        self.active_environment.as_deref() == Some(key)
     }
 
     pub fn set_active_environment(&mut self, key: EnvironmentKey) {

--- a/src/app/worker/mod.rs
+++ b/src/app/worker/mod.rs
@@ -204,7 +204,11 @@ async fn process_message(app: Arc<Mutex<App>>, message: WorkerMessage) -> Result
             dag_id, dag_run_id, ..
         } => {
             taskinstances::handle_update_task_instances(
-                &app, &client, &dag_id, &dag_run_id, &env_name,
+                &app,
+                &client,
+                &dag_id,
+                &dag_run_id,
+                &env_name,
             )
             .await;
         }
@@ -247,7 +251,13 @@ async fn process_message(app: Arc<Mutex<App>>, message: WorkerMessage) -> Result
             ..
         } => {
             logs::handle_update_task_logs(
-                &app, &client, &dag_id, &dag_run_id, &task_id, task_try, &env_name,
+                &app,
+                &client,
+                &dag_id,
+                &dag_run_id,
+                &task_id,
+                task_try,
+                &env_name,
             )
             .await;
         }


### PR DESCRIPTION
When switching servers, in-flight async worker tasks would write their
API responses to whichever environment was currently active (via
get_active_environment_mut), rather than the environment that initiated
the request. This caused data from Server A to be written into Server B's
environment, resulting in mixed/corrupted table data.

Fix by capturing the environment name at the start of each worker task
and writing results to that specific environment by name. Panel data is
only synced to the UI if the originating environment is still active.

https://claude.ai/code/session_017KYZoi6WDxYnkND7LtoQRt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Environment-specific handling now stores and updates DAGs, runs, task instances and logs per environment to avoid cross-environment interference.
  * UI sync now only updates panels for the currently active environment, reducing chances of showing stale or incorrect data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->