### PR TITLE
Preserve cached retry data when rebuilding Gantt chart

### DIFF
--- a/src/airflow/model/common/gantt.rs
+++ b/src/airflow/model/common/gantt.rs
@@ -80,7 +80,7 @@ impl GanttData {
     }
 
     /// Recalculate `window_start` and `window_end` from all tries.
-    fn recompute_window(&mut self) {
+    pub fn recompute_window(&mut self) {
         let mut min_start: Option<OffsetDateTime> = None;
         let mut max_end: Option<OffsetDateTime> = None;
         let mut any_running = false;

--- a/src/app/model/taskinstances.rs
+++ b/src/app/model/taskinstances.rs
@@ -11,7 +11,8 @@ use ratatui::widgets::{Block, BorderType, Borders, Row, StatefulWidget, Table, W
 
 use crate::airflow::graph::{sort_task_instances, TaskGraph};
 use crate::airflow::model::common::{
-    calculate_duration, format_duration, GanttData, TaskId, TaskInstance, TaskInstanceState,
+    calculate_duration, format_duration, DagRunId, GanttData, TaskId, TaskInstance,
+    TaskInstanceState,
 };
 use crate::app::events::custom::FlowrsEvent;
 use crate::ui::common::{create_headers, state_to_colored_square};
@@ -32,6 +33,9 @@ pub struct TaskInstanceModel {
     pub popup: Popup<TaskInstancePopUp>,
     /// Gantt chart data computed from task instances and their tries
     pub gantt_data: GanttData,
+    /// Tracks which DAG run the cached `gantt_data` belongs to, so we can
+    /// invalidate it when the user navigates to a different run.
+    current_dag_run_id: Option<DagRunId>,
     ticks: u32,
     event_buffer: Vec<KeyCode>,
     pub task_graph: Option<TaskGraph>,
@@ -43,6 +47,7 @@ impl Default for TaskInstanceModel {
             table: FilterableTable::new(),
             popup: Popup::None,
             gantt_data: GanttData::default(),
+            current_dag_run_id: None,
             ticks: 0,
             event_buffer: Vec::new(),
             task_graph: None,
@@ -53,6 +58,16 @@ impl Default for TaskInstanceModel {
 impl TaskInstanceModel {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Notify the model which DAG run is now active.
+    /// Resets `gantt_data` when the run changes so cached retry history from a
+    /// previous run cannot leak into the new one.
+    pub fn set_dag_run_id(&mut self, dag_run_id: &DagRunId) {
+        if self.current_dag_run_id.as_ref() != Some(dag_run_id) {
+            self.gantt_data = GanttData::default();
+            self.current_dag_run_id = Some(dag_run_id.clone());
+        }
     }
 
     /// Sort task instances by topological order (or timestamp fallback)

--- a/src/app/model/taskinstances.rs
+++ b/src/app/model/taskinstances.rs
@@ -64,15 +64,38 @@ impl TaskInstanceModel {
 
     /// Rebuild Gantt data from the current task instance list.
     /// Returns task IDs that have retries (`try_number` > 1) for fetching detailed tries.
+    ///
+    /// For tasks with retries, previously cached try history is preserved so the
+    /// Gantt chart does not flicker while fresh retry data is being fetched.
     pub fn rebuild_gantt(&mut self) -> Vec<TaskId> {
-        self.gantt_data = GanttData::from_task_instances(&self.table.all);
+        let mut new_gantt = GanttData::from_task_instances(&self.table.all);
+
+        // Collect retried task IDs and carry over cached retry data
         let mut seen = HashSet::new();
-        self.table
+        let retried: Vec<TaskId> = self
+            .table
             .all
             .iter()
             .filter(|ti| ti.try_number > 1 && seen.insert(ti.task_id.clone()))
             .map(|ti| ti.task_id.clone())
-            .collect()
+            .collect();
+
+        for task_id in &retried {
+            if let Some(cached_tries) = self.gantt_data.task_tries.get(task_id) {
+                // Only carry over if the cache has more tries than the fresh data
+                // (i.e. it already includes the detailed retry history)
+                let new_tries = new_gantt.task_tries.get(task_id);
+                if cached_tries.len() > new_tries.map_or(0, Vec::len) {
+                    new_gantt
+                        .task_tries
+                        .insert(task_id.clone(), cached_tries.clone());
+                }
+            }
+        }
+
+        new_gantt.recompute_window();
+        self.gantt_data = new_gantt;
+        retried
     }
 
     /// Mark a task instance with a new status (optimistic update)

--- a/src/app/model/taskinstances.rs
+++ b/src/app/model/taskinstances.rs
@@ -11,7 +11,7 @@ use ratatui::widgets::{Block, BorderType, Borders, Row, StatefulWidget, Table, W
 
 use crate::airflow::graph::{sort_task_instances, TaskGraph};
 use crate::airflow::model::common::{
-    calculate_duration, format_duration, DagRunId, GanttData, TaskId, TaskInstance,
+    calculate_duration, format_duration, DagId, DagRunId, GanttData, TaskId, TaskInstance,
     TaskInstanceState,
 };
 use crate::app::events::custom::FlowrsEvent;
@@ -33,9 +33,9 @@ pub struct TaskInstanceModel {
     pub popup: Popup<TaskInstancePopUp>,
     /// Gantt chart data computed from task instances and their tries
     pub gantt_data: GanttData,
-    /// Tracks which DAG run the cached `gantt_data` belongs to, so we can
-    /// invalidate it when the user navigates to a different run.
-    current_dag_run_id: Option<DagRunId>,
+    /// Tracks which DAG + run the cached `gantt_data` belongs to, so we can
+    /// invalidate it when the user navigates to a different DAG or run.
+    current_gantt_key: Option<(DagId, DagRunId)>,
     ticks: u32,
     event_buffer: Vec<KeyCode>,
     pub task_graph: Option<TaskGraph>,
@@ -47,7 +47,7 @@ impl Default for TaskInstanceModel {
             table: FilterableTable::new(),
             popup: Popup::None,
             gantt_data: GanttData::default(),
-            current_dag_run_id: None,
+            current_gantt_key: None,
             ticks: 0,
             event_buffer: Vec::new(),
             task_graph: None,
@@ -60,13 +60,14 @@ impl TaskInstanceModel {
         Self::default()
     }
 
-    /// Notify the model which DAG run is now active.
-    /// Resets `gantt_data` when the run changes so cached retry history from a
-    /// previous run cannot leak into the new one.
-    pub fn set_dag_run_id(&mut self, dag_run_id: &DagRunId) {
-        if self.current_dag_run_id.as_ref() != Some(dag_run_id) {
+    /// Notify the model which DAG + run is now active.
+    /// Resets `gantt_data` when either the DAG or the run changes so cached
+    /// retry history cannot leak into a different context.
+    pub fn set_gantt_context(&mut self, dag_id: &DagId, dag_run_id: &DagRunId) {
+        let key = (dag_id.clone(), dag_run_id.clone());
+        if self.current_gantt_key.as_ref() != Some(&key) {
             self.gantt_data = GanttData::default();
-            self.current_dag_run_id = Some(dag_run_id.clone());
+            self.current_gantt_key = Some(key);
         }
     }
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -370,7 +370,7 @@ impl App {
                 if let (Some(dag_id), Some(dag_run_id)) =
                     (self.nav_context.dag_id(), self.nav_context.dag_run_id())
                 {
-                    self.task_instances.set_dag_run_id(dag_run_id);
+                    self.task_instances.set_gantt_context(dag_id, dag_run_id);
                     self.task_instances.table.all = self
                         .environment_state
                         .get_active_task_instances(dag_id, dag_run_id);

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -370,6 +370,7 @@ impl App {
                 if let (Some(dag_id), Some(dag_run_id)) =
                     (self.nav_context.dag_id(), self.nav_context.dag_run_id())
                 {
+                    self.task_instances.set_dag_run_id(dag_run_id);
                     self.task_instances.table.all = self
                         .environment_state
                         .get_active_task_instances(dag_id, dag_run_id);


### PR DESCRIPTION
## Summary
This change prevents the Gantt chart from flickering when retry data is being fetched by preserving previously cached try history during chart rebuilds.

## Key Changes
- Modified `rebuild_gantt()` to preserve cached retry data from the previous Gantt state when fresh data is being loaded
- Only carries over cached tries if they contain more detailed information than the newly computed data (indicating complete retry history)
- Made `recompute_window()` public in `GanttData` to allow recalculation after updating cached data
- Refactored `rebuild_gantt()` to build the new Gantt data separately before applying cache preservation logic

## Implementation Details
The rebuild process now:
1. Creates a fresh `GanttData` from current task instances
2. Identifies tasks with retries (try_number > 1)
3. For each retried task, checks if the old cached data has more tries than the new data
4. Carries over the cached tries if they're more complete (avoiding data loss during fetch)
5. Recomputes the window bounds after applying cached data
6. Replaces the old Gantt data with the updated version

This ensures smooth UX by maintaining detailed retry information while fresh data is being fetched from the server.

https://claude.ai/code/session_01RorM9BtWu7NUZB4yzCPFMQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gantt view now respects the active DAG run selection, updating displayed data when the DAG run changes.

* **Bug Fixes**
  * Task retry history is preserved when Gantt chart data is rebuilt, preventing loss of historical retry information during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->