### PR TITLE
Refactor NavigationContext from struct to enum for type-safe hierarchy

### DIFF
--- a/src/app/model/dagruns.rs
+++ b/src/app/model/dagruns.rs
@@ -220,7 +220,7 @@ impl DagRunModel {
     ) -> KeyResult {
         match key_code {
             KeyCode::Char('t') => {
-                if let Some(dag_id) = &ctx.dag_id {
+                if let Some(dag_id) = ctx.dag_id() {
                     self.popup
                         .show_custom(DagRunPopUp::Trigger(TriggerDagRunPopUp::new(
                             dag_id.clone(),
@@ -230,7 +230,7 @@ impl DagRunModel {
             }
             KeyCode::Char('m') => {
                 let dag_run_ids = self.selected_dag_run_ids();
-                if let Some(dag_id) = &ctx.dag_id {
+                if let Some(dag_id) = ctx.dag_id() {
                     if !dag_run_ids.is_empty() {
                         self.popup
                             .show_custom(DagRunPopUp::Mark(MarkDagRunPopup::new(
@@ -246,7 +246,7 @@ impl DagRunModel {
                 KeyResult::Consumed
             }
             KeyCode::Char('v') => {
-                if let Some(dag_id) = &ctx.dag_id {
+                if let Some(dag_id) = ctx.dag_id() {
                     KeyResult::ConsumedWith(vec![WorkerMessage::GetDagCode {
                         dag_id: dag_id.clone(),
                     }])
@@ -256,7 +256,7 @@ impl DagRunModel {
             }
             KeyCode::Char('c') => {
                 let dag_run_ids = self.selected_dag_run_ids();
-                if let Some(dag_id) = &ctx.dag_id {
+                if let Some(dag_id) = ctx.dag_id() {
                     if !dag_run_ids.is_empty() {
                         self.popup
                             .show_custom(DagRunPopUp::Clear(ClearDagRunPopup::new(
@@ -268,7 +268,7 @@ impl DagRunModel {
                 KeyResult::Consumed
             }
             KeyCode::Enter => {
-                if let (Some(dag_id), Some(dag_run)) = (&ctx.dag_id, &self.current()) {
+                if let (Some(dag_id), Some(dag_run)) = (ctx.dag_id(), &self.current()) {
                     KeyResult::PassWith(vec![
                         WorkerMessage::UpdateTasks {
                             dag_id: dag_id.clone(),
@@ -283,7 +283,7 @@ impl DagRunModel {
                 }
             }
             KeyCode::Char('o') => {
-                if let (Some(dag_id), Some(dag_run)) = (&ctx.dag_id, &self.current()) {
+                if let (Some(dag_id), Some(dag_run)) = (ctx.dag_id(), &self.current()) {
                     KeyResult::PassWith(vec![WorkerMessage::OpenItem(OpenItem::DagRun {
                         dag_id: dag_id.clone(),
                         dag_run_id: dag_run.dag_run_id.clone(),
@@ -309,7 +309,7 @@ impl Model for DagRunModel {
                 if !self.ticks.is_multiple_of(10) {
                     return (Some(FlowrsEvent::Tick), vec![]);
                 }
-                let worker_messages = if let Some(dag_id) = &ctx.dag_id {
+                let worker_messages = if let Some(dag_id) = ctx.dag_id() {
                     vec![WorkerMessage::UpdateDagRuns {
                         dag_id: dag_id.clone(),
                     }]

--- a/src/app/model/logs.rs
+++ b/src/app/model/logs.rs
@@ -78,9 +78,12 @@ impl Model for LogModel {
                 if !self.ticks.is_multiple_of(10) {
                     return (Some(FlowrsEvent::Tick), vec![]);
                 }
-                if let (Some(dag_id), Some(dag_run_id), Some(task_id), Some(task_try)) =
-                    (&ctx.dag_id, &ctx.dag_run_id, &ctx.task_id, &ctx.task_try)
-                {
+                if let (Some(dag_id), Some(dag_run_id), Some(task_id), Some(task_try)) = (
+                    ctx.dag_id(),
+                    ctx.dag_run_id(),
+                    ctx.task_id(),
+                    ctx.task_try(),
+                ) {
                     log::debug!("Updating task logs for dag_run_id: {dag_run_id}");
                     return (
                         Some(FlowrsEvent::Tick),
@@ -88,7 +91,7 @@ impl Model for LogModel {
                             dag_id: dag_id.clone(),
                             dag_run_id: dag_run_id.clone(),
                             task_id: task_id.clone(),
-                            task_try: *task_try,
+                            task_try,
                         }],
                     );
                 }
@@ -141,7 +144,7 @@ impl Model for LogModel {
                     KeyCode::Char('o') => {
                         if self.all.get(self.current % self.all.len()).is_some() {
                             if let (Some(dag_id), Some(dag_run_id), Some(task_id)) =
-                                (&ctx.dag_id, &ctx.dag_run_id, &ctx.task_id)
+                                (ctx.dag_id(), ctx.dag_run_id(), ctx.task_id())
                             {
                                 return (
                                     Some(FlowrsEvent::Key(*key)),

--- a/src/app/model/taskinstances.rs
+++ b/src/app/model/taskinstances.rs
@@ -114,7 +114,7 @@ impl TaskInstanceModel {
             KeyCode::Char('m') => {
                 let task_ids = self.selected_task_ids();
                 if !task_ids.is_empty() {
-                    if let (Some(dag_id), Some(dag_run_id)) = (&ctx.dag_id, &ctx.dag_run_id) {
+                    if let (Some(dag_id), Some(dag_run_id)) = (ctx.dag_id(), ctx.dag_run_id()) {
                         self.popup.show_custom(TaskInstancePopUp::Mark(
                             MarkTaskInstancePopup::new(task_ids, dag_id, dag_run_id),
                         ));
@@ -124,7 +124,7 @@ impl TaskInstanceModel {
             }
             KeyCode::Char('c') => {
                 let task_ids = self.selected_task_ids();
-                if let (Some(dag_id), Some(dag_run_id)) = (&ctx.dag_id, &ctx.dag_run_id) {
+                if let (Some(dag_id), Some(dag_run_id)) = (ctx.dag_id(), ctx.dag_run_id()) {
                     if !task_ids.is_empty() {
                         self.popup.show_custom(TaskInstancePopUp::Clear(
                             ClearTaskInstancePopup::new(dag_run_id, dag_id, task_ids),
@@ -179,7 +179,7 @@ impl Model for TaskInstanceModel {
                 if !self.ticks.is_multiple_of(10) {
                     return (Some(FlowrsEvent::Tick), vec![]);
                 }
-                if let (Some(dag_id), Some(dag_run_id)) = (&ctx.dag_id, &ctx.dag_run_id) {
+                if let (Some(dag_id), Some(dag_run_id)) = (ctx.dag_id(), ctx.dag_run_id()) {
                     log::debug!("Updating task instances for dag_run_id: {dag_run_id}");
                     return (
                         Some(FlowrsEvent::Tick),

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -18,15 +18,87 @@ static BREADCRUMB_DATE_FORMAT: LazyLock<Vec<BorrowedFormatItem<'static>>> = Lazy
 });
 
 /// Centralized navigation context — the single source of truth for what the
-/// user is currently looking at. Replaces the redundant per-panel context IDs
-/// that were previously stored on `DagRunModel`, `TaskInstanceModel`, and `LogModel`.
-#[derive(Clone, Default, Debug)]
-pub struct NavigationContext {
-    pub environment: Option<String>,
-    pub dag_id: Option<DagId>,
-    pub dag_run_id: Option<DagRunId>,
-    pub task_id: Option<TaskId>,
-    pub task_try: Option<u16>,
+/// user is currently looking at. Encoded as an enum to enforce the strict
+/// hierarchy: environment ⊃ dag ⊃ `dag_run` ⊃ task. It is impossible to have,
+/// e.g., a `task_id` without a `dag_id`.
+#[derive(Clone, Debug, Default)]
+pub enum NavigationContext {
+    #[default]
+    None,
+    Environment {
+        environment: String,
+    },
+    Dag {
+        environment: String,
+        dag_id: DagId,
+    },
+    DagRun {
+        environment: String,
+        dag_id: DagId,
+        dag_run_id: DagRunId,
+    },
+    Task {
+        environment: String,
+        dag_id: DagId,
+        dag_run_id: DagRunId,
+        task_id: TaskId,
+        task_try: u16,
+    },
+}
+
+impl NavigationContext {
+    pub fn environment(&self) -> Option<&String> {
+        match self {
+            NavigationContext::None => Option::None,
+            NavigationContext::Environment { environment, .. }
+            | NavigationContext::Dag { environment, .. }
+            | NavigationContext::DagRun { environment, .. }
+            | NavigationContext::Task { environment, .. } => Some(environment),
+        }
+    }
+
+    pub fn dag_id(&self) -> Option<&DagId> {
+        match self {
+            NavigationContext::None | NavigationContext::Environment { .. } => Option::None,
+            NavigationContext::Dag { dag_id, .. }
+            | NavigationContext::DagRun { dag_id, .. }
+            | NavigationContext::Task { dag_id, .. } => Some(dag_id),
+        }
+    }
+
+    pub fn dag_run_id(&self) -> Option<&DagRunId> {
+        match self {
+            NavigationContext::None
+            | NavigationContext::Environment { .. }
+            | NavigationContext::Dag { .. } => Option::None,
+            NavigationContext::DagRun { dag_run_id, .. }
+            | NavigationContext::Task { dag_run_id, .. } => Some(dag_run_id),
+        }
+    }
+
+    pub fn task_id(&self) -> Option<&TaskId> {
+        match self {
+            NavigationContext::Task { task_id, .. } => Some(task_id),
+            _ => Option::None,
+        }
+    }
+
+    pub fn task_try(&self) -> Option<u16> {
+        match self {
+            NavigationContext::Task { task_try, .. } => Some(*task_try),
+            _ => Option::None,
+        }
+    }
+
+    /// Reset to environment-only level, discarding any deeper context.
+    pub fn reset_to_environment(&mut self) {
+        *self = match self.environment() {
+            Some(env) => NavigationContext::Environment {
+                environment: env.clone(),
+            },
+            Option::None => NavigationContext::None,
+        };
+    }
 }
 
 pub struct App {
@@ -81,9 +153,9 @@ impl App {
             Some(WarningPopup::new(warnings))
         };
 
-        let nav_context = NavigationContext {
-            environment: config.active_server.clone(),
-            ..Default::default()
+        let nav_context = match config.active_server.clone() {
+            Some(env) => NavigationContext::Environment { environment: env },
+            None => NavigationContext::None,
         };
 
         Self {
@@ -133,10 +205,7 @@ impl App {
         self.ticks = 0;
         self.loading = true;
         // Clear navigation context below the environment level
-        self.nav_context.dag_id = None;
-        self.nav_context.dag_run_id = None;
-        self.nav_context.task_id = None;
-        self.nav_context.task_try = None;
+        self.nav_context.reset_to_environment();
         // Clear view models but not environment_state
         self.dags.table.all.clear();
         self.dagruns.table.all.clear();
@@ -150,12 +219,12 @@ impl App {
         let mut parts: Vec<String> = Vec::new();
 
         // Always start with the active environment name
-        let env_name = self.nav_context.environment.as_ref()?;
+        let env_name = self.nav_context.environment()?;
         parts.push(env_name.clone());
 
         // Add DAG if we're past the Config panel
         if self.active_panel != Panel::Config && self.active_panel != Panel::Dag {
-            if let Some(dag_id) = &self.nav_context.dag_id {
+            if let Some(dag_id) = self.nav_context.dag_id() {
                 let truncated = Self::truncate_breadcrumb_part(dag_id, 25);
                 parts.push(truncated);
             }
@@ -170,7 +239,7 @@ impl App {
                         .unwrap_or_else(|_| "unknown".to_string());
                     parts.push(formatted);
                 }
-            } else if let Some(dag_run_id) = &self.nav_context.dag_run_id {
+            } else if let Some(dag_run_id) = self.nav_context.dag_run_id() {
                 let truncated = Self::truncate_breadcrumb_part(dag_run_id, 20);
                 parts.push(truncated);
             }
@@ -178,7 +247,7 @@ impl App {
 
         // Add Task if we're at Logs panel
         if self.active_panel == Panel::Logs {
-            if let Some(task_id) = &self.nav_context.task_id {
+            if let Some(task_id) = self.nav_context.task_id() {
                 let truncated = Self::truncate_breadcrumb_part(task_id, 20);
                 parts.push(truncated);
             }
@@ -213,20 +282,25 @@ impl App {
     /// This is the single place where navigation state changes in response
     /// to panel-emitted messages.
     pub fn set_context_from_message(&mut self, message: &WorkerMessage) {
+        // Capture the current environment for reuse across all branches.
+        let env = match self.nav_context.environment() {
+            Some(e) => e.clone(),
+            Option::None => return, // No environment set; nothing to navigate into
+        };
+
         match message {
             WorkerMessage::UpdateDagRuns { dag_id } => {
-                self.nav_context.dag_id = Some(dag_id.clone());
-                // Clear deeper context when navigating to a new DAG
-                self.nav_context.dag_run_id = None;
-                self.nav_context.task_id = None;
-                self.nav_context.task_try = None;
+                self.nav_context = NavigationContext::Dag {
+                    environment: env,
+                    dag_id: dag_id.clone(),
+                };
             }
             WorkerMessage::UpdateTaskInstances { dag_id, dag_run_id } => {
-                self.nav_context.dag_id = Some(dag_id.clone());
-                self.nav_context.dag_run_id = Some(dag_run_id.clone());
-                // Clear deeper context
-                self.nav_context.task_id = None;
-                self.nav_context.task_try = None;
+                self.nav_context = NavigationContext::DagRun {
+                    environment: env,
+                    dag_id: dag_id.clone(),
+                    dag_run_id: dag_run_id.clone(),
+                };
             }
             WorkerMessage::UpdateTaskLogs {
                 dag_id,
@@ -234,21 +308,24 @@ impl App {
                 task_id,
                 task_try,
             } => {
-                let is_new_context = self.nav_context.dag_id.as_ref() != Some(dag_id)
-                    || self.nav_context.dag_run_id.as_ref() != Some(dag_run_id)
-                    || self.nav_context.task_id.as_ref() != Some(task_id)
-                    || self.nav_context.task_try.as_ref() != Some(task_try);
-                self.nav_context.dag_id = Some(dag_id.clone());
-                self.nav_context.dag_run_id = Some(dag_run_id.clone());
-                self.nav_context.task_id = Some(task_id.clone());
-                self.nav_context.task_try = Some(*task_try);
+                let is_new_context = self.nav_context.dag_id() != Some(dag_id)
+                    || self.nav_context.dag_run_id() != Some(dag_run_id)
+                    || self.nav_context.task_id() != Some(task_id)
+                    || self.nav_context.task_try() != Some(*task_try);
+                self.nav_context = NavigationContext::Task {
+                    environment: env,
+                    dag_id: dag_id.clone(),
+                    dag_run_id: dag_run_id.clone(),
+                    task_id: task_id.clone(),
+                    task_try: *task_try,
+                };
                 if is_new_context {
                     self.logs.current = 0;
                     self.logs.follow_mode = true;
                 }
             }
             WorkerMessage::UpdateTasks { dag_id } => {
-                if self.nav_context.dag_id.as_ref() != Some(dag_id) {
+                if self.nav_context.dag_id() != Some(dag_id) {
                     self.task_instances.task_graph = None;
                 }
             }
@@ -273,7 +350,7 @@ impl App {
                 self.dags.table.apply_filter();
             }
             Panel::DAGRun => {
-                if let Some(dag_id) = &self.nav_context.dag_id {
+                if let Some(dag_id) = self.nav_context.dag_id() {
                     self.dagruns.table.all = self.environment_state.get_active_dag_runs(dag_id);
                     let dag_run_ids: Vec<String> = self
                         .dagruns
@@ -294,7 +371,7 @@ impl App {
             }
             Panel::TaskInstance => {
                 if let (Some(dag_id), Some(dag_run_id)) =
-                    (&self.nav_context.dag_id, &self.nav_context.dag_run_id)
+                    (self.nav_context.dag_id(), self.nav_context.dag_run_id())
                 {
                     self.task_instances.table.all = self
                         .environment_state
@@ -318,9 +395,9 @@ impl App {
             }
             Panel::Logs => {
                 if let (Some(dag_id), Some(dag_run_id), Some(task_id)) = (
-                    &self.nav_context.dag_id,
-                    &self.nav_context.dag_run_id,
-                    &self.nav_context.task_id,
+                    self.nav_context.dag_id(),
+                    self.nav_context.dag_run_id(),
+                    self.nav_context.task_id(),
                 ) {
                     self.logs.update_logs(
                         self.environment_state

--- a/src/app/worker/config.rs
+++ b/src/app/worker/config.rs
@@ -50,7 +50,9 @@ pub fn handle_config_selected(app: &Arc<Mutex<App>>, idx: usize) -> Result<()> {
     app.environment_state
         .set_active_environment(env_name.clone());
     app.config.active_server = Some(env_name.to_string());
-    app.nav_context.environment = Some(env_name.to_string());
+    app.nav_context = crate::app::state::NavigationContext::Environment {
+        environment: env_name.to_string(),
+    };
 
     // Clear the view state but NOT the environment data
     app.clear_state();


### PR DESCRIPTION
## Summary
Refactored `NavigationContext` from a flat struct with optional fields to a discriminated enum that enforces the strict hierarchical relationship between navigation levels: environment ⊃ dag ⊃ dag_run ⊃ task. This makes it impossible to represent invalid states (e.g., a task without a dag) at the type level.

## Key Changes

- **Converted NavigationContext to enum**: Replaced the struct with optional fields with an enum having variants for each valid navigation level (`None`, `Environment`, `Dag`, `DagRun`, `Task`), ensuring the hierarchy is enforced by the type system.

- **Added accessor methods**: Implemented `environment()`, `dag_id()`, `dag_run_id()`, `task_id()`, and `task_try()` methods that return references/values from the appropriate enum variant, replacing direct field access.

- **Added `reset_to_environment()` helper**: Simplifies the common operation of clearing deeper context while preserving the environment level.

- **Updated all navigation state mutations**: Changed `set_context_from_message()` to construct complete enum variants rather than setting individual fields, ensuring all required fields are always present together.

- **Updated all field accesses**: Replaced direct field access (e.g., `ctx.dag_id`) with method calls (e.g., `ctx.dag_id()`) throughout the codebase in:
  - `src/app/state.rs` (breadcrumb generation, panel updates)
  - `src/app/model/dagruns.rs`
  - `src/app/model/logs.rs`
  - `src/app/model/taskinstances.rs`
  - `src/app/worker/config.rs`

## Implementation Details

- The enum uses `#[default]` on the `None` variant for convenient default initialization.
- Accessor methods return `Option<&T>` for reference types and `Option<T>` for `Copy` types (like `u16`), maintaining consistency with the original API.
- The refactoring eliminates the possibility of partial or inconsistent navigation state at compile time.

https://claude.ai/code/session_01RzmVGWrfwvHPi9KQ7YfrYA