### PR TITLE
refactor: replace type aliases with newtypes and flatten nested HashMaps

### DIFF
--- a/src/airflow/graph.rs
+++ b/src/airflow/graph.rs
@@ -104,7 +104,7 @@ mod tests {
 
     fn make_task_instance(task_id: &str) -> TaskInstance {
         TaskInstance {
-            task_id: task_id.to_string(),
+            task_id: task_id.into(),
             ..Default::default()
         }
     }

--- a/src/airflow/model.rs
+++ b/src/airflow/model.rs
@@ -1,1 +1,2 @@
 pub mod common;
+pub mod newtype_id;

--- a/src/airflow/model/common/dag.rs
+++ b/src/airflow/model/common/dag.rs
@@ -3,11 +3,13 @@ use crate::airflow::client::v2;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
+use super::DagId;
+
 /// Common DAG model used by the application
 #[allow(clippy::struct_field_names)]
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Dag {
-    pub dag_id: super::DagId,
+    pub dag_id: DagId,
     pub dag_display_name: Option<String>,
     pub description: Option<String>,
     pub fileloc: String,

--- a/src/airflow/model/common/dag.rs
+++ b/src/airflow/model/common/dag.rs
@@ -7,7 +7,7 @@ use time::OffsetDateTime;
 #[allow(clippy::struct_field_names)]
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Dag {
-    pub dag_id: String,
+    pub dag_id: super::DagId,
     pub dag_display_name: Option<String>,
     pub description: Option<String>,
     pub fileloc: String,
@@ -44,7 +44,7 @@ pub struct Tag {
 impl From<v1::model::dag::DagResponse> for Dag {
     fn from(value: v1::model::dag::DagResponse) -> Self {
         Self {
-            dag_id: value.dag_id,
+            dag_id: value.dag_id.into(),
             dag_display_name: Some(value.dag_display_name),
             description: value.description,
             fileloc: value.fileloc,
@@ -96,7 +96,7 @@ impl From<v1::model::dag::DagTagResponse> for Tag {
 impl From<v2::model::dag::Dag> for Dag {
     fn from(value: v2::model::dag::Dag) -> Self {
         Self {
-            dag_id: value.dag_id,
+            dag_id: value.dag_id.into(),
             dag_display_name: Some(value.dag_display_name),
             description: value.description,
             fileloc: value.fileloc,

--- a/src/airflow/model/common/dagrun.rs
+++ b/src/airflow/model/common/dagrun.rs
@@ -4,13 +4,14 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 use super::duration::TimeBounded;
+use super::{DagId, DagRunId};
 
 /// Common `DagRun` model used by the application
 #[allow(clippy::struct_field_names)]
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DagRun {
-    pub dag_id: super::DagId,
-    pub dag_run_id: super::DagRunId,
+    pub dag_id: DagId,
+    pub dag_run_id: DagRunId,
     pub logical_date: Option<OffsetDateTime>,
     pub data_interval_end: Option<OffsetDateTime>,
     pub data_interval_start: Option<OffsetDateTime>,

--- a/src/airflow/model/common/dagrun.rs
+++ b/src/airflow/model/common/dagrun.rs
@@ -9,8 +9,8 @@ use super::duration::TimeBounded;
 #[allow(clippy::struct_field_names)]
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DagRun {
-    pub dag_id: String,
-    pub dag_run_id: String,
+    pub dag_id: super::DagId,
+    pub dag_run_id: super::DagRunId,
     pub logical_date: Option<OffsetDateTime>,
     pub data_interval_end: Option<OffsetDateTime>,
     pub data_interval_start: Option<OffsetDateTime>,
@@ -43,8 +43,8 @@ impl TimeBounded for DagRun {
 impl From<v1::model::dagrun::DAGRunResponse> for DagRun {
     fn from(value: v1::model::dagrun::DAGRunResponse) -> Self {
         Self {
-            dag_id: value.dag_id,
-            dag_run_id: value.dag_run_id.unwrap_or_default(),
+            dag_id: value.dag_id.into(),
+            dag_run_id: value.dag_run_id.unwrap_or_default().into(),
             logical_date: value.logical_date,
             data_interval_end: value.data_interval_end,
             data_interval_start: value.data_interval_start,
@@ -76,8 +76,8 @@ impl From<v1::model::dagrun::DAGRunCollectionResponse> for DagRunList {
 impl From<v2::model::dagrun::DagRun> for DagRun {
     fn from(value: v2::model::dagrun::DagRun) -> Self {
         Self {
-            dag_id: value.dag_id,
-            dag_run_id: value.dag_run_id,
+            dag_id: value.dag_id.into(),
+            dag_run_id: value.dag_run_id.into(),
             logical_date: value.logical_date,
             data_interval_end: value.data_interval_end,
             data_interval_start: value.data_interval_start,

--- a/src/airflow/model/common/mod.rs
+++ b/src/airflow/model/common/mod.rs
@@ -14,3 +14,6 @@ pub use duration::{calculate_duration, format_duration};
 pub use log::Log;
 pub use task::{Task, TaskList};
 pub use taskinstance::{TaskInstance, TaskInstanceList};
+
+// Re-export newtype IDs
+pub use super::newtype_id::{DagId, DagRunId, EnvironmentKey, TaskId};

--- a/src/airflow/model/common/taskinstance.rs
+++ b/src/airflow/model/common/taskinstance.rs
@@ -4,13 +4,14 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 use super::duration::TimeBounded;
+use super::{DagId, DagRunId, TaskId};
 
 /// Common `TaskInstance` model used by the application
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TaskInstance {
-    pub task_id: super::TaskId,
-    pub dag_id: super::DagId,
-    pub dag_run_id: super::DagRunId,
+    pub task_id: TaskId,
+    pub dag_id: DagId,
+    pub dag_run_id: DagRunId,
     pub logical_date: Option<OffsetDateTime>,
     pub start_date: Option<OffsetDateTime>,
     pub end_date: Option<OffsetDateTime>,

--- a/src/airflow/model/common/taskinstance.rs
+++ b/src/airflow/model/common/taskinstance.rs
@@ -8,9 +8,9 @@ use super::duration::TimeBounded;
 /// Common `TaskInstance` model used by the application
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TaskInstance {
-    pub task_id: String,
-    pub dag_id: String,
-    pub dag_run_id: String,
+    pub task_id: super::TaskId,
+    pub dag_id: super::DagId,
+    pub dag_run_id: super::DagRunId,
     pub logical_date: Option<OffsetDateTime>,
     pub start_date: Option<OffsetDateTime>,
     pub end_date: Option<OffsetDateTime>,
@@ -51,9 +51,9 @@ impl TimeBounded for TaskInstance {
 impl From<v1::model::taskinstance::TaskInstanceResponse> for TaskInstance {
     fn from(value: v1::model::taskinstance::TaskInstanceResponse) -> Self {
         Self {
-            task_id: value.task_id,
-            dag_id: value.dag_id,
-            dag_run_id: value.dag_run_id,
+            task_id: value.task_id.into(),
+            dag_id: value.dag_id.into(),
+            dag_run_id: value.dag_run_id.into(),
             logical_date: Some(value.execution_date),
             start_date: value.start_date,
             end_date: value.end_date,
@@ -93,9 +93,9 @@ impl From<v1::model::taskinstance::TaskInstanceCollectionResponse> for TaskInsta
 impl From<v2::model::taskinstance::TaskInstance> for TaskInstance {
     fn from(value: v2::model::taskinstance::TaskInstance) -> Self {
         Self {
-            task_id: value.task_id,
-            dag_id: value.dag_id,
-            dag_run_id: value.dag_run_id,
+            task_id: value.task_id.into(),
+            dag_id: value.dag_id.into(),
+            dag_run_id: value.dag_run_id.into(),
             logical_date: value.logical_date,
             start_date: value.start_date,
             end_date: value.end_date,

--- a/src/airflow/model/newtype_id.rs
+++ b/src/airflow/model/newtype_id.rs
@@ -1,0 +1,151 @@
+/// Generates a newtype wrapper around `String` with common trait implementations.
+///
+/// Each generated type provides:
+/// - `Deref<Target = str>` for transparent `&str` access (e.g. passing to API functions)
+/// - `From<String>`, `From<&str>` for ergonomic construction
+/// - `Display`, `Debug`, `Clone`, `PartialEq`, `Eq`, `Hash`, `Default` via standard derives
+/// - `Serialize`/`Deserialize` via `#[serde(transparent)]` so JSON fields stay as plain strings
+/// - `AsRef<str>` for generic string conversion
+macro_rules! define_id {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(
+            Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord,
+            serde::Serialize, serde::Deserialize,
+        )]
+        #[serde(transparent)]
+        pub struct $name(pub String);
+
+        impl std::ops::Deref for $name {
+            type Target = str;
+            fn deref(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(s: String) -> Self {
+                Self(s)
+            }
+        }
+
+        impl From<&str> for $name {
+            fn from(s: &str) -> Self {
+                Self(s.to_owned())
+            }
+        }
+
+        impl From<$name> for String {
+            fn from(id: $name) -> Self {
+                id.0
+            }
+        }
+
+        impl std::borrow::Borrow<str> for $name {
+            fn borrow(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl PartialEq<&str> for $name {
+            fn eq(&self, other: &&str) -> bool {
+                self.0 == *other
+            }
+        }
+
+        impl PartialEq<str> for $name {
+            fn eq(&self, other: &str) -> bool {
+                self.0 == other
+            }
+        }
+    };
+}
+
+define_id!(
+    /// Strongly-typed identifier for an Airflow DAG.
+    DagId
+);
+
+define_id!(
+    /// Strongly-typed identifier for an Airflow DAG run.
+    DagRunId
+);
+
+define_id!(
+    /// Strongly-typed identifier for an Airflow task.
+    TaskId
+);
+
+define_id!(
+    /// Strongly-typed identifier for an Airflow environment / server configuration.
+    EnvironmentKey
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deref_to_str() {
+        let id = DagId::from("my_dag");
+        let s: &str = &id;
+        assert_eq!(s, "my_dag");
+    }
+
+    #[test]
+    fn test_display() {
+        let id = DagRunId::from("run_123".to_string());
+        assert_eq!(format!("{id}"), "run_123");
+    }
+
+    #[test]
+    fn test_from_string() {
+        let id: TaskId = "task_abc".to_string().into();
+        assert_eq!(id.0, "task_abc");
+    }
+
+    #[test]
+    fn test_into_string() {
+        let id = EnvironmentKey::from("prod");
+        let s: String = id.into();
+        assert_eq!(s, "prod");
+    }
+
+    #[test]
+    fn test_hash_map_key() {
+        use std::collections::HashMap;
+        let mut map = HashMap::new();
+        map.insert(DagId::from("dag1"), 42);
+        assert_eq!(map.get(&DagId::from("dag1")), Some(&42));
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let id = DagId::from("my_dag");
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(json, "\"my_dag\"");
+        let back: DagId = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, id);
+    }
+
+    #[test]
+    fn test_borrow_for_hashmap_lookup() {
+        use std::collections::HashMap;
+        let mut map = HashMap::new();
+        map.insert(DagId::from("dag1"), 1);
+        // Can look up with &str thanks to Borrow<str>
+        assert_eq!(map.get("dag1"), Some(&1));
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,7 +9,10 @@ use ratatui::{prelude::Backend, Terminal};
 use state::{App, Panel};
 use worker::{Dispatcher, WorkerMessage};
 
-use crate::{airflow::client::create_client, ui::draw_ui};
+use crate::{
+    airflow::{client::create_client, model::common::EnvironmentKey},
+    ui::draw_ui,
+};
 
 pub mod environment_state;
 pub mod events;
@@ -42,7 +45,7 @@ where
                     let env_data = environment_state::EnvironmentData::new(client);
                     app.environment_state
                         .environments
-                        .insert(server_config.name.clone(), env_data);
+                        .insert(EnvironmentKey::from(server_config.name.clone()), env_data);
                 } else {
                     log::error!(
                         "Failed to create client for server '{}'; skipping",
@@ -55,7 +58,7 @@ where
         // Set the active environment if one was configured
         if let Some(active_server_name) = active_server_name {
             app.environment_state
-                .set_active_environment(active_server_name);
+                .set_active_environment(EnvironmentKey::from(active_server_name));
         }
     }
 

--- a/src/app/environment_state.rs
+++ b/src/app/environment_state.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::airflow::{
-    model::common::{Dag, DagId, DagRun, DagRunId, DagStatistic, EnvironmentKey, Log, TaskId, TaskInstance},
+    model::common::{
+        Dag, DagId, DagRun, DagRunId, DagStatistic, EnvironmentKey, Log, TaskId, TaskInstance,
+    },
     traits::AirflowClient as AirflowClientTrait,
 };
 
@@ -74,7 +76,7 @@ impl EnvironmentData {
     }
 
     /// Replace logs for a specific task instance.
-    pub fn add_task_logs(
+    pub fn replace_task_logs(
         &mut self,
         dag_id: &DagId,
         dag_run_id: &DagRunId,
@@ -144,7 +146,10 @@ impl EnvironmentStateContainer {
         dag_run_id: &DagRunId,
     ) -> Vec<TaskInstance> {
         self.get_active_environment()
-            .and_then(|env| env.task_instances.get(&(dag_id.clone(), dag_run_id.clone())))
+            .and_then(|env| {
+                env.task_instances
+                    .get(&(dag_id.clone(), dag_run_id.clone()))
+            })
             .cloned()
             .unwrap_or_default()
     }

--- a/src/app/environment_state.rs
+++ b/src/app/environment_state.rs
@@ -2,22 +2,16 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::airflow::{
-    model::common::{Dag, DagRun, DagStatistic, Log, TaskInstance},
+    model::common::{Dag, DagId, DagRun, DagRunId, DagStatistic, EnvironmentKey, Log, TaskId, TaskInstance},
     traits::AirflowClient as AirflowClientTrait,
 };
-
-/// Key identifying an environment (Airflow server configuration)
-pub type EnvironmentKey = String;
-pub type DagId = String;
-pub type DagRunId = String;
-pub type TaskId = String;
 
 /// Flat, request-keyed cache for a single Airflow environment.
 ///
 /// Each collection is keyed by the parameters of the API request that produced
-/// it. This replaces the previous nested `DagData → DagRunData → TaskInstanceData`
-/// hierarchy with direct lookups, and makes stale-entry eviction trivial
-/// (just replace the whole Vec).
+/// it. `task_instances` and `task_logs` use composite tuple keys instead of
+/// nested `HashMap`s, giving single-lookup access and eliminating intermediate
+/// allocations.
 #[derive(Clone)]
 pub struct EnvironmentData {
     pub client: Arc<dyn AirflowClientTrait>,
@@ -31,11 +25,11 @@ pub struct EnvironmentData {
     /// Result of `list_dagruns(dag_id)` — keyed by `dag_id`.
     pub dag_runs: HashMap<DagId, Vec<DagRun>>,
 
-    /// Result of `list_task_instances(dag_id, dag_run_id)` — keyed by (`dag_id`, `dag_run_id`).
-    pub task_instances: HashMap<DagId, HashMap<DagRunId, Vec<TaskInstance>>>,
+    /// Result of `list_task_instances(dag_id, dag_run_id)` — flat composite key.
+    pub task_instances: HashMap<(DagId, DagRunId), Vec<TaskInstance>>,
 
-    /// Result of `get_task_logs(dag_id, dag_run_id, task_id, try)` — keyed by (`dag_id`, `dag_run_id`, `task_id`).
-    pub task_logs: HashMap<DagId, HashMap<DagRunId, HashMap<TaskId, Vec<Log>>>>,
+    /// Result of `get_task_logs(dag_id, dag_run_id, task_id, try)` — flat composite key.
+    pub task_logs: HashMap<(DagId, DagRunId, TaskId), Vec<Log>>,
 }
 
 impl EnvironmentData {
@@ -59,36 +53,36 @@ impl EnvironmentData {
     }
 
     /// Replace stats for a single DAG.
-    pub fn update_dag_stats(&mut self, dag_id: &str, stats: Vec<DagStatistic>) {
-        self.dag_stats.insert(dag_id.to_string(), stats);
+    pub fn update_dag_stats(&mut self, dag_id: &DagId, stats: Vec<DagStatistic>) {
+        self.dag_stats.insert(dag_id.clone(), stats);
     }
 
     /// Replace all DAG runs for a DAG (evicts deleted runs).
-    pub fn replace_dag_runs(&mut self, dag_id: &str, dag_runs: Vec<DagRun>) {
-        self.dag_runs.insert(dag_id.to_string(), dag_runs);
+    pub fn replace_dag_runs(&mut self, dag_id: &DagId, dag_runs: Vec<DagRun>) {
+        self.dag_runs.insert(dag_id.clone(), dag_runs);
     }
 
     /// Replace all task instances for a DAG run (evicts deleted instances).
     pub fn replace_task_instances(
         &mut self,
-        dag_id: &str,
-        dag_run_id: &str,
+        dag_id: &DagId,
+        dag_run_id: &DagRunId,
         task_instances: Vec<TaskInstance>,
     ) {
         self.task_instances
-            .entry(dag_id.to_string())
-            .or_default()
-            .insert(dag_run_id.to_string(), task_instances);
+            .insert((dag_id.clone(), dag_run_id.clone()), task_instances);
     }
 
     /// Replace logs for a specific task instance.
-    pub fn add_task_logs(&mut self, dag_id: &str, dag_run_id: &str, task_id: &str, logs: Vec<Log>) {
+    pub fn add_task_logs(
+        &mut self,
+        dag_id: &DagId,
+        dag_run_id: &DagRunId,
+        task_id: &TaskId,
+        logs: Vec<Log>,
+    ) {
         self.task_logs
-            .entry(dag_id.to_string())
-            .or_default()
-            .entry(dag_run_id.to_string())
-            .or_default()
-            .insert(task_id.to_string(), logs);
+            .insert((dag_id.clone(), dag_run_id.clone(), task_id.clone()), logs);
     }
 }
 
@@ -129,14 +123,14 @@ impl EnvironmentStateContainer {
     }
 
     /// Get all DAG statistics for the active environment.
-    pub fn get_active_dag_stats(&self) -> HashMap<String, Vec<DagStatistic>> {
+    pub fn get_active_dag_stats(&self) -> HashMap<DagId, Vec<DagStatistic>> {
         self.get_active_environment()
             .map(|env| env.dag_stats.clone())
             .unwrap_or_default()
     }
 
     /// Get all DAG runs for a specific DAG in the active environment.
-    pub fn get_active_dag_runs(&self, dag_id: &str) -> Vec<DagRun> {
+    pub fn get_active_dag_runs(&self, dag_id: &DagId) -> Vec<DagRun> {
         self.get_active_environment()
             .and_then(|env| env.dag_runs.get(dag_id))
             .cloned()
@@ -144,20 +138,29 @@ impl EnvironmentStateContainer {
     }
 
     /// Get all task instances for a specific DAG run in the active environment.
-    pub fn get_active_task_instances(&self, dag_id: &str, dag_run_id: &str) -> Vec<TaskInstance> {
+    pub fn get_active_task_instances(
+        &self,
+        dag_id: &DagId,
+        dag_run_id: &DagRunId,
+    ) -> Vec<TaskInstance> {
         self.get_active_environment()
-            .and_then(|env| env.task_instances.get(dag_id))
-            .and_then(|runs| runs.get(dag_run_id))
+            .and_then(|env| env.task_instances.get(&(dag_id.clone(), dag_run_id.clone())))
             .cloned()
             .unwrap_or_default()
     }
 
     /// Get logs for a specific task instance in the active environment.
-    pub fn get_active_task_logs(&self, dag_id: &str, dag_run_id: &str, task_id: &str) -> Vec<Log> {
+    pub fn get_active_task_logs(
+        &self,
+        dag_id: &DagId,
+        dag_run_id: &DagRunId,
+        task_id: &TaskId,
+    ) -> Vec<Log> {
         self.get_active_environment()
-            .and_then(|env| env.task_logs.get(dag_id))
-            .and_then(|runs| runs.get(dag_run_id))
-            .and_then(|tasks| tasks.get(task_id))
+            .and_then(|env| {
+                env.task_logs
+                    .get(&(dag_id.clone(), dag_run_id.clone(), task_id.clone()))
+            })
             .cloned()
             .unwrap_or_default()
     }

--- a/src/app/model/dagruns.rs
+++ b/src/app/model/dagruns.rs
@@ -139,7 +139,11 @@ impl DagRunModel {
     }
 
     /// Mark a DAG run with a new status (optimistic update)
-    pub fn mark_dag_run(&mut self, dag_run_id: &crate::airflow::model::common::DagRunId, status: &str) {
+    pub fn mark_dag_run(
+        &mut self,
+        dag_run_id: &crate::airflow::model::common::DagRunId,
+        status: &str,
+    ) {
         if let Some(dag_run) = self
             .table
             .filtered

--- a/src/app/model/dagruns.rs
+++ b/src/app/model/dagruns.rs
@@ -134,18 +134,18 @@ impl DagRunModel {
     }
 
     /// Returns selected DAG run IDs for passing to mark/clear popups
-    fn selected_dag_run_ids(&self) -> Vec<String> {
+    fn selected_dag_run_ids(&self) -> Vec<crate::airflow::model::common::DagRunId> {
         self.table.selected_ids(|item| item.dag_run_id.clone())
     }
 
     /// Mark a DAG run with a new status (optimistic update)
-    pub fn mark_dag_run(&mut self, dag_run_id: &str, status: &str) {
+    pub fn mark_dag_run(&mut self, dag_run_id: &crate::airflow::model::common::DagRunId, status: &str) {
         if let Some(dag_run) = self
             .table
             .filtered
             .items
             .iter_mut()
-            .find(|dr| dr.dag_run_id == dag_run_id)
+            .find(|dr| dr.dag_run_id == *dag_run_id)
         {
             dag_run.state = status.to_string();
         }
@@ -420,7 +420,7 @@ impl Widget for &mut DagRunModel {
                 Row::new(vec![
                     Line::from(Span::styled("■", Style::default().fg(state_color))),
                     Line::from(Span::styled(
-                        item.dag_run_id.as_str(),
+                        &*item.dag_run_id,
                         Style::default().add_modifier(Modifier::BOLD),
                     )),
                     Line::from(if let Some(date) = item.logical_date {
@@ -570,8 +570,8 @@ mod tests {
 
         // Oldest run: completed (has both logical_date and start_date)
         let oldest_run = DagRun {
-            dag_id: "test_dag".to_string(),
-            dag_run_id: "run_1".to_string(),
+            dag_id: "test_dag".into(),
+            dag_run_id: "run_1".into(),
             logical_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
             start_date: Some(datetime!(2024-01-01 10:05:00 UTC)),
             end_date: Some(datetime!(2024-01-01 10:30:00 UTC)),
@@ -582,8 +582,8 @@ mod tests {
 
         // Middle run: queued (has logical_date but no start_date)
         let queued_run = DagRun {
-            dag_id: "test_dag".to_string(),
-            dag_run_id: "run_2".to_string(),
+            dag_id: "test_dag".into(),
+            dag_run_id: "run_2".into(),
             logical_date: Some(datetime!(2024-01-02 10:00:00 UTC)),
             start_date: None, // Queued runs don't have start_date
             end_date: None,
@@ -594,8 +594,8 @@ mod tests {
 
         // Newest run: running (has both logical_date and start_date)
         let newest_run = DagRun {
-            dag_id: "test_dag".to_string(),
-            dag_run_id: "run_3".to_string(),
+            dag_id: "test_dag".into(),
+            dag_run_id: "run_3".into(),
             logical_date: Some(datetime!(2024-01-03 10:00:00 UTC)),
             start_date: Some(datetime!(2024-01-03 10:05:00 UTC)),
             end_date: None,
@@ -624,8 +624,8 @@ mod tests {
 
         // Run with only start_date (logical_date is None)
         let run_with_start = DagRun {
-            dag_id: "test_dag".to_string(),
-            dag_run_id: "run_1".to_string(),
+            dag_id: "test_dag".into(),
+            dag_run_id: "run_1".into(),
             logical_date: None,
             start_date: Some(datetime!(2024-01-02 10:00:00 UTC)),
             state: "running".to_string(),
@@ -635,8 +635,8 @@ mod tests {
 
         // Run with both dates
         let run_with_both = DagRun {
-            dag_id: "test_dag".to_string(),
-            dag_run_id: "run_2".to_string(),
+            dag_id: "test_dag".into(),
+            dag_run_id: "run_2".into(),
             logical_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
             start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
             state: "success".to_string(),
@@ -659,8 +659,8 @@ mod tests {
         let mut model = DagRunModel::new();
 
         let run_manual = DagRun {
-            dag_id: "test_dag".to_string(),
-            dag_run_id: "manual_run_1".to_string(),
+            dag_id: "test_dag".into(),
+            dag_run_id: "manual_run_1".into(),
             logical_date: Some(datetime!(2024-01-02 10:00:00 UTC)),
             state: "success".to_string(),
             run_type: "manual".to_string(),
@@ -668,8 +668,8 @@ mod tests {
         };
 
         let run_scheduled = DagRun {
-            dag_id: "test_dag".to_string(),
-            dag_run_id: "scheduled_run_1".to_string(),
+            dag_id: "test_dag".into(),
+            dag_run_id: "scheduled_run_1".into(),
             logical_date: Some(datetime!(2024-01-03 10:00:00 UTC)),
             state: "queued".to_string(),
             run_type: "scheduled".to_string(),

--- a/src/app/model/dagruns.rs
+++ b/src/app/model/dagruns.rs
@@ -13,7 +13,7 @@ use syntect::parsing::SyntaxSet;
 use syntect::util::LinesWithEndings;
 use time::format_description;
 
-use crate::airflow::model::common::{calculate_duration, format_duration, DagRun};
+use crate::airflow::model::common::{calculate_duration, format_duration, DagRun, DagRunId};
 use crate::app::events::custom::FlowrsEvent;
 use crate::ui::common::create_headers;
 use crate::ui::constants::AirflowStateColor;
@@ -134,16 +134,12 @@ impl DagRunModel {
     }
 
     /// Returns selected DAG run IDs for passing to mark/clear popups
-    fn selected_dag_run_ids(&self) -> Vec<crate::airflow::model::common::DagRunId> {
+    fn selected_dag_run_ids(&self) -> Vec<DagRunId> {
         self.table.selected_ids(|item| item.dag_run_id.clone())
     }
 
     /// Mark a DAG run with a new status (optimistic update)
-    pub fn mark_dag_run(
-        &mut self,
-        dag_run_id: &crate::airflow::model::common::DagRunId,
-        status: &str,
-    ) {
+    pub fn mark_dag_run(&mut self, dag_run_id: &DagRunId, status: &str) {
         if let Some(dag_run) = self
             .table
             .filtered

--- a/src/app/model/dags.rs
+++ b/src/app/model/dags.rs
@@ -9,7 +9,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Row, StatefulWidget, Table, Widget};
 use time::OffsetDateTime;
 
-use crate::airflow::model::common::{Dag, DagStatistic};
+use crate::airflow::model::common::{Dag, DagId, DagStatistic};
 use crate::app::events::custom::FlowrsEvent;
 use crate::app::model::popup::dagruns::trigger::TriggerDagRunPopUp;
 use crate::app::model::popup::dags::commands::DAG_COMMAND_POP_UP;
@@ -28,7 +28,7 @@ pub struct DagModel {
     /// Filterable table containing all DAGs and filtered view
     pub table: FilterableTable<Dag>,
     /// DAG statistics by `dag_id`
-    pub dag_stats: HashMap<crate::airflow::model::common::DagId, Vec<DagStatistic>>,
+    pub dag_stats: HashMap<DagId, Vec<DagStatistic>>,
     /// Unified popup state (error, commands, or custom for this model)
     pub popup: Popup<DagPopUp>,
     ticks: u32,

--- a/src/app/model/dags.rs
+++ b/src/app/model/dags.rs
@@ -28,7 +28,7 @@ pub struct DagModel {
     /// Filterable table containing all DAGs and filtered view
     pub table: FilterableTable<Dag>,
     /// DAG statistics by `dag_id`
-    pub dag_stats: HashMap<String, Vec<DagStatistic>>,
+    pub dag_stats: HashMap<crate::airflow::model::common::DagId, Vec<DagStatistic>>,
     /// Unified popup state (error, commands, or custom for this model)
     pub popup: Popup<DagPopUp>,
     ticks: u32,
@@ -200,7 +200,7 @@ impl Widget for &mut DagModel {
                             Line::from(Span::styled("𖣘", Style::default().fg(DAG_ACTIVE)))
                         },
                         Line::from(Span::styled(
-                            item.dag_id.as_str(),
+                            &*item.dag_id,
                             Style::default().add_modifier(Modifier::BOLD),
                         )),
                         Line::from(item.owners.join(", ")),

--- a/src/app/model/filter/impls.rs
+++ b/src/app/model/filter/impls.rs
@@ -11,7 +11,7 @@ use crate::impl_filterable;
 
 impl_filterable! {
     Dag,
-    primary: dag_id => |s: &Dag| Some(s.dag_id.clone()),
+    primary: dag_id => |s: &Dag| Some(s.dag_id.to_string()),
     fields: [
         is_paused: enum["true", "false"] => |s: &Dag| Some(s.is_paused.to_string()),
         owners => |s: &Dag| Some(s.owners.join(", ")),
@@ -21,7 +21,7 @@ impl_filterable! {
 
 impl_filterable! {
     DagRun,
-    primary: dag_run_id => |s: &DagRun| Some(s.dag_run_id.clone()),
+    primary: dag_run_id => |s: &DagRun| Some(s.dag_run_id.to_string()),
     fields: [
         state: enum["running", "success", "failed", "queued", "up_for_retry"] => |s: &DagRun| Some(s.state.clone()),
         run_type: enum["scheduled", "manual", "backfill", "dataset_triggered"] => |s: &DagRun| Some(s.run_type.clone()),
@@ -30,7 +30,7 @@ impl_filterable! {
 
 impl_filterable! {
     TaskInstance,
-    primary: task_id => |s: &TaskInstance| Some(s.task_id.clone()),
+    primary: task_id => |s: &TaskInstance| Some(s.task_id.to_string()),
     fields: [
         state: enum[
             "running", "success", "failed", "queued",
@@ -92,7 +92,7 @@ mod tests {
     #[test]
     fn test_dag_get_field_value() {
         let dag = Dag {
-            dag_id: "test_dag".to_string(),
+            dag_id: "test_dag".into(),
             is_paused: true,
             owners: vec!["alice".to_string(), "bob".to_string()],
             ..Default::default()

--- a/src/app/model/filterable_table.rs
+++ b/src/app/model/filterable_table.rs
@@ -119,9 +119,9 @@ impl<T: Filterable + Clone> FilterableTable<T> {
 
     /// Returns selected item IDs based on a provided key extractor
     /// In visual mode, returns all selected items; otherwise just the current item
-    pub fn selected_ids<F>(&self, key_fn: F) -> Vec<String>
+    pub fn selected_ids<F, R>(&self, key_fn: F) -> Vec<R>
     where
-        F: Fn(&T) -> String,
+        F: Fn(&T) -> R,
     {
         match self.visual_selection() {
             Some(range) => range

--- a/src/app/model/popup/dagruns/clear.rs
+++ b/src/app/model/popup/dagruns/clear.rs
@@ -17,14 +17,16 @@ use crate::{
     ui::theme::{BORDER_STYLE, DEFAULT_STYLE, SURFACE_STYLE},
 };
 
+use crate::airflow::model::common::{DagId, DagRunId};
+
 pub struct ClearDagRunPopup {
-    pub dag_run_ids: Vec<String>,
-    pub dag_id: String,
+    pub dag_run_ids: Vec<DagRunId>,
+    pub dag_id: DagId,
     pub confirm: bool,
 }
 
 impl ClearDagRunPopup {
-    pub const fn new(dag_run_ids: Vec<String>, dag_id: String) -> Self {
+    pub const fn new(dag_run_ids: Vec<DagRunId>, dag_id: DagId) -> Self {
         Self {
             dag_run_ids,
             dag_id,

--- a/src/app/model/popup/dagruns/mark.rs
+++ b/src/app/model/popup/dagruns/mark.rs
@@ -17,11 +17,13 @@ use crate::{
         SURFACE_STYLE,
     },
 };
+use crate::airflow::model::common::{DagId, DagRunId};
+
 pub struct MarkDagRunPopup {
-    pub dag_id: String,
+    pub dag_id: DagId,
     pub status: MarkState,
     pub confirm: bool,
-    pub marked: Vec<String>,
+    pub marked: Vec<DagRunId>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Display)]
@@ -35,7 +37,7 @@ pub enum MarkState {
 }
 
 impl MarkDagRunPopup {
-    pub const fn new(marked: Vec<String>, dag_id: String) -> Self {
+    pub const fn new(marked: Vec<DagRunId>, dag_id: DagId) -> Self {
         Self {
             dag_id,
             status: MarkState::Success,

--- a/src/app/model/popup/dagruns/mark.rs
+++ b/src/app/model/popup/dagruns/mark.rs
@@ -6,6 +6,7 @@ use ratatui::{
 };
 use strum::Display;
 
+use crate::airflow::model::common::{DagId, DagRunId};
 use crate::{
     app::{
         events::custom::FlowrsEvent,
@@ -17,7 +18,6 @@ use crate::{
         SURFACE_STYLE,
     },
 };
-use crate::airflow::model::common::{DagId, DagRunId};
 
 pub struct MarkDagRunPopup {
     pub dag_id: DagId,

--- a/src/app/model/popup/dagruns/trigger.rs
+++ b/src/app/model/popup/dagruns/trigger.rs
@@ -17,13 +17,15 @@ use crate::{
     ui::theme::{BORDER_STYLE, DEFAULT_STYLE, SURFACE_STYLE},
 };
 
+use crate::airflow::model::common::DagId;
+
 pub struct TriggerDagRunPopUp {
-    pub dag_id: String,
+    pub dag_id: DagId,
     pub confirm: bool,
 }
 
 impl TriggerDagRunPopUp {
-    pub const fn new(dag_id: String) -> Self {
+    pub const fn new(dag_id: DagId) -> Self {
         Self {
             dag_id,
             confirm: false,

--- a/src/app/model/popup/taskinstances/clear.rs
+++ b/src/app/model/popup/taskinstances/clear.rs
@@ -17,18 +17,20 @@ use crate::{
     ui::theme::{BORDER_STYLE, DEFAULT_STYLE, SURFACE_STYLE},
 };
 
+use crate::airflow::model::common::{DagId, DagRunId, TaskId};
+
 pub struct ClearTaskInstancePopup {
-    pub dag_run_id: String,
-    pub dag_id: String,
-    pub task_ids: Vec<String>,
+    pub dag_run_id: DagRunId,
+    pub dag_id: DagId,
+    pub task_ids: Vec<TaskId>,
     pub confirm: bool,
 }
 
 impl ClearTaskInstancePopup {
-    pub fn new(dag_run_id: &str, dag_id: &str, task_ids: Vec<String>) -> Self {
+    pub fn new(dag_run_id: &DagRunId, dag_id: &DagId, task_ids: Vec<TaskId>) -> Self {
         Self {
-            dag_run_id: dag_run_id.to_string(),
-            dag_id: dag_id.to_string(),
+            dag_run_id: dag_run_id.clone(),
+            dag_id: dag_id.clone(),
             task_ids,
             confirm: false,
         }

--- a/src/app/model/popup/taskinstances/mark.rs
+++ b/src/app/model/popup/taskinstances/mark.rs
@@ -17,12 +17,14 @@ use crate::{
         SURFACE_STYLE,
     },
 };
+use crate::airflow::model::common::{DagId, DagRunId, TaskId};
+
 pub struct MarkTaskInstancePopup {
-    pub dag_id: String,
-    pub dag_run_id: String,
+    pub dag_id: DagId,
+    pub dag_run_id: DagRunId,
     pub status: MarkState,
     pub confirm: bool,
-    pub marked: Vec<String>,
+    pub marked: Vec<TaskId>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Display)]
@@ -36,13 +38,13 @@ pub enum MarkState {
 }
 
 impl MarkTaskInstancePopup {
-    pub fn new(marked: Vec<String>, dag_id: &str, dag_run_id: &str) -> Self {
+    pub fn new(marked: Vec<TaskId>, dag_id: &DagId, dag_run_id: &DagRunId) -> Self {
         Self {
-            dag_id: dag_id.to_string(),
+            dag_id: dag_id.clone(),
             status: MarkState::Success,
             confirm: false,
             marked,
-            dag_run_id: dag_run_id.to_string(),
+            dag_run_id: dag_run_id.clone(),
         }
     }
 

--- a/src/app/model/popup/taskinstances/mark.rs
+++ b/src/app/model/popup/taskinstances/mark.rs
@@ -6,6 +6,7 @@ use ratatui::{
 };
 use strum::Display;
 
+use crate::airflow::model::common::{DagId, DagRunId, TaskId};
 use crate::{
     app::{
         events::custom::FlowrsEvent,
@@ -17,7 +18,6 @@ use crate::{
         SURFACE_STYLE,
     },
 };
-use crate::airflow::model::common::{DagId, DagRunId, TaskId};
 
 pub struct MarkTaskInstancePopup {
     pub dag_id: DagId,

--- a/src/app/model/taskinstances.rs
+++ b/src/app/model/taskinstances.rs
@@ -59,7 +59,11 @@ impl TaskInstanceModel {
     }
 
     /// Mark a task instance with a new status (optimistic update)
-    pub fn mark_task_instance(&mut self, task_id: &crate::airflow::model::common::TaskId, status: &str) {
+    pub fn mark_task_instance(
+        &mut self,
+        task_id: &crate::airflow::model::common::TaskId,
+        status: &str,
+    ) {
         if let Some(task_instance) = self
             .table
             .filtered

--- a/src/app/model/taskinstances.rs
+++ b/src/app/model/taskinstances.rs
@@ -59,20 +59,20 @@ impl TaskInstanceModel {
     }
 
     /// Mark a task instance with a new status (optimistic update)
-    pub fn mark_task_instance(&mut self, task_id: &str, status: &str) {
+    pub fn mark_task_instance(&mut self, task_id: &crate::airflow::model::common::TaskId, status: &str) {
         if let Some(task_instance) = self
             .table
             .filtered
             .items
             .iter_mut()
-            .find(|ti| ti.task_id == task_id)
+            .find(|ti| ti.task_id == *task_id)
         {
             task_instance.state = Some(status.to_string());
         }
     }
 
     /// Returns selected task IDs for passing to mark/clear popups
-    fn selected_task_ids(&self) -> Vec<String> {
+    fn selected_task_ids(&self) -> Vec<crate::airflow::model::common::TaskId> {
         self.table.selected_ids(|item| item.task_id.clone())
     }
 }
@@ -233,7 +233,7 @@ impl Widget for &mut TaskInstanceModel {
             .enumerate()
             .map(|(idx, item)| {
                 Row::new(vec![
-                    Line::from(item.task_id.as_str()),
+                    Line::from(item.task_id.as_ref()),
                     Line::from(if let Some(date) = item.logical_date {
                         date.format(
                             &format_description::parse(TIME_FORMAT)

--- a/src/app/model/taskinstances.rs
+++ b/src/app/model/taskinstances.rs
@@ -10,7 +10,7 @@ use ratatui::widgets::{Block, BorderType, Borders, Row, StatefulWidget, Table, W
 use time::format_description;
 
 use crate::airflow::graph::{sort_task_instances, TaskGraph};
-use crate::airflow::model::common::{calculate_duration, format_duration, TaskInstance};
+use crate::airflow::model::common::{calculate_duration, format_duration, TaskId, TaskInstance};
 use crate::app::events::custom::FlowrsEvent;
 use crate::ui::common::{create_headers, state_to_colored_square};
 use crate::ui::constants::AirflowStateColor;
@@ -59,11 +59,7 @@ impl TaskInstanceModel {
     }
 
     /// Mark a task instance with a new status (optimistic update)
-    pub fn mark_task_instance(
-        &mut self,
-        task_id: &crate::airflow::model::common::TaskId,
-        status: &str,
-    ) {
+    pub fn mark_task_instance(&mut self, task_id: &TaskId, status: &str) {
         if let Some(task_instance) = self
             .table
             .filtered
@@ -76,7 +72,7 @@ impl TaskInstanceModel {
     }
 
     /// Returns selected task IDs for passing to mark/clear popups
-    fn selected_task_ids(&self) -> Vec<crate::airflow::model::common::TaskId> {
+    fn selected_task_ids(&self) -> Vec<TaskId> {
         self.table.selected_ids(|item| item.task_id.clone())
     }
 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1,6 +1,7 @@
 use std::sync::LazyLock;
 
 use crate::airflow::config::FlowrsConfig;
+use crate::airflow::model::common::{DagId, DagRunId, TaskId};
 use crate::app::environment_state::EnvironmentStateContainer;
 use crate::app::model::dagruns::DagRunModel;
 use crate::app::model::dags::DagModel;
@@ -22,9 +23,9 @@ static BREADCRUMB_DATE_FORMAT: LazyLock<Vec<BorrowedFormatItem<'static>>> = Lazy
 #[derive(Clone, Default, Debug)]
 pub struct NavigationContext {
     pub environment: Option<String>,
-    pub dag_id: Option<String>,
-    pub dag_run_id: Option<String>,
-    pub task_id: Option<String>,
+    pub dag_id: Option<DagId>,
+    pub dag_run_id: Option<DagRunId>,
+    pub task_id: Option<TaskId>,
     pub task_try: Option<u16>,
 }
 
@@ -266,7 +267,7 @@ impl App {
                     .table
                     .all
                     .iter()
-                    .map(|d| d.dag_id.clone())
+                    .map(|d| d.dag_id.to_string())
                     .collect();
                 self.dags.table.filter.set_primary_values("dag_id", dag_ids);
                 self.dags.table.apply_filter();
@@ -279,7 +280,7 @@ impl App {
                         .table
                         .all
                         .iter()
-                        .map(|dr| dr.dag_run_id.clone())
+                        .map(|dr| dr.dag_run_id.to_string())
                         .collect();
                     self.dagruns
                         .table
@@ -304,7 +305,7 @@ impl App {
                         .table
                         .all
                         .iter()
-                        .map(|ti| ti.task_id.clone())
+                        .map(|ti| ti.task_id.to_string())
                         .collect();
                     self.task_instances
                         .table

--- a/src/app/worker/config.rs
+++ b/src/app/worker/config.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 
+use crate::airflow::model::common::EnvironmentKey;
 use crate::app::environment_state::EnvironmentData;
 use crate::app::state::App;
 
@@ -23,7 +24,7 @@ pub fn handle_config_selected(app: &Arc<Mutex<App>>, idx: usize) -> Result<()> {
         app.loading = false;
         return Ok(());
     };
-    let env_name = selected_config.name.clone();
+    let env_name = EnvironmentKey::from(selected_config.name.clone());
 
     // Check if environment already exists, if not create it
     if !app.environment_state.environments.contains_key(&env_name) {
@@ -48,8 +49,8 @@ pub fn handle_config_selected(app: &Arc<Mutex<App>>, idx: usize) -> Result<()> {
     // Set this as the active environment
     app.environment_state
         .set_active_environment(env_name.clone());
-    app.config.active_server = Some(env_name.clone());
-    app.nav_context.environment = Some(env_name);
+    app.config.active_server = Some(env_name.to_string());
+    app.nav_context.environment = Some(env_name.to_string());
 
     // Clear the view state but NOT the environment data
     app.clear_state();

--- a/src/app/worker/dagruns.rs
+++ b/src/app/worker/dagruns.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use log::debug;
 
+use crate::airflow::model::common::{DagId, DagRunId};
 use crate::airflow::traits::AirflowClient;
 use crate::app::model::popup::dagruns::mark::MarkState;
 use crate::app::state::App;
@@ -13,7 +14,7 @@ use crate::app::state::App;
 pub async fn handle_update_dag_runs(
     app: &Arc<Mutex<App>>,
     client: &Arc<dyn AirflowClient>,
-    dag_id: &str,
+    dag_id: &DagId,
     env_name: &str,
 ) {
     let dag_runs = client.list_dagruns(dag_id).await;
@@ -39,8 +40,8 @@ pub async fn handle_update_dag_runs(
 pub async fn handle_clear_dag_run(
     app: &Arc<Mutex<App>>,
     client: &Arc<dyn AirflowClient>,
-    dag_id: &str,
-    dag_run_id: &str,
+    dag_id: &DagId,
+    dag_run_id: &DagRunId,
 ) {
     debug!("Clearing dag_run: {dag_run_id}");
     let dag_run = client.clear_dagrun(dag_id, dag_run_id).await;
@@ -55,8 +56,8 @@ pub async fn handle_clear_dag_run(
 pub async fn handle_mark_dag_run(
     app: &Arc<Mutex<App>>,
     client: &Arc<dyn AirflowClient>,
-    dag_id: &str,
-    dag_run_id: &str,
+    dag_id: &DagId,
+    dag_run_id: &DagRunId,
     status: MarkState,
 ) {
     debug!("Marking dag_run: {dag_run_id}");
@@ -79,7 +80,7 @@ pub async fn handle_mark_dag_run(
 pub async fn handle_trigger_dag_run(
     app: &Arc<Mutex<App>>,
     client: &Arc<dyn AirflowClient>,
-    dag_id: &str,
+    dag_id: &DagId,
     env_name: &str,
 ) {
     debug!("Triggering dag_run: {dag_id}");

--- a/src/app/worker/dags.rs
+++ b/src/app/worker/dags.rs
@@ -55,7 +55,10 @@ pub async fn handle_update_dags_and_stats(
                     let mut app = app.lock().unwrap();
                     if let Some(env) = app.environment_state.environments.get_mut(env_name) {
                         for dag_stats in dag_stats.dags {
-                            env.update_dag_stats(&DagId::from(dag_stats.dag_id.clone()), dag_stats.stats);
+                            env.update_dag_stats(
+                                &DagId::from(dag_stats.dag_id.clone()),
+                                dag_stats.stats,
+                            );
                         }
                     }
                 }
@@ -88,7 +91,10 @@ pub async fn handle_update_dags_and_stats(
             Ok(dag_stats) => {
                 if let Some(env) = app.environment_state.environments.get_mut(env_name) {
                     for dag_stats in dag_stats.dags {
-                        env.update_dag_stats(&DagId::from(dag_stats.dag_id.clone()), dag_stats.stats);
+                        env.update_dag_stats(
+                            &DagId::from(dag_stats.dag_id.clone()),
+                            dag_stats.stats,
+                        );
                     }
                 }
             }
@@ -110,7 +116,7 @@ pub async fn handle_update_dags_and_stats(
 pub async fn handle_toggle_dag(
     app: &Arc<Mutex<App>>,
     client: &Arc<dyn AirflowClient>,
-    dag_id: &str,
+    dag_id: &DagId,
     is_paused: bool,
 ) {
     let dag = client.toggle_dag(dag_id, is_paused).await;
@@ -124,14 +130,14 @@ pub async fn handle_toggle_dag(
 pub async fn handle_get_dag_code(
     app: &Arc<Mutex<App>>,
     client: &Arc<dyn AirflowClient>,
-    dag_id: &str,
+    dag_id: &DagId,
 ) {
     let current_dag = {
         let app_lock = app.lock().unwrap();
         app_lock
             .environment_state
             .get_active_environment()
-            .and_then(|env| env.dags.iter().find(|d| *d.dag_id == *dag_id).cloned())
+            .and_then(|env| env.dags.iter().find(|d| d.dag_id == *dag_id).cloned())
     };
 
     if let Some(current_dag) = current_dag {

--- a/src/app/worker/dags.rs
+++ b/src/app/worker/dags.rs
@@ -1,5 +1,6 @@
 use std::sync::{Arc, Mutex};
 
+use crate::airflow::model::common::DagId;
 use crate::airflow::traits::AirflowClient;
 use crate::app::state::App;
 
@@ -16,7 +17,7 @@ pub async fn handle_update_dags_and_stats(
     env_name: &str,
 ) {
     // Snapshot cached DAG IDs from the originating environment for the stats request
-    let cached_dag_ids: Vec<String> = {
+    let cached_dag_ids: Vec<DagId> = {
         let app_lock = app.lock().unwrap();
         app_lock
             .environment_state
@@ -30,11 +31,11 @@ pub async fn handle_update_dags_and_stats(
         // Cold start: fetch DAGs first, then stats with fresh IDs
         let dag_list_result = client.list_dags().await;
 
-        let dag_ids: Vec<String> = {
+        let dag_ids: Vec<DagId> = {
             let mut app = app.lock().unwrap();
             match dag_list_result {
                 Ok(dag_list) => {
-                    let ids: Vec<String> = dag_list.dags.iter().map(|d| d.dag_id.clone()).collect();
+                    let ids: Vec<DagId> = dag_list.dags.iter().map(|d| d.dag_id.clone()).collect();
                     if let Some(env) = app.environment_state.environments.get_mut(env_name) {
                         env.replace_dags(dag_list.dags);
                     }
@@ -48,13 +49,13 @@ pub async fn handle_update_dags_and_stats(
         };
 
         if !dag_ids.is_empty() {
-            let refs: Vec<&str> = dag_ids.iter().map(String::as_str).collect();
+            let refs: Vec<&str> = dag_ids.iter().map(AsRef::as_ref).collect();
             match client.get_dag_stats(refs).await {
                 Ok(dag_stats) => {
                     let mut app = app.lock().unwrap();
                     if let Some(env) = app.environment_state.environments.get_mut(env_name) {
                         for dag_stats in dag_stats.dags {
-                            env.update_dag_stats(&dag_stats.dag_id, dag_stats.stats);
+                            env.update_dag_stats(&DagId::from(dag_stats.dag_id.clone()), dag_stats.stats);
                         }
                     }
                 }
@@ -66,7 +67,7 @@ pub async fn handle_update_dags_and_stats(
     } else {
         // Warm cache: fetch DAG list and stats concurrently using cached IDs
         let (dag_list_result, dag_stats_result) = tokio::join!(client.list_dags(), async {
-            let refs: Vec<&str> = cached_dag_ids.iter().map(String::as_str).collect();
+            let refs: Vec<&str> = cached_dag_ids.iter().map(AsRef::as_ref).collect();
             client.get_dag_stats(refs).await
         });
 
@@ -87,7 +88,7 @@ pub async fn handle_update_dags_and_stats(
             Ok(dag_stats) => {
                 if let Some(env) = app.environment_state.environments.get_mut(env_name) {
                     for dag_stats in dag_stats.dags {
-                        env.update_dag_stats(&dag_stats.dag_id, dag_stats.stats);
+                        env.update_dag_stats(&DagId::from(dag_stats.dag_id.clone()), dag_stats.stats);
                     }
                 }
             }
@@ -130,7 +131,7 @@ pub async fn handle_get_dag_code(
         app_lock
             .environment_state
             .get_active_environment()
-            .and_then(|env| env.dags.iter().find(|d| d.dag_id == dag_id).cloned())
+            .and_then(|env| env.dags.iter().find(|d| *d.dag_id == *dag_id).cloned())
     };
 
     if let Some(current_dag) = current_dag {

--- a/src/app/worker/logs.rs
+++ b/src/app/worker/logs.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 use futures::future::join_all;
 use log::debug;
 
+use crate::airflow::model::common::{DagId, DagRunId, TaskId};
 use crate::airflow::traits::AirflowClient;
 use crate::app::model::popup::error::ErrorPopup;
 use crate::app::state::App;
@@ -14,9 +15,9 @@ use crate::app::state::App;
 pub async fn handle_update_task_logs(
     app: &Arc<Mutex<App>>,
     client: &Arc<dyn AirflowClient>,
-    dag_id: &str,
-    dag_run_id: &str,
-    task_id: &str,
+    dag_id: &DagId,
+    dag_run_id: &DagRunId,
+    task_id: &TaskId,
     task_try: u16,
     env_name: &str,
 ) {

--- a/src/app/worker/logs.rs
+++ b/src/app/worker/logs.rs
@@ -44,7 +44,7 @@ pub async fn handle_update_task_logs(
     // Store logs in the originating environment, not the active one
     if !collected_logs.is_empty() {
         if let Some(env) = app.environment_state.environments.get_mut(env_name) {
-            env.add_task_logs(dag_id, dag_run_id, task_id, collected_logs);
+            env.replace_task_logs(dag_id, dag_run_id, task_id, collected_logs);
         }
     }
 

--- a/src/app/worker/mod.rs
+++ b/src/app/worker/mod.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex};
 use super::model::popup::dagruns::mark::MarkState;
 use super::model::popup::taskinstances::mark::MarkState as TaskMarkState;
 use super::state::App;
+use crate::airflow::model::common::{DagId, DagRunId, TaskId};
 use anyhow::Result;
 use tokio::sync::mpsc::Receiver;
 use tokio::task::JoinSet;
@@ -25,50 +26,50 @@ pub enum WorkerMessage {
     ConfigSelected(usize),
     UpdateDagsAndStats,
     ToggleDag {
-        dag_id: String,
+        dag_id: DagId,
         is_paused: bool,
     },
     UpdateDagRuns {
-        dag_id: String,
+        dag_id: DagId,
     },
     UpdateTaskInstances {
-        dag_id: String,
-        dag_run_id: String,
+        dag_id: DagId,
+        dag_run_id: DagRunId,
     },
     GetDagCode {
-        dag_id: String,
+        dag_id: DagId,
     },
     ClearDagRun {
-        dag_run_id: String,
-        dag_id: String,
+        dag_run_id: DagRunId,
+        dag_id: DagId,
     },
     UpdateTaskLogs {
-        dag_id: String,
-        dag_run_id: String,
-        task_id: String,
+        dag_id: DagId,
+        dag_run_id: DagRunId,
+        task_id: TaskId,
         task_try: u16,
     },
     MarkDagRun {
-        dag_run_id: String,
-        dag_id: String,
+        dag_run_id: DagRunId,
+        dag_id: DagId,
         status: MarkState,
     },
     ClearTaskInstance {
-        task_id: String,
-        dag_id: String,
-        dag_run_id: String,
+        task_id: TaskId,
+        dag_id: DagId,
+        dag_run_id: DagRunId,
     },
     MarkTaskInstance {
-        task_id: String,
-        dag_id: String,
-        dag_run_id: String,
+        task_id: TaskId,
+        dag_id: DagId,
+        dag_run_id: DagRunId,
         status: TaskMarkState,
     },
     TriggerDagRun {
-        dag_id: String,
+        dag_id: DagId,
     },
     UpdateTasks {
-        dag_id: String,
+        dag_id: DagId,
     },
     OpenItem(OpenItem),
 }
@@ -77,21 +78,21 @@ pub enum WorkerMessage {
 pub enum OpenItem {
     Config(String),
     Dag {
-        dag_id: String,
+        dag_id: DagId,
     },
     DagRun {
-        dag_id: String,
-        dag_run_id: String,
+        dag_id: DagId,
+        dag_run_id: DagRunId,
     },
     TaskInstance {
-        dag_id: String,
-        dag_run_id: String,
-        task_id: String,
+        dag_id: DagId,
+        dag_run_id: DagRunId,
+        task_id: TaskId,
     },
     Log {
-        dag_id: String,
-        dag_run_id: String,
-        task_id: String,
+        dag_id: DagId,
+        dag_run_id: DagRunId,
+        task_id: TaskId,
         #[allow(dead_code)]
         task_try: u16,
     },

--- a/src/app/worker/taskinstances.rs
+++ b/src/app/worker/taskinstances.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use log::debug;
 
+use crate::airflow::model::common::{DagId, DagRunId, TaskId};
 use crate::airflow::traits::AirflowClient;
 use crate::app::model::popup::taskinstances::mark::MarkState;
 use crate::app::state::App;
@@ -13,8 +14,8 @@ use crate::app::state::App;
 pub async fn handle_update_task_instances(
     app: &Arc<Mutex<App>>,
     client: &Arc<dyn AirflowClient>,
-    dag_id: &str,
-    dag_run_id: &str,
+    dag_id: &DagId,
+    dag_run_id: &DagRunId,
     env_name: &str,
 ) {
     let task_instances = client.list_task_instances(dag_id, dag_run_id).await;
@@ -41,9 +42,9 @@ pub async fn handle_update_task_instances(
 pub async fn handle_clear_task_instance(
     app: &Arc<Mutex<App>>,
     client: &Arc<dyn AirflowClient>,
-    dag_id: &str,
-    dag_run_id: &str,
-    task_id: &str,
+    dag_id: &DagId,
+    dag_run_id: &DagRunId,
+    task_id: &TaskId,
 ) {
     debug!("Clearing task_instance: {task_id}");
     let task_instance = client
@@ -60,9 +61,9 @@ pub async fn handle_clear_task_instance(
 pub async fn handle_mark_task_instance(
     app: &Arc<Mutex<App>>,
     client: &Arc<dyn AirflowClient>,
-    dag_id: &str,
-    dag_run_id: &str,
-    task_id: &str,
+    dag_id: &DagId,
+    dag_run_id: &DagRunId,
+    task_id: &TaskId,
     status: MarkState,
 ) {
     debug!("Marking task_instance: {task_id}");

--- a/tests/v2_api_test.rs
+++ b/tests/v2_api_test.rs
@@ -57,7 +57,7 @@ async fn test_v2_get_dag_code() {
             .get_dag_code(dag)
             .await
             .expect("Failed to get DAG code");
-        assert!(code.contains(&dag.dag_id), "DAG code should contain DAG ID");
+        assert!(code.contains(&*dag.dag_id), "DAG code should contain DAG ID");
     }
 }
 
@@ -99,7 +99,7 @@ async fn test_v2_dag_stats() {
             .dags
             .iter()
             .take(2)
-            .map(|d| d.dag_id.as_str())
+            .map(|d| d.dag_id.as_ref())
             .collect();
         let result = client.get_dag_stats(dag_ids.clone()).await;
         assert!(

--- a/tests/v2_api_test.rs
+++ b/tests/v2_api_test.rs
@@ -57,7 +57,10 @@ async fn test_v2_get_dag_code() {
             .get_dag_code(dag)
             .await
             .expect("Failed to get DAG code");
-        assert!(code.contains(&*dag.dag_id), "DAG code should contain DAG ID");
+        assert!(
+            code.contains(&*dag.dag_id),
+            "DAG code should contain DAG ID"
+        );
     }
 }
 


### PR DESCRIPTION
Introduce strongly-typed DagId, DagRunId, TaskId, and EnvironmentKey
newtypes that catch identifier mix-ups at compile time instead of
runtime. The macro-generated types provide Deref<Target=str> for
transparent API-layer usage, serde(transparent) for JSON compat, and
Borrow<str> for ergonomic HashMap lookups.

Flatten EnvironmentData's nested HashMaps (task_instances was
HashMap<DagId, HashMap<DagRunId, Vec<...>>>, task_logs was 3 levels
deep) into single-lookup composite tuple keys, eliminating chained
.get() calls and intermediate HashMap allocations.

https://claude.ai/code/session_01GkpZCZcNTSJ6f4KDh78cip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced generic string IDs with strongly-typed identifiers for DAGs, DAG runs, tasks, and environments across the app.
  * Internal storage now uses composite keys for task instances and logs, improving lookup consistency.
  * UI rendering and actions updated to use the new ID types (display and selection behavior preserved).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->