### PR TITLE
refactor: centralize navigation context, flatten cache, add request d…

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -41,7 +41,8 @@ where
                 if let Ok(client) = create_client(&server_config) {
                     let env_data = environment_state::EnvironmentData::new(client);
                     app.environment_state
-                        .add_environment(server_config.name.clone(), env_data);
+                        .environments
+                        .insert(server_config.name.clone(), env_data);
                 } else {
                     log::error!(
                         "Failed to create client for server '{}'; skipping",
@@ -169,11 +170,13 @@ where
                     }
                     KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') => {
                         app.next_panel();
-                        app.sync_panel_data();
+                        let panel = app.active_panel.clone();
+                        app.sync_panel(&panel);
                     }
                     KeyCode::Esc | KeyCode::Left | KeyCode::Char('h') => {
                         app.previous_panel();
-                        app.sync_panel_data();
+                        let panel = app.active_panel.clone();
+                        app.sync_panel(&panel);
                     }
                     _ => {}
                 }

--- a/src/app/environment_state.rs
+++ b/src/app/environment_state.rs
@@ -107,10 +107,6 @@ impl EnvironmentStateContainer {
         }
     }
 
-    pub fn add_environment(&mut self, key: EnvironmentKey, data: EnvironmentData) {
-        self.environments.insert(key, data);
-    }
-
     pub fn get_active_environment(&self) -> Option<&EnvironmentData> {
         self.active_environment
             .as_ref()
@@ -129,23 +125,13 @@ impl EnvironmentStateContainer {
         }
     }
 
-    pub fn get_active_client(&self) -> Option<Arc<dyn AirflowClientTrait>> {
-        self.get_active_environment().map(|env| env.client.clone())
-    }
-
-    // ── Read methods (called by sync_panel and workers) ─────────────
+    // ── Read methods (called by sync_panel) ────────────────────────
 
     /// Get all DAGs for the active environment (already sorted).
     pub fn get_active_dags(&self) -> Vec<Dag> {
         self.get_active_environment()
             .map(|env| env.dags.clone())
             .unwrap_or_default()
-    }
-
-    /// Get a specific DAG by ID from the active environment.
-    pub fn get_active_dag(&self, dag_id: &str) -> Option<Dag> {
-        self.get_active_environment()
-            .and_then(|env| env.dags.iter().find(|d| d.dag_id == dag_id).cloned())
     }
 
     /// Get all DAG statistics for the active environment.

--- a/src/app/environment_state.rs
+++ b/src/app/environment_state.rs
@@ -82,13 +82,7 @@ impl EnvironmentData {
     }
 
     /// Replace logs for a specific task instance.
