### PR TITLE
Refactor TokenCmd to TokenSource enum for token authentication

### DIFF
--- a/src/airflow/config/mod.rs
+++ b/src/airflow/config/mod.rs
@@ -80,7 +80,7 @@ const fn default_timeout() -> u64 {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub enum AirflowAuth {
     Basic(BasicAuth),
-    Token(TokenCmd),
+    Token(TokenSource),
     Conveyor,
     Mwaa(super::managed_services::mwaa::MwaaAuth),
     Astronomer(super::managed_services::astronomer::AstronomerAuth),
@@ -93,9 +93,10 @@ pub struct BasicAuth {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct TokenCmd {
-    pub cmd: Option<String>,
-    pub token: Option<String>,
+#[serde(untagged)]
+pub enum TokenSource {
+    Command { cmd: String },
+    Static { token: String },
 }
 
 impl Default for FlowrsConfig {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use flowrs_tui::airflow::client::create_client;
 use flowrs_tui::airflow::config::{
-    AirflowAuth, AirflowConfig, AirflowVersion, BasicAuth, TokenCmd,
+    AirflowAuth, AirflowConfig, AirflowVersion, BasicAuth, TokenSource,
 };
 use flowrs_tui::airflow::traits::AirflowClient;
 
@@ -88,10 +88,7 @@ pub async fn create_test_client_v3() -> anyhow::Result<Arc<dyn AirflowClient>> {
     let config = AirflowConfig {
         name: "test".to_string(),
         endpoint: url,
-        auth: AirflowAuth::Token(TokenCmd {
-            cmd: None,
-            token: Some(jwt_token),
-        }),
+        auth: AirflowAuth::Token(TokenSource::Static { token: jwt_token }),
         managed: None,
         version: AirflowVersion::V3,
         timeout_secs: 30,


### PR DESCRIPTION
## Summary
Refactored the token authentication system to use a discriminated union (`TokenSource` enum) instead of a struct with optional fields. This change improves type safety and makes the intent clearer by explicitly distinguishing between command-based and static token sources.

## Key Changes
- **Replaced `TokenCmd` struct with `TokenSource` enum**: The new enum has two variants:
  - `Command { cmd: String }`: For tokens generated by executing a command
  - `Static { token: String }`: For static token values
  
- **Updated token configuration flow**: 
  - Removed the optional token field that was being stored during config setup
  - Token commands are now executed at request time rather than at configuration time
  - Simplified the config add/update commands to only store the command, not the generated token

- **Improved token execution in BaseClient**:
  - Refactored token authentication to use pattern matching on the `TokenSource` enum
  - Command-based tokens are executed fresh on each request
  - Static tokens are used directly without execution
  - Better logging to distinguish between command and static token sources

- **Updated all references**: Changed imports and usages across config commands, client code, and tests to use the new `TokenSource` enum

## Notable Implementation Details
- Used `#[serde(untagged)]` on the `TokenSource` enum to maintain backward compatibility with existing configuration serialization
- Token validation during config setup now discards the generated token (prefixed with `_`) since tokens are generated on-demand
- Fixed a bug in `update.rs` where the command was being passed directly to `Command::new()` instead of using `sh -c` for proper shell execution

https://claude.ai/code/session_01TTG9zkaSpoC1a8iFtamqux