### PR TITLE
chore: release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/jvanbuel/flowrs/compare/v0.9.0...v0.9.1) - 2026-02-21
+
+### Fixed
+
+- use RangeInclusive::contains to satisfy clippy
+- don't use current time as end_date for non-running entities
+- run token command off async runtime and fix quote stripping
+- redact credentials in Debug impls for auth providers
+- redact api_token in AstronomerAuthProvider Debug impl
+
+### Other
+
+- split core auth providers into separate files
+- remove unnecessary Clone from client types
+- apply cargo fmt
+- extract authentication into AuthProvider trait
+
 ## [0.8.11](https://github.com/jvanbuel/flowrs/compare/v0.8.10...v0.8.11) - 2026-02-16
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-tui"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-tui"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Flowrs is a Terminal User Interface (TUI) for Apache Airflow"


### PR DESCRIPTION



## 🤖 New release

* `flowrs-tui`: 0.9.0 -> 0.9.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.1](https://github.com/jvanbuel/flowrs/compare/v0.9.0...v0.9.1) - 2026-02-21

### Fixed

- use RangeInclusive::contains to satisfy clippy
- don't use current time as end_date for non-running entities
- run token command off async runtime and fix quote stripping
- redact credentials in Debug impls for auth providers
- redact api_token in AstronomerAuthProvider Debug impl

### Other

- split core auth providers into separate files
- remove unnecessary Clone from client types
- apply cargo fmt
- extract authentication into AuthProvider trait
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).