### PR TITLE
fix: use BTreeMap for consistent Airflow log field ordering

### DIFF
--- a/src/airflow/client/v2/model/log.rs
+++ b/src/airflow/client/v2/model/log.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     fmt::{Display, Formatter},
 };
 
@@ -11,7 +11,7 @@ pub struct StructuredLogMessage {
     pub timestamp: Option<String>,
     pub event: String,
     #[serde(flatten)]
-    pub additional_fields: HashMap<String, serde_json::Value>,
+    pub additional_fields: BTreeMap<String, serde_json::Value>,
 }
 
 /// Log content can be either structured messages or plain text lines


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized structured logging implementation to enhance field ordering consistency. This update improves predictability of additional field serialization and iteration, resulting in more reliable log processing. The change ensures consistent behavior across different environments and makes logs more suitable for systematic analysis and integration with downstream systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->