### PR TITLE
chore: release v0.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.6](https://github.com/jvanbuel/flowrs/compare/v0.9.5...v0.9.6) - 2026-03-05
+
+### Fixed
+
+- give task instance names more room in TaskInstance panel
+
 ## [0.9.5](https://github.com/jvanbuel/flowrs/compare/v0.9.4...v0.9.5) - 2026-02-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-tui"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-tui"
-version = "0.9.5"
+version = "0.9.6"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Flowrs is a Terminal User Interface (TUI) for Apache Airflow"


### PR DESCRIPTION



## 🤖 New release

* `flowrs-tui`: 0.9.5 -> 0.9.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.6](https://github.com/jvanbuel/flowrs/compare/v0.9.5...v0.9.6) - 2026-03-05

### Fixed

- give task instance names more room in TaskInstance panel
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout in the TaskInstance panel to provide additional space for task instance names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->