### PR TITLE
Change task_try type from u16 to u32 and simplify formatting

### DIFF
--- a/src/airflow/client/v1/log.rs
+++ b/src/airflow/client/v1/log.rs
@@ -14,7 +14,7 @@ impl LogOperations for V1Client {
         dag_id: &str,
         dag_run_id: &str,
         task_id: &str,
-        task_try: u16,
+        task_try: u32,
     ) -> Result<Log> {
         let response = self
             .base_api(

--- a/src/airflow/client/v1/model/taskinstance.rs
+++ b/src/airflow/client/v1/model/taskinstance.rs
@@ -21,7 +21,7 @@ pub struct TaskInstanceResponse {
     pub end_date: Option<OffsetDateTime>,
     pub duration: Option<f64>,
     pub state: Option<String>,
-    pub try_number: i64,
+    pub try_number: u32,
     pub map_index: i64,
     pub max_tries: i64,
     pub hostname: String,

--- a/src/airflow/client/v2/log.rs
+++ b/src/airflow/client/v2/log.rs
@@ -15,7 +15,7 @@ impl LogOperations for V2Client {
         dag_id: &str,
         dag_run_id: &str,
         task_id: &str,
-        task_try: u16,
+        task_try: u32,
     ) -> Result<Log> {
         let response = self
             .base_api(

--- a/src/airflow/client/v2/model/taskinstance.rs
+++ b/src/airflow/client/v2/model/taskinstance.rs
@@ -28,7 +28,7 @@ pub struct TaskInstance {
     pub end_date: Option<OffsetDateTime>,
     pub duration: Option<f64>,
     pub state: Option<String>,
-    pub try_number: i64,
+    pub try_number: u32,
     pub max_tries: i64,
     pub task_display_name: String,
     pub hostname: Option<String>,

--- a/src/airflow/model/common/taskinstance.rs
+++ b/src/airflow/model/common/taskinstance.rs
@@ -17,7 +17,7 @@ pub struct TaskInstance {
     pub end_date: Option<OffsetDateTime>,
     pub duration: Option<f64>,
     pub state: Option<String>,
-    pub try_number: i64,
+    pub try_number: u32,
     pub max_tries: i64,
     pub map_index: i64,
     pub hostname: Option<String>,

--- a/src/airflow/traits/log.rs
+++ b/src/airflow/traits/log.rs
@@ -12,6 +12,6 @@ pub trait LogOperations: Send + Sync {
         dag_id: &str,
         dag_run_id: &str,
         task_id: &str,
-        task_try: u16,
+        task_try: u32,
     ) -> Result<Log>;
 }

--- a/src/app/model/logs.rs
+++ b/src/app/model/logs.rs
@@ -150,7 +150,7 @@ impl Model for LogModel {
                                         dag_run_id: dag_run_id.clone(),
                                         task_id: task_id.clone(),
                                         #[allow(clippy::cast_possible_truncation)]
-                                        task_try: (self.current + 1) as u16,
+                                        task_try: (self.current + 1) as u32,
                                     })],
                                 );
                             }

--- a/src/app/model/taskinstances.rs
+++ b/src/app/model/taskinstances.rs
@@ -139,13 +139,11 @@ impl TaskInstanceModel {
             }
             KeyCode::Enter => {
                 if let Some(task_instance) = self.table.current() {
-                    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-                    let task_try = task_instance.try_number as u16;
                     KeyResult::PassWith(vec![WorkerMessage::UpdateTaskLogs {
                         dag_id: task_instance.dag_id.clone(),
                         dag_run_id: task_instance.dag_run_id.clone(),
                         task_id: task_instance.task_id.clone(),
-                        task_try,
+                        task_try: task_instance.try_number,
                     }])
                 } else {
                     KeyResult::Consumed
@@ -263,7 +261,7 @@ impl Widget for &mut TaskInstanceModel {
                     } else {
                         state_to_colored_square(AirflowStateColor::None)
                     }),
-                    Line::from(format!("{:?}", item.try_number)),
+                    Line::from(item.try_number.to_string()),
                 ])
                 .style(self.table.row_style(idx))
             });

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -26,7 +26,7 @@ pub struct NavigationContext {
     pub dag_id: Option<DagId>,
     pub dag_run_id: Option<DagRunId>,
     pub task_id: Option<TaskId>,
-    pub task_try: Option<u16>,
+    pub task_try: Option<u32>,
 }
 
 pub struct App {

--- a/src/app/worker/logs.rs
+++ b/src/app/worker/logs.rs
@@ -18,7 +18,7 @@ pub async fn handle_update_task_logs(
     dag_id: &DagId,
     dag_run_id: &DagRunId,
     task_id: &TaskId,
-    task_try: u16,
+    task_try: u32,
     env_name: &str,
 ) {
     debug!("Getting logs for task: {task_id}, try number {task_try}");

--- a/src/app/worker/mod.rs
+++ b/src/app/worker/mod.rs
@@ -47,7 +47,7 @@ pub enum WorkerMessage {
         dag_id: DagId,
         dag_run_id: DagRunId,
         task_id: TaskId,
-        task_try: u16,
+        task_try: u32,
     },
     MarkDagRun {
         dag_run_id: DagRunId,
@@ -94,7 +94,7 @@ pub enum OpenItem {
         dag_run_id: DagRunId,
         task_id: TaskId,
         #[allow(dead_code)]
-        task_try: u16,
+        task_try: u32,
     },
 }
 


### PR DESCRIPTION
## Summary
This PR updates the `task_try` field type from `u16` to `u32` across the codebase to better accommodate the actual range of try numbers from the Airflow API, and simplifies the formatting of try numbers in the UI.

## Key Changes
- **Type change**: Updated `try_number` field type from `i64` to `u32` in all TaskInstance model structs (v1, v2, and common models)
- **API consistency**: Changed `task_try` parameter type from `u16` to `u32` in:
  - `WorkerMessage::UpdateTaskLogs`
  - `OpenItem::TaskLogs`
  - `LogOperations` trait and implementations (v1 and v2 clients)
  - `NavigationContext`
  - Worker log handling functions
- **UI improvements**: 
  - Removed unnecessary `#[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]` annotation in taskinstances.rs
  - Simplified try number formatting from `format!("{:?}", item.try_number)` to `item.try_number.to_string()` for cleaner output
  - Removed intermediate variable cast in the Enter key handler, now passing `task_instance.try_number` directly
- **Cast updates**: Updated cast in logs.rs from `as u16` to `as u32`

## Implementation Details
The change from `u16` to `u32` provides better alignment with Airflow's actual try number range while maintaining type safety. The removal of the intermediate cast and clippy suppressions simplifies the code without sacrificing correctness, as the source type (`u32`) no longer requires lossy conversions.

https://claude.ai/code/session_012ajQitp6V6Siht15yTR7it