### PR TITLE
Support Airflow v3 run_after field and simplify DAG run table

### DIFF
--- a/src/airflow/model/common/dagrun.rs
+++ b/src/airflow/model/common/dagrun.rs
@@ -94,6 +94,7 @@ pub struct DagRun {
     pub dag_id: DagId,
     pub dag_run_id: DagRunId,
     pub logical_date: Option<OffsetDateTime>,
+    pub run_after: Option<OffsetDateTime>,
     pub data_interval_end: Option<OffsetDateTime>,
     pub data_interval_start: Option<OffsetDateTime>,
     pub end_date: Option<OffsetDateTime>,
@@ -109,6 +110,16 @@ pub struct DagRun {
 pub struct DagRunList {
     pub dag_runs: Vec<DagRun>,
     pub total_entries: i64,
+}
+
+impl DagRun {
+    /// Returns the most meaningful date for display and sorting.
+    ///
+    /// Prefers `run_after` (Airflow v3) over `logical_date` (Airflow v2),
+    /// since `logical_date` can be `None` for manually triggered runs in v3.
+    pub fn display_date(&self) -> Option<OffsetDateTime> {
+        self.run_after.or(self.logical_date)
+    }
 }
 
 impl TimeBounded for DagRun {
@@ -132,6 +143,7 @@ impl From<v1::model::dagrun::DAGRunResponse> for DagRun {
             dag_id: value.dag_id.into(),
             dag_run_id: value.dag_run_id.unwrap_or_default().into(),
             logical_date: value.logical_date,
+            run_after: None,
             data_interval_end: value.data_interval_end,
             data_interval_start: value.data_interval_start,
             end_date: value.end_date,
@@ -165,6 +177,7 @@ impl From<v2::model::dagrun::DagRun> for DagRun {
             dag_id: value.dag_id.into(),
             dag_run_id: value.dag_run_id.into(),
             logical_date: value.logical_date,
+            run_after: value.run_after,
             data_interval_end: value.data_interval_end,
             data_interval_start: value.data_interval_start,
             end_date: value.end_date,


### PR DESCRIPTION
## Summary
This PR adds support for Airflow v3's `run_after` field while maintaining backward compatibility with Airflow v2's `logical_date`. It also simplifies the DAG run display table by removing the DAG Run ID column and consolidating date display.

## Key Changes

- **Added `run_after` field support**: The `DagRun` struct now includes an optional `run_after` field to support Airflow v3, with a new `display_date()` method that prefers `run_after` over `logical_date` for display and sorting purposes.

- **Simplified table layout**: Removed the dedicated "DAG Run ID" column from the table display, reducing visual clutter while keeping the information accessible through the state indicator and other context.

- **Improved date handling**: The sorting logic now uses `display_date()` which intelligently selects between `run_after` (v3), `logical_date` (v2), and `start_date` as fallback, ensuring correct chronological ordering across Airflow versions.

- **Updated table constraints**: Adjusted column width calculations to account for the removed DAG Run ID column, improving space allocation for the duration gauge.

- **Enhanced test coverage**: Added a new test case `test_sort_dag_runs_prefers_run_after()` to verify that `run_after` takes precedence over `logical_date` when both are present.

- **Cleaned up imports**: Removed unused `Modifier` import from ratatui style module.

## Implementation Details

The `display_date()` method provides a clean abstraction for date selection, making it easy to handle the transition between Airflow versions. The sorting implementation now uses this method consistently, ensuring that runs are always ordered by the most meaningful date available. The table layout changes maintain the same visual hierarchy while reducing cognitive load by focusing on essential information.

https://claude.ai/code/session_01Ntp6UzeBVp78XaMQm1rS21