### PR TITLE
Remove startup state tracking and simplify initialization logic

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyModifiers};
 use events::{custom::FlowrsEvent, generator::EventGenerator};
 use log::debug;
 use model::Model;
@@ -136,20 +136,6 @@ where
             }
             if fall_through_event.is_none() {
                 continue;
-            }
-
-            // We do this so that when a user switches config,
-            // it does not show the previous DAGs (because the Enter event falls through before the existing DAGs are cleared).
-            // Not very mindful, not very demure.
-            if let Some(FlowrsEvent::Key(KeyEvent {
-                code: KeyCode::Enter,
-                ..
-            })) = fall_through_event
-            {
-                let mut app = app.lock().unwrap();
-                if app.active_panel == Panel::Config {
-                    app.ticks = 0;
-                }
             }
 
             // then handle generic events

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -41,7 +41,6 @@ pub struct App {
     pub ticks: u32,
     pub active_panel: Panel,
     pub loading: bool,
-    pub startup: bool,
     pub throbber_state: ThrobberState,
     /// Global warning popup shown on startup (e.g., legacy config conflict)
     pub warning_popup: Option<WarningPopup>,
@@ -102,7 +101,6 @@ impl App {
             },
             ticks: 0,
             loading: true,
-            startup: true,
             throbber_state: ThrobberState::default(),
             warning_popup,
             focused: true,
@@ -130,7 +128,6 @@ impl App {
     }
 
     pub fn clear_state(&mut self) {
-        self.ticks = 0;
         self.loading = true;
         // Clear navigation context below the environment level
         self.nav_context.dag_id = None;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -20,11 +20,10 @@ pub const TIME_FORMAT: &str = "[year]-[month]-[day] [hour]:[minute]:[second]";
 
 pub fn draw_ui(f: &mut Frame, app: &Arc<Mutex<App>>) {
     let mut app = app.lock().unwrap();
-    if app.startup && app.ticks <= 10 {
+    if app.ticks <= 10 {
         render_init_screen(f, app.ticks);
         return;
     }
-    app.startup = false;
 
     // Split area vertically: header (1 line), tab bar (3 lines), panel (remaining)
     let [top_line, tab_area, panel_area] = Layout::vertical([


### PR DESCRIPTION
## Summary
This PR removes the `startup` flag from the application state and simplifies the initialization screen rendering logic. The startup state was being used to display an initialization screen for the first 10 ticks, but this can be achieved more simply by checking the tick count directly.

## Key Changes
- Removed the `startup` boolean field from the `App` struct in `src/app/state.rs`
- Removed initialization of `startup: true` in `App::new()`
- Removed the `startup` flag check from the initialization screen rendering condition in `src/ui.rs`
- Removed the `app.startup = false` assignment that was clearing the flag after initialization
- Removed unused `KeyEvent` import from `src/app.rs`
- Removed a workaround in the event handling loop that was resetting ticks when switching configs on the Config panel (the `fall_through_event` Enter key handling)
- Removed `self.ticks = 0` from the `clear_state()` method

## Implementation Details
The initialization screen now renders based solely on `app.ticks <= 10`, eliminating the need for a separate state variable. This simplifies the state management while maintaining the same visual behavior during startup. The removal of the tick reset logic in `clear_state()` and the config panel Enter key handling suggests these were workarounds that are no longer necessary with the simplified approach.

https://claude.ai/code/session_01LMic7aAkUm6QiLoEbNj2Bt