### PR TITLE
Remove unused confirm field from mark popups

### DIFF
--- a/src/app/model/popup/dagruns/mark.rs
+++ b/src/app/model/popup/dagruns/mark.rs
@@ -22,7 +22,6 @@ use crate::{
 pub struct MarkDagRunPopup {
     pub dag_id: DagId,
     pub status: MarkState,
-    pub confirm: bool,
     pub marked: Vec<DagRunId>,
 }
 
@@ -41,7 +40,6 @@ impl MarkDagRunPopup {
         Self {
             dag_id,
             status: MarkState::Success,
-            confirm: false,
             marked,
         }
     }

--- a/src/app/model/popup/taskinstances/mark.rs
+++ b/src/app/model/popup/taskinstances/mark.rs
@@ -23,7 +23,6 @@ pub struct MarkTaskInstancePopup {
     pub dag_id: DagId,
     pub dag_run_id: DagRunId,
     pub status: MarkState,
-    pub confirm: bool,
     pub marked: Vec<TaskId>,
 }
 
@@ -42,7 +41,6 @@ impl MarkTaskInstancePopup {
         Self {
             dag_id: dag_id.clone(),
             status: MarkState::Success,
-            confirm: false,
             marked,
             dag_run_id: dag_run_id.clone(),
         }


### PR DESCRIPTION
## Summary
Removed the unused `confirm` boolean field from both `MarkDagRunPopup` and `MarkTaskInstancePopup` structs, along with their initialization in the constructors.

## Changes
- **MarkDagRunPopup**: Removed `confirm: bool` field and its `false` initialization
- **MarkTaskInstancePopup**: Removed `confirm: bool` field and its `false` initialization

## Details
The `confirm` field was not being utilized in either popup struct and has been removed to simplify the data model and reduce unnecessary state management.

https://claude.ai/code/session_01KX3VAMxR6y7Gy8TLdzBnxY