### PR TITLE
Add is_running() method to TimeBounded trait for duration calculation

### DIFF
--- a/src/airflow/model/common/dagrun.rs
+++ b/src/airflow/model/common/dagrun.rs
@@ -119,6 +119,10 @@ impl TimeBounded for DagRun {
     fn end_date(&self) -> Option<OffsetDateTime> {
         self.end_date
     }
+
+    fn is_running(&self) -> bool {
+        self.state == DagRunState::Running || self.state == DagRunState::Queued
+    }
 }
 
 // From trait implementations for v1 models

--- a/src/airflow/model/common/duration.rs
+++ b/src/airflow/model/common/duration.rs
@@ -128,7 +128,7 @@ mod tests {
             running: true,
         };
         let duration = calculate_duration(&entity).unwrap();
-        assert!(duration >= 59.0 && duration <= 62.0);
+        assert!((59.0..=62.0).contains(&duration));
     }
 
     #[test]

--- a/src/airflow/model/common/duration.rs
+++ b/src/airflow/model/common/duration.rs
@@ -6,14 +6,22 @@ pub trait TimeBounded {
     fn start_date(&self) -> Option<OffsetDateTime>;
     /// Returns the end date of the entity, if available.
     fn end_date(&self) -> Option<OffsetDateTime>;
+    /// Returns whether the entity is currently running/active.
+    /// Used to decide if current time should be used as end date for duration calculation.
+    fn is_running(&self) -> bool;
 }
 
 /// Calculate duration in seconds for any time-bounded entity.
 /// Returns None if `start_date` is not available or if `end_date` precedes `start_date`.
 /// For running entities (no `end_date`), uses current time.
+/// For non-running entities without `end_date`, returns None.
 pub fn calculate_duration<T: TimeBounded>(item: &T) -> Option<f64> {
     let start = item.start_date()?;
-    let end = item.end_date().unwrap_or_else(OffsetDateTime::now_utc);
+    let end = match item.end_date() {
+        Some(end) => end,
+        None if item.is_running() => OffsetDateTime::now_utc(),
+        None => return None,
+    };
     if end < start {
         return None;
     }
@@ -55,6 +63,25 @@ pub fn format_duration(seconds: f64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use time::Duration;
+
+    struct TestEntity {
+        start: Option<OffsetDateTime>,
+        end: Option<OffsetDateTime>,
+        running: bool,
+    }
+
+    impl TimeBounded for TestEntity {
+        fn start_date(&self) -> Option<OffsetDateTime> {
+            self.start
+        }
+        fn end_date(&self) -> Option<OffsetDateTime> {
+            self.end
+        }
+        fn is_running(&self) -> bool {
+            self.running
+        }
+    }
 
     #[test]
     fn test_format_duration() {
@@ -69,5 +96,59 @@ mod tests {
         // Days
         assert_eq!(format_duration(90000.0), "1d 1h");
         assert_eq!(format_duration(172_800.0), "2d");
+    }
+
+    #[test]
+    fn test_calculate_duration_with_start_and_end() {
+        let now = OffsetDateTime::now_utc();
+        let entity = TestEntity {
+            start: Some(now - Duration::seconds(120)),
+            end: Some(now),
+            running: false,
+        };
+        let duration = calculate_duration(&entity).unwrap();
+        assert!((duration - 120.0).abs() < 1.0);
+    }
+
+    #[test]
+    fn test_calculate_duration_no_start_returns_none() {
+        let entity = TestEntity {
+            start: None,
+            end: Some(OffsetDateTime::now_utc()),
+            running: false,
+        };
+        assert!(calculate_duration(&entity).is_none());
+    }
+
+    #[test]
+    fn test_calculate_duration_running_no_end_uses_now() {
+        let entity = TestEntity {
+            start: Some(OffsetDateTime::now_utc() - Duration::seconds(60)),
+            end: None,
+            running: true,
+        };
+        let duration = calculate_duration(&entity).unwrap();
+        assert!(duration >= 59.0 && duration <= 62.0);
+    }
+
+    #[test]
+    fn test_calculate_duration_not_running_no_end_returns_none() {
+        let entity = TestEntity {
+            start: Some(OffsetDateTime::now_utc() - Duration::seconds(60)),
+            end: None,
+            running: false,
+        };
+        assert!(calculate_duration(&entity).is_none());
+    }
+
+    #[test]
+    fn test_calculate_duration_end_before_start_returns_none() {
+        let now = OffsetDateTime::now_utc();
+        let entity = TestEntity {
+            start: Some(now),
+            end: Some(now - Duration::seconds(60)),
+            running: false,
+        };
+        assert!(calculate_duration(&entity).is_none());
     }
 }

--- a/src/airflow/model/common/taskinstance.rs
+++ b/src/airflow/model/common/taskinstance.rs
@@ -110,6 +110,21 @@ impl TimeBounded for TaskInstance {
     fn end_date(&self) -> Option<OffsetDateTime> {
         self.end_date
     }
+
+    fn is_running(&self) -> bool {
+        matches!(
+            self.state,
+            Some(
+                TaskInstanceState::Running
+                    | TaskInstanceState::Queued
+                    | TaskInstanceState::Scheduled
+                    | TaskInstanceState::Deferred
+                    | TaskInstanceState::Restarting
+                    | TaskInstanceState::UpForReschedule
+                    | TaskInstanceState::UpForRetry
+            )
+        )
+    }
 }
 
 // From trait implementations for v1 models


### PR DESCRIPTION
## Summary
This PR enhances the duration calculation logic by introducing an `is_running()` method to the `TimeBounded` trait. This allows for more accurate duration calculations by distinguishing between actively running entities and completed ones when an end date is not available.

## Key Changes
- **TimeBounded trait**: Added `is_running()` method to determine if an entity is currently active
- **calculate_duration() function**: Updated logic to:
  - Use current time as end date only for running entities without an explicit end date
  - Return `None` for non-running entities without an end date (instead of assuming current time)
- **TaskInstance implementation**: Implemented `is_running()` to check for active states (Running, Queued, Scheduled, Deferred, Restarting, UpForReschedule, UpForRetry)
- **DagRun implementation**: Implemented `is_running()` to check for Running or Queued states
- **Test coverage**: Added comprehensive test suite covering:
  - Duration calculation with both start and end dates
  - Missing start date handling
  - Running entities without end dates
  - Non-running entities without end dates
  - Invalid date ranges (end before start)

## Implementation Details
The change improves the semantics of duration calculation by making the distinction explicit: only entities that are actively running should use the current time as their end date. This prevents incorrect duration calculations for entities that have completed but don't have an explicit end date recorded.

https://claude.ai/code/session_01EPyt9jWwDDKJSn5WfMJN1v