### PR TITLE
chore: release v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3](https://github.com/jvanbuel/flowrs/compare/v0.9.2...v0.9.3) - 2026-02-21
+
+### Added
+
+- add DAG code viewer to DAG panel via 'v' key
+
+### Other
+
+- extract duplicated DAG not found error into variable
+- format code with cargo fmt
+
 ## [0.9.2](https://github.com/jvanbuel/flowrs/compare/v0.9.1...v0.9.2) - 2026-02-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-tui"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-tui"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Flowrs is a Terminal User Interface (TUI) for Apache Airflow"


### PR DESCRIPTION



## 🤖 New release

* `flowrs-tui`: 0.9.2 -> 0.9.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.3](https://github.com/jvanbuel/flowrs/compare/v0.9.2...v0.9.3) - 2026-02-21

### Added

- add DAG code viewer to DAG panel via 'v' key

### Other

- extract duplicated DAG not found error into variable
- format code with cargo fmt
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).