-    pub fn add_task_logs(
-        &mut self,
-        dag_id: &str,
-        dag_run_id: &str,
-        task_id: &str,
-        logs: Vec<Log>,
-    ) {
+    pub fn add_task_logs(&mut self, dag_id: &str, dag_run_id: &str, task_id: &str, logs: Vec<Log>) {
         self.task_logs
             .entry(dag_id.to_string())
             .or_default()
@@ -179,12 +173,7 @@ impl EnvironmentStateContainer {
     }
 
     /// Get logs for a specific task instance in the active environment.
-    pub fn get_active_task_logs(
-        &self,
-        dag_id: &str,
-        dag_run_id: &str,
-        task_id: &str,
-    ) -> Vec<Log> {
+    pub fn get_active_task_logs(&self, dag_id: &str, dag_run_id: &str, task_id: &str) -> Vec<Log> {
         self.get_active_environment()
             .and_then(|env| env.task_logs.get(dag_id))
             .and_then(|runs| runs.get(dag_run_id))

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -1,6 +1,6 @@
 use ratatui::widgets::TableState;
 
-use super::{events::custom::FlowrsEvent, worker::WorkerMessage};
+use super::{events::custom::FlowrsEvent, state::NavigationContext, worker::WorkerMessage};
 
 pub mod config;
 pub mod dagruns;
@@ -65,7 +65,11 @@ impl KeyResult {
 }
 
 pub trait Model {
-    fn update(&mut self, event: &FlowrsEvent) -> (Option<FlowrsEvent>, Vec<WorkerMessage>);
+    fn update(
+        &mut self,
+        event: &FlowrsEvent,
+        ctx: &NavigationContext,
+    ) -> (Option<FlowrsEvent>, Vec<WorkerMessage>);
 }
 
 #[derive(Clone, Default)]

--- a/src/app/model/config.rs
+++ b/src/app/model/config.rs
@@ -76,7 +76,11 @@ impl ConfigModel {
 }
 
 impl Model for ConfigModel {
-    fn update(&mut self, event: &FlowrsEvent) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
+    fn update(
+        &mut self,
+        event: &FlowrsEvent,
+        _ctx: &crate::app::state::NavigationContext,
+    ) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
         match event {
             FlowrsEvent::Tick => (Some(FlowrsEvent::Tick), vec![]),
             FlowrsEvent::Key(key_event) => {

--- a/src/app/model/dags.rs
+++ b/src/app/model/dags.rs
@@ -52,13 +52,6 @@ impl DagModel {
         Self::default()
     }
 
-    /// Find a DAG by its ID
-    pub fn get_dag_by_id(&self, dag_id: &str) -> Option<&Dag> {
-        self.table.all.iter().find(|dag| dag.dag_id == dag_id)
-    }
-}
-
-impl DagModel {
     /// Handle model-specific popup (returns messages from popup)
     fn handle_popup(
         &mut self,

--- a/src/app/model/dags.rs
+++ b/src/app/model/dags.rs
@@ -60,10 +60,14 @@ impl DagModel {
 
 impl DagModel {
     /// Handle model-specific popup (returns messages from popup)
-    fn handle_popup(&mut self, event: &FlowrsEvent) -> Option<Vec<WorkerMessage>> {
+    fn handle_popup(
+        &mut self,
+        event: &FlowrsEvent,
+        ctx: &crate::app::state::NavigationContext,
+    ) -> Option<Vec<WorkerMessage>> {
         let custom_popup = self.popup.custom_mut()?;
         let DagPopUp::Trigger(trigger_popup) = custom_popup;
-        let (key_event, messages) = trigger_popup.update(event);
+        let (key_event, messages) = trigger_popup.update(event, ctx);
         debug!("Popup messages: {messages:?}");
 
         if let Some(FlowrsEvent::Key(key_event)) = &key_event {
@@ -140,7 +144,11 @@ impl DagModel {
 }
 
 impl Model for DagModel {
-    fn update(&mut self, event: &FlowrsEvent) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
+    fn update(
+        &mut self,
+        event: &FlowrsEvent,
+        ctx: &crate::app::state::NavigationContext,
+    ) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
         match event {
             FlowrsEvent::Tick => {
                 self.ticks += 1;
@@ -154,7 +162,7 @@ impl Model for DagModel {
             }
             FlowrsEvent::Key(key_event) => {
                 // Popup handling (has its own update method)
-                if let Some(messages) = self.handle_popup(event) {
+                if let Some(messages) = self.handle_popup(event, ctx) {
                     return (None, messages);
                 }
 

--- a/src/app/model/popup/dagruns/clear.rs
+++ b/src/app/model/popup/dagruns/clear.rs
@@ -34,7 +34,11 @@ impl ClearDagRunPopup {
 }
 
 impl Model for ClearDagRunPopup {
-    fn update(&mut self, event: &FlowrsEvent, _ctx: &crate::app::state::NavigationContext) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
+    fn update(
+        &mut self,
+        event: &FlowrsEvent,
+        _ctx: &crate::app::state::NavigationContext,
+    ) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
         if let FlowrsEvent::Key(key_event) = event {
             match key_event.code {
                 KeyCode::Enter => {

--- a/src/app/model/popup/dagruns/clear.rs
+++ b/src/app/model/popup/dagruns/clear.rs
@@ -34,7 +34,7 @@ impl ClearDagRunPopup {
 }
 
 impl Model for ClearDagRunPopup {
-    fn update(&mut self, event: &FlowrsEvent) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
+    fn update(&mut self, event: &FlowrsEvent, _ctx: &crate::app::state::NavigationContext) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
         if let FlowrsEvent::Key(key_event) = event {
             match key_event.code {
                 KeyCode::Enter => {

--- a/src/app/model/popup/dagruns/mark.rs
+++ b/src/app/model/popup/dagruns/mark.rs
@@ -62,7 +62,7 @@ impl MarkDagRunPopup {
 }
 
 impl Model for MarkDagRunPopup {
-    fn update(&mut self, event: &FlowrsEvent) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
+    fn update(&mut self, event: &FlowrsEvent, _ctx: &crate::app::state::NavigationContext) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
         if let FlowrsEvent::Key(key_event) = event {
             match key_event.code {
                 KeyCode::Enter => {

--- a/src/app/model/popup/dagruns/mark.rs
+++ b/src/app/model/popup/dagruns/mark.rs
@@ -62,7 +62,11 @@ impl MarkDagRunPopup {
 }
 
 impl Model for MarkDagRunPopup {
-    fn update(&mut self, event: &FlowrsEvent, _ctx: &crate::app::state::NavigationContext) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
+    fn update(
+        &mut self,
+        event: &FlowrsEvent,
+        _ctx: &crate::app::state::NavigationContext,
+    ) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
         if let FlowrsEvent::Key(key_event) = event {
             match key_event.code {
                 KeyCode::Enter => {

--- a/src/app/model/popup/dagruns/mark.rs
+++ b/src/app/model/popup/dagruns/mark.rs
@@ -73,11 +73,6 @@ impl Model for MarkDagRunPopup {
                     // On Enter, we always return the key event, so the parent can close the popup
                     return (
                         Some(FlowrsEvent::Key(*key_event)),
-                        // vec![WorkerMessage::MarkDagRun {
-                        //     dag_run_id: self.dag_run_id.clone(),
-                        //     dag_id: self.dag_id.clone(),
-                        //     status: self.status.clone(),
-                        // }],
                         self.marked
                             .iter()
                             .map(|i| WorkerMessage::MarkDagRun {

--- a/src/app/model/popup/dagruns/trigger.rs
+++ b/src/app/model/popup/dagruns/trigger.rs
@@ -32,7 +32,7 @@ impl TriggerDagRunPopUp {
 }
 
 impl Model for TriggerDagRunPopUp {
-    fn update(&mut self, event: &FlowrsEvent) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
+    fn update(&mut self, event: &FlowrsEvent, _ctx: &crate::app::state::NavigationContext) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
         if let FlowrsEvent::Key(key_event) = event {
             match key_event.code {
                 KeyCode::Enter => {

--- a/src/app/model/popup/dagruns/trigger.rs
+++ b/src/app/model/popup/dagruns/trigger.rs
@@ -32,7 +32,11 @@ impl TriggerDagRunPopUp {
 }
 
 impl Model for TriggerDagRunPopUp {
-    fn update(&mut self, event: &FlowrsEvent, _ctx: &crate::app::state::NavigationContext) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
+    fn update(
+        &mut self,
+        event: &FlowrsEvent,
+        _ctx: &crate::app::state::NavigationContext,
+    ) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
         if let FlowrsEvent::Key(key_event) = event {
             match key_event.code {
                 KeyCode::Enter => {

--- a/src/app/model/popup/taskinstances/clear.rs
+++ b/src/app/model/popup/taskinstances/clear.rs
@@ -36,7 +36,7 @@ impl ClearTaskInstancePopup {
 }
 
 impl Model for ClearTaskInstancePopup {
-    fn update(&mut self, event: &FlowrsEvent) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
+    fn update(&mut self, event: &FlowrsEvent, _ctx: &crate::app::state::NavigationContext) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
         if let FlowrsEvent::Key(key_event) = event {
             match key_event.code {
                 KeyCode::Enter => {

--- a/src/app/model/popup/taskinstances/clear.rs
+++ b/src/app/model/popup/taskinstances/clear.rs
@@ -36,7 +36,11 @@ impl ClearTaskInstancePopup {
 }
 
 impl Model for ClearTaskInstancePopup {
-    fn update(&mut self, event: &FlowrsEvent, _ctx: &crate::app::state::NavigationContext) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
+    fn update(
+        &mut self,
+        event: &FlowrsEvent,
+        _ctx: &crate::app::state::NavigationContext,
+    ) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
         if let FlowrsEvent::Key(key_event) = event {
             match key_event.code {
                 KeyCode::Enter => {

--- a/src/app/model/popup/taskinstances/mark.rs
+++ b/src/app/model/popup/taskinstances/mark.rs
@@ -64,7 +64,7 @@ impl MarkTaskInstancePopup {
 }
 
 impl Model for MarkTaskInstancePopup {
-    fn update(&mut self, event: &FlowrsEvent) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
+    fn update(&mut self, event: &FlowrsEvent, _ctx: &crate::app::state::NavigationContext) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
         if let FlowrsEvent::Key(key_event) = event {
             match key_event.code {
                 KeyCode::Enter => {

--- a/src/app/model/popup/taskinstances/mark.rs
+++ b/src/app/model/popup/taskinstances/mark.rs
@@ -64,7 +64,11 @@ impl MarkTaskInstancePopup {
 }
 
 impl Model for MarkTaskInstancePopup {
-    fn update(&mut self, event: &FlowrsEvent, _ctx: &crate::app::state::NavigationContext) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
+    fn update(
+        &mut self,
+        event: &FlowrsEvent,
+        _ctx: &crate::app::state::NavigationContext,
+    ) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
         if let FlowrsEvent::Key(key_event) = event {
             match key_event.code {
                 KeyCode::Enter => {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -344,11 +344,4 @@ impl App {
             }
         }
     }
-
-    /// Sync the active panel's data from `environment_state`.
-    /// Called on panel navigation and after worker completes API calls.
-    pub fn sync_panel_data(&mut self) {
-        let panel = self.active_panel.clone();
-        self.sync_panel(&panel);
-    }
 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -235,7 +235,8 @@ impl App {
             } => {
                 let is_new_context = self.nav_context.dag_id.as_ref() != Some(dag_id)
                     || self.nav_context.dag_run_id.as_ref() != Some(dag_run_id)
-                    || self.nav_context.task_id.as_ref() != Some(task_id);
+                    || self.nav_context.task_id.as_ref() != Some(task_id)
+                    || self.nav_context.task_try.as_ref() != Some(task_try);
                 self.nav_context.dag_id = Some(dag_id.clone());
                 self.nav_context.dag_run_id = Some(dag_run_id.clone());
                 self.nav_context.task_id = Some(task_id.clone());
@@ -272,8 +273,7 @@ impl App {
             }
             Panel::DAGRun => {
                 if let Some(dag_id) = &self.nav_context.dag_id {
-                    self.dagruns.table.all =
-                        self.environment_state.get_active_dag_runs(dag_id);
+                    self.dagruns.table.all = self.environment_state.get_active_dag_runs(dag_id);
                     let dag_run_ids: Vec<String> = self
                         .dagruns
                         .table

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -9,15 +9,29 @@ use throbber_widgets_tui::ThrobberState;
 use time::format_description::BorrowedFormatItem;
 
 use super::model::{config::ConfigModel, logs::LogModel, taskinstances::TaskInstanceModel};
+use super::worker::WorkerMessage;
 
 /// Cached date format for breadcrumb display (YYYY-MM-DD)
 static BREADCRUMB_DATE_FORMAT: LazyLock<Vec<BorrowedFormatItem<'static>>> = LazyLock::new(|| {
     time::format_description::parse("[year]-[month]-[day]").expect("Invalid date format")
 });
 
+/// Centralized navigation context — the single source of truth for what the
+/// user is currently looking at. Replaces the redundant per-panel context IDs
+/// that were previously stored on `DagRunModel`, `TaskInstanceModel`, and `LogModel`.
+#[derive(Clone, Default, Debug)]
+pub struct NavigationContext {
+    pub environment: Option<String>,
+    pub dag_id: Option<String>,
+    pub dag_run_id: Option<String>,
+    pub task_id: Option<String>,
+    pub task_try: Option<u16>,
+}
+
 pub struct App {
     pub config: FlowrsConfig,
     pub environment_state: EnvironmentStateContainer,
+    pub nav_context: NavigationContext,
     pub dags: DagModel,
     pub configs: ConfigModel,
     pub dagruns: DagRunModel,
@@ -66,9 +80,15 @@ impl App {
             Some(WarningPopup::new(warnings))
         };
 
+        let nav_context = NavigationContext {
+            environment: config.active_server.clone(),
+            ..Default::default()
+        };
+
         Self {
             config,
             environment_state: EnvironmentStateContainer::new(),
+            nav_context,
             dags: DagModel::new(),
             configs: ConfigModel::new_with_errors(&servers, errors),
             dagruns: DagRunModel::new(),
@@ -111,8 +131,12 @@ impl App {
     pub fn clear_state(&mut self) {
         self.ticks = 0;
         self.loading = true;
+        // Clear navigation context below the environment level
+        self.nav_context.dag_id = None;
+        self.nav_context.dag_run_id = None;
+        self.nav_context.task_id = None;
+        self.nav_context.task_try = None;
         // Clear view models but not environment_state
-        // This clears UI state (filters, selections) but data persists in environment_state
         self.dags.table.all.clear();
         self.dagruns.table.all.clear();
         self.task_instances.table.all.clear();
@@ -124,14 +148,13 @@ impl App {
     pub fn breadcrumb(&self) -> Option<String> {
         let mut parts: Vec<String> = Vec::new();
 
-        // Always start with the active environment (config) name if set
-        let env_name = self.config.active_server.as_ref()?;
+        // Always start with the active environment name
+        let env_name = self.nav_context.environment.as_ref()?;
         parts.push(env_name.clone());
 
         // Add DAG if we're past the Config panel
         if self.active_panel != Panel::Config && self.active_panel != Panel::Dag {
-            if let Some(dag_id) = &self.dagruns.dag_id {
-                // Truncate long dag_id
+            if let Some(dag_id) = &self.nav_context.dag_id {
                 let truncated = Self::truncate_breadcrumb_part(dag_id, 25);
                 parts.push(truncated);
             }
@@ -139,7 +162,6 @@ impl App {
 
         // Add DAG Run logical date if we're at TaskInstance or Logs panel
         if self.active_panel == Panel::TaskInstance || self.active_panel == Panel::Logs {
-            // Get logical_date from the first task instance (they all share the same dag run)
             if let Some(task_instance) = self.task_instances.table.filtered.items.first() {
                 if let Some(logical_date) = task_instance.logical_date {
                     let formatted = logical_date
@@ -147,8 +169,7 @@ impl App {
                         .unwrap_or_else(|_| "unknown".to_string());
                     parts.push(formatted);
                 }
-            } else if let Some(dag_run_id) = &self.task_instances.dag_run_id {
-                // Fallback to dag_run_id if no task instances loaded yet
+            } else if let Some(dag_run_id) = &self.nav_context.dag_run_id {
                 let truncated = Self::truncate_breadcrumb_part(dag_run_id, 20);
                 parts.push(truncated);
             }
@@ -156,8 +177,7 @@ impl App {
 
         // Add Task if we're at Logs panel
         if self.active_panel == Panel::Logs {
-            if let Some(task_id) = &self.logs.task_id {
-                // Truncate long task_id
+            if let Some(task_id) = &self.nav_context.task_id {
                 let truncated = Self::truncate_breadcrumb_part(task_id, 20);
                 parts.push(truncated);
             }
@@ -179,7 +199,6 @@ impl App {
         if char_count <= max_chars {
             s.to_string()
         } else {
-            // Find the byte index at the char boundary for truncation
             let truncate_at = max_chars.saturating_sub(3);
             let byte_index = s
                 .char_indices()
@@ -189,14 +208,58 @@ impl App {
         }
     }
 
-    /// Sync panel data from `environment_state`
-    /// This should be called when switching panels or environments
-    pub fn sync_panel_data(&mut self) {
-        match self.active_panel {
+    /// Update the centralized navigation context from a `WorkerMessage`.
+    /// This is the single place where navigation state changes in response
+    /// to panel-emitted messages.
+    pub fn set_context_from_message(&mut self, message: &WorkerMessage) {
+        match message {
+            WorkerMessage::UpdateDagRuns { dag_id } => {
+                self.nav_context.dag_id = Some(dag_id.clone());
+                // Clear deeper context when navigating to a new DAG
+                self.nav_context.dag_run_id = None;
+                self.nav_context.task_id = None;
+                self.nav_context.task_try = None;
+            }
+            WorkerMessage::UpdateTaskInstances { dag_id, dag_run_id } => {
+                self.nav_context.dag_id = Some(dag_id.clone());
+                self.nav_context.dag_run_id = Some(dag_run_id.clone());
+                // Clear deeper context
+                self.nav_context.task_id = None;
+                self.nav_context.task_try = None;
+            }
+            WorkerMessage::UpdateTaskLogs {
+                dag_id,
+                dag_run_id,
+                task_id,
+                task_try,
+            } => {
+                let is_new_context = self.nav_context.dag_id.as_ref() != Some(dag_id)
+                    || self.nav_context.dag_run_id.as_ref() != Some(dag_run_id)
+                    || self.nav_context.task_id.as_ref() != Some(task_id);
+                self.nav_context.dag_id = Some(dag_id.clone());
+                self.nav_context.dag_run_id = Some(dag_run_id.clone());
+                self.nav_context.task_id = Some(task_id.clone());
+                self.nav_context.task_try = Some(*task_try);
+                if is_new_context {
+                    self.logs.current = 0;
+                    self.logs.follow_mode = true;
+                }
+            }
+            WorkerMessage::UpdateTasks { dag_id } => {
+                if self.nav_context.dag_id.as_ref() != Some(dag_id) {
+                    self.task_instances.task_graph = None;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Sync a specific panel's data from `environment_state`.
+    pub fn sync_panel(&mut self, panel: &Panel) {
+        match panel {
             Panel::Dag => {
                 self.dags.table.all = self.environment_state.get_active_dags();
                 self.dags.dag_stats = self.environment_state.get_active_dag_stats();
-                // Set primary values for autocomplete (dag_id is the primary field)
                 let dag_ids: Vec<String> = self
                     .dags
                     .table
@@ -208,9 +271,9 @@ impl App {
                 self.dags.table.apply_filter();
             }
             Panel::DAGRun => {
-                if let Some(dag_id) = &self.dagruns.dag_id {
-                    self.dagruns.table.all = self.environment_state.get_active_dag_runs(dag_id);
-                    // Set primary values for autocomplete (dag_run_id is the primary field)
+                if let Some(dag_id) = &self.nav_context.dag_id {
+                    self.dagruns.table.all =
+                        self.environment_state.get_active_dag_runs(dag_id);
                     let dag_run_ids: Vec<String> = self
                         .dagruns
                         .table
@@ -230,13 +293,12 @@ impl App {
             }
             Panel::TaskInstance => {
                 if let (Some(dag_id), Some(dag_run_id)) =
-                    (&self.task_instances.dag_id, &self.task_instances.dag_run_id)
+                    (&self.nav_context.dag_id, &self.nav_context.dag_run_id)
                 {
                     self.task_instances.table.all = self
                         .environment_state
                         .get_active_task_instances(dag_id, dag_run_id);
                     self.task_instances.sort_task_instances();
-                    // Set primary values for autocomplete (task_id is the primary field)
                     let task_ids: Vec<String> = self
                         .task_instances
                         .table
@@ -254,9 +316,11 @@ impl App {
                 }
             }
             Panel::Logs => {
-                if let (Some(dag_id), Some(dag_run_id), Some(task_id)) =
-                    (&self.logs.dag_id, &self.logs.dag_run_id, &self.logs.task_id)
-                {
+                if let (Some(dag_id), Some(dag_run_id), Some(task_id)) = (
+                    &self.nav_context.dag_id,
+                    &self.nav_context.dag_run_id,
+                    &self.nav_context.task_id,
+                ) {
                     self.logs.update_logs(
                         self.environment_state
                             .get_active_task_logs(dag_id, dag_run_id, task_id),
@@ -266,7 +330,6 @@ impl App {
                 }
             }
             Panel::Config => {
-                // Set primary values for config filter (name is the primary field)
                 let config_names: Vec<String> = self
                     .configs
                     .table
@@ -280,5 +343,12 @@ impl App {
                     .set_primary_values("name", config_names);
             }
         }
+    }
+
+    /// Sync the active panel's data from `environment_state`.
+    /// Called on panel navigation and after worker completes API calls.
+    pub fn sync_panel_data(&mut self) {
+        let panel = self.active_panel.clone();
+        self.sync_panel(&panel);
     }
 }

--- a/src/app/worker/config.rs
+++ b/src/app/worker/config.rs
@@ -47,7 +47,8 @@ pub fn handle_config_selected(app: &Arc<Mutex<App>>, idx: usize) -> Result<()> {
     // Set this as the active environment
     app.environment_state
         .set_active_environment(env_name.clone());
-    app.config.active_server = Some(env_name);
+    app.config.active_server = Some(env_name.clone());
+    app.nav_context.environment = Some(env_name);
 
     // Clear the view state but NOT the environment data
     app.clear_state();

--- a/src/app/worker/config.rs
+++ b/src/app/worker/config.rs
@@ -31,7 +31,8 @@ pub fn handle_config_selected(app: &Arc<Mutex<App>>, idx: usize) -> Result<()> {
             Ok(client) => {
                 let env_data = EnvironmentData::new(client);
                 app.environment_state
-                    .add_environment(env_name.clone(), env_data);
+                    .environments
+                    .insert(env_name.clone(), env_data);
             }
             Err(e) => {
                 log::error!("Failed to create client for '{env_name}': {e}");
@@ -54,7 +55,8 @@ pub fn handle_config_selected(app: &Arc<Mutex<App>>, idx: usize) -> Result<()> {
     app.clear_state();
 
     // Sync panel data from the new environment
-    app.sync_panel_data();
+    let panel = app.active_panel.clone();
+    app.sync_panel(&panel);
     app.loading = false;
     Ok(())
 }

--- a/src/app/worker/dagruns.rs
+++ b/src/app/worker/dagruns.rs
@@ -16,14 +16,12 @@ pub async fn handle_update_dag_runs(
     let mut app = app.lock().unwrap();
     match dag_runs {
         Ok(dag_runs) => {
-            // Store DAG runs in the environment state
+            // Replace DAG runs — full replacement evicts stale entries
             if let Some(env) = app.environment_state.get_active_environment_mut() {
-                for dag_run in &dag_runs.dag_runs {
-                    env.upsert_dag_run(dag_run.clone());
-                }
+                env.replace_dag_runs(dag_id, dag_runs.dag_runs);
             }
-            // Sync panel data from environment state to refresh with new API data
-            app.sync_panel_data();
+            // Sync the DAGRun panel from environment state
+            app.sync_panel(&crate::app::state::Panel::DAGRun);
         }
         Err(e) => {
             app.dagruns.popup.show_error(vec![e.to_string()]);

--- a/src/app/worker/dags.rs
+++ b/src/app/worker/dags.rs
@@ -13,10 +13,9 @@ pub async fn handle_update_dags_and_stats(app: &Arc<Mutex<App>>, client: &Arc<dy
         let app_lock = app.lock().unwrap();
         app_lock
             .environment_state
-            .get_active_dags()
-            .iter()
-            .map(|dag| dag.dag_id.clone())
-            .collect()
+            .get_active_environment()
+            .map(|env| env.dags.iter().map(|dag| dag.dag_id.clone()).collect())
+            .unwrap_or_default()
     };
 
     if cached_dag_ids.is_empty() {
@@ -118,7 +117,10 @@ pub async fn handle_get_dag_code(
 ) {
     let current_dag = {
         let app_lock = app.lock().unwrap();
-        app_lock.environment_state.get_active_dag(dag_id)
+        app_lock
+            .environment_state
+            .get_active_environment()
+            .and_then(|env| env.dags.iter().find(|d| d.dag_id == dag_id).cloned())
     };
 
     if let Some(current_dag) = current_dag {

--- a/src/app/worker/dags.rs
+++ b/src/app/worker/dags.rs
@@ -4,16 +4,11 @@ use crate::airflow::traits::AirflowClient;
 use crate::app::state::App;
 
 /// Handle updating DAGs and their statistics from the Airflow server.
-/// Fetches DAGs first, then fetches stats for all DAG IDs in parallel.
+/// Fetches DAG list and stats concurrently. Stats use cached DAG IDs so both
+/// requests can start immediately; new DAGs pick up stats on the next refresh.
 pub async fn handle_update_dags_and_stats(app: &Arc<Mutex<App>>, client: &Arc<dyn AirflowClient>) {
-    // First, fetch DAGs
-    let dag_list_result = client.list_dags().await;
-
-    // Collect DAG IDs for stats query
-    let dag_ids: Vec<String> = if let Ok(dag_list) = &dag_list_result {
-        dag_list.dags.iter().map(|dag| dag.dag_id.clone()).collect()
-    } else {
-        // If DAG list failed, try to use cached DAG IDs
+    // Snapshot cached DAG IDs for the stats request (avoids holding the lock during I/O)
+    let cached_dag_ids: Vec<String> = {
         let app_lock = app.lock().unwrap();
         app_lock
             .environment_state
@@ -23,19 +18,19 @@ pub async fn handle_update_dags_and_stats(app: &Arc<Mutex<App>>, client: &Arc<dy
             .collect()
     };
 
-    // Fetch stats for all DAGs
-    let dag_ids_refs: Vec<&str> = dag_ids.iter().map(String::as_str).collect();
-    let dag_stats_result = client.get_dag_stats(dag_ids_refs).await;
+    // Fetch DAG list and stats concurrently
+    let (dag_list_result, dag_stats_result) = tokio::join!(client.list_dags(), async {
+        let refs: Vec<&str> = cached_dag_ids.iter().map(String::as_str).collect();
+        client.get_dag_stats(refs).await
+    });
 
     let mut app = app.lock().unwrap();
 
-    // Process DAGs
+    // Process DAGs — full replacement evicts stale entries
     match dag_list_result {
         Ok(dag_list) => {
             if let Some(env) = app.environment_state.get_active_environment_mut() {
-                for dag in &dag_list.dags {
-                    env.upsert_dag(dag.clone());
-                }
+                env.replace_dags(dag_list.dags);
             }
         }
         Err(e) => {
@@ -58,8 +53,8 @@ pub async fn handle_update_dags_and_stats(app: &Arc<Mutex<App>>, client: &Arc<dy
         }
     }
 
-    // Sync panel data from environment state
-    app.sync_panel_data();
+    // Sync the Dag panel from environment state
+    app.sync_panel(&crate::app::state::Panel::Dag);
 }
 
 /// Handle toggling the paused state of a DAG.

--- a/src/app/worker/dags.rs
+++ b/src/app/worker/dags.rs
@@ -4,8 +4,9 @@ use crate::airflow::traits::AirflowClient;
 use crate::app::state::App;
 
 /// Handle updating DAGs and their statistics from the Airflow server.
-/// Fetches DAG list and stats concurrently. Stats use cached DAG IDs so both
-/// requests can start immediately; new DAGs pick up stats on the next refresh.
+/// On cold start (empty cache), fetches DAGs first then stats sequentially so
+/// stats use fresh IDs. On warm cache, fetches both concurrently using cached
+/// DAG IDs; new DAGs pick up stats on the next refresh.
 pub async fn handle_update_dags_and_stats(app: &Arc<Mutex<App>>, client: &Arc<dyn AirflowClient>) {
     // Snapshot cached DAG IDs for the stats request (avoids holding the lock during I/O)
     let cached_dag_ids: Vec<String> = {
@@ -18,43 +19,81 @@ pub async fn handle_update_dags_and_stats(app: &Arc<Mutex<App>>, client: &Arc<dy
             .collect()
     };
 
-    // Fetch DAG list and stats concurrently
-    let (dag_list_result, dag_stats_result) = tokio::join!(client.list_dags(), async {
-        let refs: Vec<&str> = cached_dag_ids.iter().map(String::as_str).collect();
-        client.get_dag_stats(refs).await
-    });
+    if cached_dag_ids.is_empty() {
+        // Cold start: fetch DAGs first, then stats with fresh IDs
+        let dag_list_result = client.list_dags().await;
 
-    let mut app = app.lock().unwrap();
-
-    // Process DAGs — full replacement evicts stale entries
-    match dag_list_result {
-        Ok(dag_list) => {
-            if let Some(env) = app.environment_state.get_active_environment_mut() {
-                env.replace_dags(dag_list.dags);
+        let dag_ids: Vec<String> = {
+            let mut app = app.lock().unwrap();
+            match dag_list_result {
+                Ok(dag_list) => {
+                    let ids: Vec<String> = dag_list.dags.iter().map(|d| d.dag_id.clone()).collect();
+                    if let Some(env) = app.environment_state.get_active_environment_mut() {
+                        env.replace_dags(dag_list.dags);
+                    }
+                    ids
+                }
+                Err(e) => {
+                    app.dags.popup.show_error(vec![e.to_string()]);
+                    vec![]
+                }
             }
-        }
-        Err(e) => {
-            app.dags.popup.show_error(vec![e.to_string()]);
-        }
-    }
+        };
 
-    // Process stats
-    match dag_stats_result {
-        Ok(dag_stats) => {
-            if let Some(env) = app.environment_state.get_active_environment_mut() {
-                for dag_stats in dag_stats.dags {
-                    env.update_dag_stats(&dag_stats.dag_id, dag_stats.stats);
+        if !dag_ids.is_empty() {
+            let refs: Vec<&str> = dag_ids.iter().map(String::as_str).collect();
+            match client.get_dag_stats(refs).await {
+                Ok(dag_stats) => {
+                    let mut app = app.lock().unwrap();
+                    if let Some(env) = app.environment_state.get_active_environment_mut() {
+                        for dag_stats in dag_stats.dags {
+                            env.update_dag_stats(&dag_stats.dag_id, dag_stats.stats);
+                        }
+                    }
+                }
+                Err(e) => {
+                    log::error!("Failed to fetch dag stats: {e}");
                 }
             }
         }
-        Err(e) => {
-            // Don't overwrite existing error popup, just log
-            log::error!("Failed to fetch dag stats: {e}");
+    } else {
+        // Warm cache: fetch DAG list and stats concurrently using cached IDs
+        let (dag_list_result, dag_stats_result) = tokio::join!(client.list_dags(), async {
+            let refs: Vec<&str> = cached_dag_ids.iter().map(String::as_str).collect();
+            client.get_dag_stats(refs).await
+        });
+
+        let mut app = app.lock().unwrap();
+
+        match dag_list_result {
+            Ok(dag_list) => {
+                if let Some(env) = app.environment_state.get_active_environment_mut() {
+                    env.replace_dags(dag_list.dags);
+                }
+            }
+            Err(e) => {
+                app.dags.popup.show_error(vec![e.to_string()]);
+            }
+        }
+
+        match dag_stats_result {
+            Ok(dag_stats) => {
+                if let Some(env) = app.environment_state.get_active_environment_mut() {
+                    for dag_stats in dag_stats.dags {
+                        env.update_dag_stats(&dag_stats.dag_id, dag_stats.stats);
+                    }
+                }
+            }
+            Err(e) => {
+                log::error!("Failed to fetch dag stats: {e}");
+            }
         }
     }
 
     // Sync the Dag panel from environment state
-    app.sync_panel(&crate::app::state::Panel::Dag);
+    app.lock()
+        .unwrap()
+        .sync_panel(&crate::app::state::Panel::Dag);
 }
 
 /// Handle toggling the paused state of a DAG.

--- a/src/app/worker/logs.rs
+++ b/src/app/worker/logs.rs
@@ -43,6 +43,6 @@ pub async fn handle_update_task_logs(
         }
     }
 
-    // Sync panel data from environment state to refresh with new API data
-    app.sync_panel_data();
+    // Sync the Logs panel from environment state
+    app.sync_panel(&crate::app::state::Panel::Logs);
 }

--- a/src/app/worker/mod.rs
+++ b/src/app/worker/mod.rs
@@ -186,7 +186,9 @@ async fn process_message(app: Arc<Mutex<App>>, message: WorkerMessage) -> Result
     // Get the active client from the environment state
     let client = {
         let app = app.lock().unwrap();
-        app.environment_state.get_active_client()
+        app.environment_state
+            .get_active_environment()
+            .map(|env| env.client.clone())
     };
 
     let Some(client) = client else {

--- a/src/app/worker/mod.rs
+++ b/src/app/worker/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
 use super::model::popup::dagruns::mark::MarkState;
@@ -96,6 +97,30 @@ pub enum OpenItem {
     },
 }
 
+impl WorkerMessage {
+    /// Returns a dedup key for periodic refresh messages.
+    /// One-off user actions (mark, clear, trigger, toggle, etc.) return `None`
+    /// so they are never deduplicated.
+    fn dedup_key(&self) -> Option<String> {
+        match self {
+            Self::UpdateDagsAndStats => Some("UpdateDagsAndStats".to_string()),
+            Self::UpdateDagRuns { dag_id } => Some(format!("UpdateDagRuns:{dag_id}")),
+            Self::UpdateTaskInstances { dag_id, dag_run_id } => {
+                Some(format!("UpdateTaskInstances:{dag_id}:{dag_run_id}"))
+            }
+            Self::UpdateTaskLogs {
+                dag_id,
+                dag_run_id,
+                task_id,
+                ..
+            } => Some(format!("UpdateTaskLogs:{dag_id}:{dag_run_id}:{task_id}")),
+            Self::UpdateTasks { dag_id } => Some(format!("UpdateTasks:{dag_id}")),
+            // One-off operations should never be deduplicated
+            _ => None,
+        }
+    }
+}
+
 impl Dispatcher {
     pub const fn new(app: Arc<Mutex<App>>) -> Self {
         Self { app }
@@ -103,15 +128,32 @@ impl Dispatcher {
 
     pub async fn run(self, mut rx: Receiver<WorkerMessage>) -> Result<()> {
         let mut tasks = JoinSet::new();
+        let in_flight: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
 
         // Process messages until the channel is closed (recv returns None)
         while let Some(message) = rx.recv().await {
+            let dedup_key = message.dedup_key();
+
+            // Skip if an identical periodic request is already in flight
+            if let Some(ref key) = dedup_key {
+                let mut set = in_flight.lock().unwrap();
+                if set.contains(key) {
+                    log::debug!("Skipping duplicate in-flight message: {key}");
+                    continue;
+                }
+                set.insert(key.clone());
+            }
+
             // Spawn each message processing as a concurrent task
-            // This allows multiple API requests to run in parallel
             let app = self.app.clone();
+            let in_flight = in_flight.clone();
             tasks.spawn(async move {
                 if let Err(e) = process_message(app, message).await {
                     log::error!("Error processing message: {e}");
+                }
+                // Remove from in-flight set when done
+                if let Some(key) = dedup_key {
+                    in_flight.lock().unwrap().remove(&key);
                 }
             });
         }

--- a/src/app/worker/taskinstances.rs
+++ b/src/app/worker/taskinstances.rs
@@ -17,14 +17,12 @@ pub async fn handle_update_task_instances(
     let mut app = app.lock().unwrap();
     match task_instances {
         Ok(task_instances) => {
-            // Store task instances in the environment state
+            // Replace task instances — full replacement evicts stale entries
             if let Some(env) = app.environment_state.get_active_environment_mut() {
-                for task_instance in &task_instances.task_instances {
-                    env.upsert_task_instance(task_instance.clone());
-                }
+                env.replace_task_instances(dag_id, dag_run_id, task_instances.task_instances);
             }
-            // Sync panel data from environment state to refresh with new API data
-            app.sync_panel_data();
+            // Sync the TaskInstance panel from environment state
+            app.sync_panel(&crate::app::state::Panel::TaskInstance);
         }
         Err(e) => {
             log::error!("Error getting task instances: {e:?}");

--- a/src/ui/init_screen.rs
+++ b/src/ui/init_screen.rs
@@ -6,7 +6,6 @@ use ratatui::{
 };
 
 pub fn render_init_screen(f: &mut Frame, index: u32) {
-    // let text = ASCII_LOGO.into_text().unwrap();
     let text = ROTATING_LOGO[index as usize % ROTATING_LOGO.len()]
         .into_text()
         .expect("ROTATING_LOGO should contain valid ANSI text");


### PR DESCRIPTION
…edup

- Collapse pre-sync block into worker-only sync via set_context_from_message()
- Centralize NavigationContext (environment, dag_id, dag_run_id, task_id, task_try) and pass through Model trait, removing redundant fields from panel models
- Add in-flight deduplication in Dispatcher using WorkerMessage::dedup_key() to prevent duplicate API requests from tick-based auto-refresh
- Flatten nested DagData/DagRunData/TaskInstanceData cache into request-keyed HashMaps with replace_* methods for clean stale-entry eviction
- Parallelize DAG list + stats fetch with tokio::join!

https://claude.ai/code/session_017Q2J8ddM6JXSvdy8xxH6W6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized navigation context used across panels; panels now derive IDs and state from a shared context.
  * Switched UI state model to flatter, batch-replace updates for lists (dags, runs, tasks, logs) instead of per-item upserts.

* **Performance**
  * Added deduplication for periodic worker messages to avoid redundant processing.
  * More targeted panel syncs and concurrent DAG metadata fetching to reduce UI latency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->