### PR TITLE
Refactor visual mode state to use Option instead of bool flag

### DIFF
--- a/src/app/model/dagruns.rs
+++ b/src/app/model/dagruns.rs
@@ -204,7 +204,6 @@ impl DagRunModel {
                     matches!(custom_popup, DagRunPopUp::Clear(_) | DagRunPopUp::Mark(_));
                 self.popup.close();
                 if exit_visual {
-                    self.table.visual_mode = false;
                     self.table.visual_anchor = None;
                 }
             }

--- a/src/app/model/taskinstances.rs
+++ b/src/app/model/taskinstances.rs
@@ -97,7 +97,6 @@ impl TaskInstanceModel {
                 KeyCode::Enter | KeyCode::Esc | KeyCode::Char('q')
             ) {
                 self.popup.close();
-                self.table.visual_mode = false;
                 self.table.visual_anchor = None;
             }
         }


### PR DESCRIPTION
## Summary
Refactored the visual mode state management in `FilterableTable` to use a single `Option<usize>` field (`visual_anchor`) instead of a separate boolean flag (`visual_mode`). This eliminates redundant state and simplifies the logic by using the presence of an anchor value to determine if visual mode is active.

## Key Changes
- **Removed `visual_mode` boolean field** from `FilterableTable` struct and replaced all state checks with `visual_anchor.is_some()`
- **Simplified visual mode activation** in `handle_visual_mode_key()` - now only sets `visual_anchor` without explicitly setting a separate flag
- **Simplified visual mode deactivation** - clearing `visual_anchor` is now the single source of truth for exiting visual mode
- **Updated `visual_selection()` method** to rely on `visual_anchor` presence instead of checking `visual_mode` flag
- **Updated `status_title()` method** to check `visual_anchor.is_some()` instead of `visual_mode`
- **Cleaned up related code** in `dagruns.rs` and `taskinstances.rs` that were setting both `visual_mode` and `visual_anchor`
- **Updated all tests** to assert on `visual_anchor.is_some()` / `visual_anchor.is_none()` instead of the removed `visual_mode` field

## Implementation Details
This refactoring reduces cognitive overhead by eliminating the need to keep two related state variables in sync. The `visual_anchor` field now serves dual purpose: it both stores the selection anchor point AND indicates whether visual mode is active. This is a common pattern in state management where the presence of a value carries semantic meaning.

https://claude.ai/code/session_01N7y2HVXo4FFHpVaJoRcY4Y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved visual selection state management in table components throughout the application. Enhanced tracking of visual selection mode during table navigation and popup interactions. Refined internal state handling when opening and closing dialogs in task run and task instance views to ensure consistent and reliable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->