### PR TITLE
Refactor config fields from Option<Vec<T>> to Vec<T>

### DIFF
--- a/src/airflow/config/mod.rs
+++ b/src/airflow/config/mod.rs
@@ -53,8 +53,10 @@ impl Display for ManagedService {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct FlowrsConfig {
-    pub servers: Option<Vec<AirflowConfig>>,
-    pub managed_services: Option<Vec<ManagedService>>,
+    #[serde(default)]
+    pub servers: Vec<AirflowConfig>,
+    #[serde(default)]
+    pub managed_services: Vec<ManagedService>,
     pub active_server: Option<String>,
     #[serde(skip_serializing)]
     pub path: Option<PathBuf>,
@@ -114,8 +116,8 @@ impl FlowrsConfig {
     /// - Default config file path
     pub fn new() -> Self {
         Self {
-            servers: None,
-            managed_services: None,
+            servers: Vec::new(),
+            managed_services: Vec::new(),
             active_server: None,
             path: Some(CONFIG_PATHS.write_path.clone()),
         }
@@ -141,12 +143,11 @@ impl FlowrsConfig {
 
     pub fn parse_toml(config: &str) -> Result<Self> {
         let config: Self = toml::from_str(config)?;
-        let num_serves = config.servers.as_ref().map_or(0, std::vec::Vec::len);
-        let num_managed = config
-            .managed_services
-            .as_ref()
-            .map_or(0, std::vec::Vec::len);
-        info!("Loaded config: servers={num_serves}, managed_services={num_managed}");
+        info!(
+            "Loaded config: servers={}, managed_services={}",
+            config.servers.len(),
+            config.managed_services.len()
+        );
         Ok(config)
     }
 
@@ -154,10 +155,7 @@ impl FlowrsConfig {
     where
         I: IntoIterator<Item = AirflowConfig>,
     {
-        match &mut self.servers {
-            Some(existing) => existing.extend(new_servers),
-            None => self.servers = Some(new_servers.into_iter().collect()),
-        }
+        self.servers.extend(new_servers);
     }
 
     /// Expands the config by resolving managed services and adding their servers.
@@ -167,11 +165,11 @@ impl FlowrsConfig {
     pub async fn expand_managed_services(mut self) -> Result<(Self, Vec<String>)> {
         let mut all_errors = Vec::new();
 
-        if self.managed_services.is_none() {
+        if self.managed_services.is_empty() {
             return Ok((self, all_errors));
         }
 
-        let services = self.managed_services.clone().unwrap();
+        let services = self.managed_services.clone();
         for service in services {
             match service {
                 ManagedService::Conveyor => {
@@ -192,9 +190,9 @@ impl FlowrsConfig {
                 }
             }
         }
-        let total = self.servers.as_ref().map_or(0, std::vec::Vec::len);
         info!(
-            "Expanded config: servers={total}, errors={}",
+            "Expanded config: servers={}, errors={}",
+            self.servers.len(),
             all_errors.len()
         );
         Ok((self, all_errors))
@@ -223,13 +221,7 @@ impl FlowrsConfig {
             .open(path)?;
 
         // Only write non-managed servers to the config file
-        if let Some(servers) = &mut self.servers {
-            *servers = servers
-                .iter()
-                .filter(|server| server.managed.is_none())
-                .cloned()
-                .collect();
-        }
+        self.servers.retain(|server| server.managed.is_none());
         file.write_all(Self::to_str(self)?.as_bytes())?;
         Ok(())
     }
@@ -251,9 +243,8 @@ mod tests {
     #[test]
     fn test_get_config() {
         let result = FlowrsConfig::parse_toml(TEST_CONFIG).unwrap();
-        let servers = result.servers.unwrap();
-        assert_eq!(servers.len(), 1);
-        assert_eq!(servers[0].name, "test");
+        assert_eq!(result.servers.len(), 1);
+        assert_eq!(result.servers[0].name, "test");
     }
 
     const TEST_CONFIG_CONVEYOR: &str = r#"
@@ -272,15 +263,14 @@ password = "airflow"
     #[test]
     fn test_get_config_conveyor() {
         let result = FlowrsConfig::parse_toml(TEST_CONFIG_CONVEYOR.trim()).unwrap();
-        let services = result.managed_services.unwrap();
-        assert_eq!(services.len(), 1);
-        assert_eq!(services[0], ManagedService::Conveyor);
+        assert_eq!(result.managed_services.len(), 1);
+        assert_eq!(result.managed_services[0], ManagedService::Conveyor);
     }
 
     #[test]
     fn test_write_config_conveyor() {
         let config = FlowrsConfig {
-            servers: Some(vec![AirflowConfig {
+            servers: vec![AirflowConfig {
                 name: "bla".to_string(),
                 endpoint: "http://localhost:8080".to_string(),
                 auth: AirflowAuth::Basic(BasicAuth {
@@ -290,8 +280,8 @@ password = "airflow"
                 managed: None,
                 version: AirflowVersion::V2,
                 timeout_secs: default_timeout(),
-            }]),
-            managed_services: Some(vec![ManagedService::Conveyor]),
+            }],
+            managed_services: vec![ManagedService::Conveyor],
             active_server: None,
             path: None,
         };

--- a/src/app.rs
+++ b/src/app.rs
@@ -39,19 +39,17 @@ where
         let active_server_name = app.config.active_server.clone();
 
         // Initialize all environments with their clients
-        if let Some(servers) = servers {
-            for server_config in servers {
-                if let Ok(client) = create_client(&server_config) {
-                    let env_data = environment_state::EnvironmentData::new(client);
-                    app.environment_state
-                        .environments
-                        .insert(EnvironmentKey::from(server_config.name.clone()), env_data);
-                } else {
-                    log::error!(
-                        "Failed to create client for server '{}'; skipping",
-                        server_config.name
-                    );
-                }
+        for server_config in servers {
+            if let Ok(client) = create_client(&server_config) {
+                let env_data = environment_state::EnvironmentData::new(client);
+                app.environment_state
+                    .environments
+                    .insert(EnvironmentKey::from(server_config.name.clone()), env_data);
+            } else {
+                log::error!(
+                    "Failed to create client for server '{}'; skipping",
+                    server_config.name
+                );
             }
         }
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -69,7 +69,7 @@ impl App {
         errors: Vec<String>,
         warnings: Vec<String>,
     ) -> Self {
-        let servers = config.servers.clone().unwrap_or_default();
+        let servers = config.servers.clone();
         let has_active_server = config
             .active_server
             .as_ref()

--- a/src/app/worker/browser.rs
+++ b/src/app/worker/browser.rs
@@ -22,13 +22,9 @@ pub fn handle_open_item(
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("No active server configured"))?;
 
-        let servers = app_lock
+        let server = app_lock
             .config
             .servers
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("No servers configured"))?;
-
-        let server = servers
             .iter()
             .find(|s| &s.name == active_server_name)
             .ok_or_else(|| {

--- a/src/commands/config/add.rs
+++ b/src/commands/config/add.rs
@@ -86,13 +86,10 @@ impl AddCommand {
             config.path = Some(user_path);
         }
 
-        if let Some(mut servers) = config.servers.clone() {
-            servers.retain(|server| server.name != new_config.name && server.managed.is_none());
-            servers.push(new_config);
-            config.servers = Some(servers);
-        } else {
-            config.servers = Some(vec![new_config]);
-        }
+        config
+            .servers
+            .retain(|server| server.name != new_config.name && server.managed.is_none());
+        config.servers.push(new_config);
 
         config.write_to_file()?;
 

--- a/src/commands/config/list.rs
+++ b/src/commands/config/list.rs
@@ -8,7 +8,7 @@ impl ListCommand {
     pub fn run(&self) -> Result<()> {
         let path = self.file.as_ref().map(PathBuf::from);
         let config = FlowrsConfig::from_file(path.as_ref())?;
-        let servers = config.servers.unwrap_or_default();
+        let servers = config.servers;
 
         if servers.is_empty() {
             println!("❌ No servers found in the config file!");

--- a/src/commands/config/managed_services.rs
+++ b/src/commands/config/managed_services.rs
@@ -18,18 +18,11 @@ impl ManagedServiceCommand {
         let path = self.file.as_ref().map(PathBuf::from);
         let mut config = FlowrsConfig::from_file(path.as_ref())?;
 
-        match config.managed_services {
-            Some(ref mut services) => {
-                if services.contains(&managed_service) {
-                    println!("Managed service already enabled!");
-                    return Ok(());
-                }
-                services.push(managed_service);
-            }
-            None => {
-                config.managed_services = Some(vec![managed_service]);
-            }
+        if config.managed_services.contains(&managed_service) {
+            println!("Managed service already enabled!");
+            return Ok(());
         }
+        config.managed_services.push(managed_service);
 
         config.write_to_file()?;
 
@@ -46,13 +39,13 @@ impl ManagedServiceCommand {
         let path = self.file.as_ref().map(PathBuf::from);
         let mut config = FlowrsConfig::from_file(path.as_ref())?;
 
-        if let Some(ref mut services) = config.managed_services {
-            if !services.contains(&managed_service) {
-                println!("Managed service already disabled!");
-                return Ok(());
-            }
-            services.retain(|service| service != &managed_service);
+        if !config.managed_services.contains(&managed_service) {
+            println!("Managed service already disabled!");
+            return Ok(());
         }
+        config
+            .managed_services
+            .retain(|service| service != &managed_service);
 
         config.write_to_file()?;
 

--- a/src/commands/config/remove.rs
+++ b/src/commands/config/remove.rs
@@ -11,21 +11,24 @@ impl RemoveCommand {
         let path = self.file.as_ref().map(PathBuf::from);
         let mut config = FlowrsConfig::from_file(path.as_ref())?;
 
-        if let Some(mut servers) = config.servers.clone() {
-            let name = match self.name {
-                None => Select::new(
-                    "name",
-                    servers.iter().map(|server| server.name.clone()).collect(),
-                )
-                .prompt()?,
-                Some(ref name) => name.clone(),
-            };
-            servers.retain(|server| server.name != name && server.managed.is_none());
-            config.servers = Some(servers);
-            config.write_to_file()?;
+        let name = match self.name {
+            None => Select::new(
+                "name",
+                config
+                    .servers
+                    .iter()
+                    .map(|server| server.name.clone())
+                    .collect(),
+            )
+            .prompt()?,
+            Some(ref name) => name.clone(),
+        };
+        config
+            .servers
+            .retain(|server| server.name != name && server.managed.is_none());
+        config.write_to_file()?;
 
-            println!("✅ Config '{name}' removed successfully!");
-        }
+        println!("✅ Config '{name}' removed successfully!");
         Ok(())
     }
 }

--- a/src/commands/config/update.rs
+++ b/src/commands/config/update.rs
@@ -17,12 +17,12 @@ impl UpdateCommand {
         let path = self.file.as_ref().map(PathBuf::from);
         let mut config = FlowrsConfig::from_file(path.as_ref())?;
 
-        if config.servers.is_none() {
+        if config.servers.is_empty() {
             println!("❌ No servers found in config file");
             return Ok(());
         }
 
-        let mut servers = config.servers.unwrap();
+        let mut servers = config.servers;
 
         let name: String = if self.name.is_none() {
             Select::new(
@@ -80,7 +80,7 @@ impl UpdateCommand {
             }
         }
 
-        config.servers = Some(servers);
+        config.servers = servers;
         config.write_to_file()?;
 
         println!("✅ Config updated successfully!");


### PR DESCRIPTION
## Summary
This PR refactors the `FlowrsConfig` struct to use `Vec<T>` instead of `Option<Vec<T>>` for the `servers` and `managed_services` fields. This simplifies the codebase by eliminating unnecessary `Option` wrapping and reduces boilerplate code throughout the application.

## Key Changes

- **Config struct refactoring**: Changed `servers` and `managed_services` from `Option<Vec<T>>` to `Vec<T>` with `#[serde(default)]` attributes to maintain backward compatibility with existing config files
- **Simplified initialization**: Updated `FlowrsConfig::new()` to initialize fields with empty vectors instead of `None`
- **Removed Option handling**: Eliminated numerous `match`, `if let`, and `unwrap_or_default()` patterns throughout the codebase
- **Cleaner logging**: Simplified log statements by directly calling `.len()` on vectors instead of using `map_or()`
- **Streamlined operations**: 
  - `extend_servers()` now directly extends the vector without Option matching
  - `expand_managed_services()` uses `is_empty()` instead of `is_none()`
  - `write_to_file()` uses `retain()` directly instead of conditional matching
- **Updated all command handlers**: Simplified code in `add.rs`, `remove.rs`, `managed_services.rs`, `update.rs`, and `list.rs` by removing Option unwrapping
- **Simplified app initialization**: Removed Option handling in `app.rs` and `browser.rs` when accessing server configurations
- **Updated tests**: Simplified test code to work with direct vector access instead of unwrapping Options

## Implementation Details

The `#[serde(default)]` attribute ensures that if the TOML config file doesn't contain these fields, they will deserialize to empty vectors rather than causing errors. This maintains backward compatibility while allowing the internal API to be simpler and more ergonomic.

https://claude.ai/code/session_015vdh25qBYWStnVAxUtTaYe