### PR TITLE
feat: add configurable API poll interval

### DIFF
--- a/src/airflow/config/mod.rs
+++ b/src/airflow/config/mod.rs
@@ -62,6 +62,13 @@ pub struct GccConfig {
     pub projects: Option<Vec<String>>,
 }
 
+const TICK_RATE_MS: u64 = 200;
+const MIN_POLL_INTERVAL_MS: u64 = 500;
+
+const fn default_poll_interval_ms() -> u64 {
+    2000
+}
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct FlowrsConfig {
     #[serde(default)]
@@ -69,6 +76,10 @@ pub struct FlowrsConfig {
     #[serde(default)]
     pub managed_services: Vec<ManagedService>,
     pub active_server: Option<String>,
+    /// API poll interval in milliseconds. Controls how often the TUI refreshes
+    /// data from the Airflow API. Minimum 500ms, default 2000ms.
+    #[serde(default = "default_poll_interval_ms")]
+    pub poll_interval_ms: u64,
     #[serde(default)]
     pub gcc: Option<GccConfig>,
     #[serde(skip_serializing)]
@@ -134,9 +145,28 @@ impl FlowrsConfig {
             servers: Vec::new(),
             managed_services: Vec::new(),
             active_server: None,
+            poll_interval_ms: default_poll_interval_ms(),
             gcc: None,
             path: Some(CONFIG_PATHS.write_path.clone()),
         }
+    }
+
+    /// Compute the tick multiplier for API polling based on `poll_interval_ms`.
+    /// Clamps values below the minimum and logs a warning.
+    pub fn poll_tick_multiplier(&self) -> u32 {
+        let interval = if self.poll_interval_ms < MIN_POLL_INTERVAL_MS {
+            log::warn!(
+                "poll_interval_ms ({}) is below minimum ({}), clamping",
+                self.poll_interval_ms,
+                MIN_POLL_INTERVAL_MS
+            );
+            MIN_POLL_INTERVAL_MS
+        } else {
+            self.poll_interval_ms
+        };
+        #[allow(clippy::cast_possible_truncation)]
+        let multiplier = (interval / TICK_RATE_MS) as u32;
+        multiplier.max(1)
     }
 
     pub fn from_file(config_path: Option<&PathBuf>) -> Result<Self> {
@@ -310,6 +340,7 @@ mod tests {
 
     const TEST_CONFIG_CONVEYOR: &str = r#"
 managed_services = ["Conveyor"]
+poll_interval_ms = 2000
 
 [[servers]]
 name = "bla"
@@ -344,6 +375,7 @@ password = "airflow"
             }],
             managed_services: vec![ManagedService::Conveyor],
             active_server: None,
+            poll_interval_ms: default_poll_interval_ms(),
             gcc: None,
             path: None,
         };
@@ -369,5 +401,49 @@ password = "airflow"
 
         let config = config.unwrap();
         assert_eq!(config.path.unwrap(), CONFIG_PATHS.read_path);
+    }
+
+    #[test]
+    fn test_poll_interval_ms_default() {
+        let config = FlowrsConfig::parse_toml(TEST_CONFIG).unwrap();
+        assert_eq!(config.poll_interval_ms, 2000);
+        assert_eq!(config.poll_tick_multiplier(), 10);
+    }
+
+    #[test]
+    fn test_poll_interval_ms_custom() {
+        let toml = r#"
+poll_interval_ms = 5000
+
+[[servers]]
+name = "test"
+endpoint = "http://localhost:8080"
+
+[servers.auth.Basic]
+username = "airflow"
+password = "airflow"
+"#;
+        let config = FlowrsConfig::parse_toml(toml).unwrap();
+        assert_eq!(config.poll_interval_ms, 5000);
+        assert_eq!(config.poll_tick_multiplier(), 25);
+    }
+
+    #[test]
+    fn test_poll_interval_ms_clamped_to_minimum() {
+        let toml = r#"
+poll_interval_ms = 100
+
+[[servers]]
+name = "test"
+endpoint = "http://localhost:8080"
+
+[servers.auth.Basic]
+username = "airflow"
+password = "airflow"
+"#;
+        let config = FlowrsConfig::parse_toml(toml).unwrap();
+        assert_eq!(config.poll_interval_ms, 100);
+        // Should clamp to 500ms minimum → 500/200 = 2
+        assert_eq!(config.poll_tick_multiplier(), 2);
     }
 }

--- a/src/app/model/dagruns.rs
+++ b/src/app/model/dagruns.rs
@@ -41,6 +41,7 @@ pub struct DagRunModel {
     /// Unified popup state (error, commands, or custom for this model)
     pub popup: Popup<DagRunPopUp>,
     ticks: u32,
+    poll_tick_multiplier: u32,
     event_buffer: Vec<KeyCode>,
 }
 
@@ -51,6 +52,7 @@ impl Default for DagRunModel {
             table: FilterableTable::new(),
             popup: Popup::None,
             ticks: 0,
+            poll_tick_multiplier: 10,
             event_buffer: Vec::new(),
         }
     }
@@ -136,8 +138,11 @@ impl DagCodeView {
 }
 
 impl DagRunModel {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(poll_tick_multiplier: u32) -> Self {
+        Self {
+            poll_tick_multiplier,
+            ..Self::default()
+        }
     }
 
     /// Create a text-based duration gauge line.
@@ -349,7 +354,7 @@ impl Model for DagRunModel {
         match event {
             FlowrsEvent::Tick => {
                 self.ticks += 1;
-                if !self.ticks.is_multiple_of(10) {
+                if !self.ticks.is_multiple_of(self.poll_tick_multiplier) {
                     return (Some(FlowrsEvent::Tick), vec![]);
                 }
                 let worker_messages = if let Some(dag_id) = ctx.dag_id() {
@@ -580,7 +585,7 @@ mod tests {
     #[test]
     fn test_sort_dag_runs_by_logical_date() {
         // Create test DAG runs with different states and dates
-        let mut model = DagRunModel::new();
+        let mut model = DagRunModel::default();
 
         // Oldest run: completed (has both logical_date and start_date)
         let oldest_run = DagRun {
@@ -634,7 +639,7 @@ mod tests {
 
     #[test]
     fn test_sort_dag_runs_fallback_to_start_date() {
-        let mut model = DagRunModel::new();
+        let mut model = DagRunModel::default();
 
         // Run with only start_date (logical_date is None)
         let run_with_start = DagRun {
@@ -670,7 +675,7 @@ mod tests {
 
     #[test]
     fn test_filter_and_sort_dag_runs_with_prefix() {
-        let mut model = DagRunModel::new();
+        let mut model = DagRunModel::default();
 
         let run_manual = DagRun {
             dag_id: "test_dag".into(),

--- a/src/app/model/dags.rs
+++ b/src/app/model/dags.rs
@@ -35,6 +35,7 @@ pub struct DagModel {
     /// DAG source code viewer
     pub dag_code: Option<DagCodeView>,
     ticks: u32,
+    poll_tick_multiplier: u32,
     event_buffer: Vec<KeyCode>,
 }
 
@@ -46,14 +47,18 @@ impl Default for DagModel {
             popup: Popup::None,
             dag_code: None,
             ticks: 0,
+            poll_tick_multiplier: 10,
             event_buffer: Vec::new(),
         }
     }
 }
 
 impl DagModel {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(poll_tick_multiplier: u32) -> Self {
+        Self {
+            poll_tick_multiplier,
+            ..Self::default()
+        }
     }
 
     /// Handle model-specific popup (returns messages from popup)
@@ -171,7 +176,7 @@ impl Model for DagModel {
         match event {
             FlowrsEvent::Tick => {
                 self.ticks += 1;
-                if !self.ticks.is_multiple_of(10) {
+                if !self.ticks.is_multiple_of(self.poll_tick_multiplier) {
                     return (Some(FlowrsEvent::Tick), vec![]);
                 }
                 (

--- a/src/app/model/logs.rs
+++ b/src/app/model/logs.rs
@@ -50,20 +50,38 @@ impl ScrollMode {
     }
 }
 
-#[derive(Default)]
 pub struct LogModel {
     pub all: Vec<Log>,
     pub current: usize,
     pub error_popup: Option<ErrorPopup>,
     ticks: u32,
+    poll_tick_multiplier: u32,
     scroll_mode: ScrollMode,
     vertical_scroll_state: ScrollbarState,
     pending_g: bool,
 }
 
+impl Default for LogModel {
+    fn default() -> Self {
+        Self {
+            all: Vec::new(),
+            current: 0,
+            error_popup: None,
+            ticks: 0,
+            poll_tick_multiplier: 10,
+            scroll_mode: ScrollMode::default(),
+            vertical_scroll_state: ScrollbarState::default(),
+            pending_g: false,
+        }
+    }
+}
+
 impl LogModel {
-    pub fn new() -> Self {
-        Self::default() // ScrollMode defaults to Following
+    pub fn new(poll_tick_multiplier: u32) -> Self {
+        Self {
+            poll_tick_multiplier,
+            ..Self::default()
+        }
     }
 
     /// Reset scroll to follow mode (used when navigating to a new context)
@@ -95,7 +113,7 @@ impl Model for LogModel {
         match event {
             FlowrsEvent::Tick => {
                 self.ticks += 1;
-                if !self.ticks.is_multiple_of(10) {
+                if !self.ticks.is_multiple_of(self.poll_tick_multiplier) {
                     return (Some(FlowrsEvent::Tick), vec![]);
                 }
                 if let (Some(dag_id), Some(dag_run_id), Some(task_id), Some(task_try)) = (

--- a/src/app/model/taskinstances.rs
+++ b/src/app/model/taskinstances.rs
@@ -37,6 +37,7 @@ pub struct TaskInstanceModel {
     /// invalidate it when the user navigates to a different DAG or run.
     current_gantt_key: Option<(DagId, DagRunId)>,
     ticks: u32,
+    poll_tick_multiplier: u32,
     event_buffer: Vec<KeyCode>,
     pub task_graph: Option<TaskGraph>,
 }
@@ -49,6 +50,7 @@ impl Default for TaskInstanceModel {
             gantt_data: GanttData::default(),
             current_gantt_key: None,
             ticks: 0,
+            poll_tick_multiplier: 10,
             event_buffer: Vec::new(),
             task_graph: None,
         }
@@ -56,8 +58,11 @@ impl Default for TaskInstanceModel {
 }
 
 impl TaskInstanceModel {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(poll_tick_multiplier: u32) -> Self {
+        Self {
+            poll_tick_multiplier,
+            ..Self::default()
+        }
     }
 
     /// Notify the model which DAG + run is now active.
@@ -229,7 +234,7 @@ impl Model for TaskInstanceModel {
         match event {
             FlowrsEvent::Tick => {
                 self.ticks += 1;
-                if !self.ticks.is_multiple_of(10) {
+                if !self.ticks.is_multiple_of(self.poll_tick_multiplier) {
                     return (Some(FlowrsEvent::Tick), vec![]);
                 }
                 if let (Some(dag_id), Some(dag_run_id)) = (ctx.dag_id(), ctx.dag_run_id()) {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -157,15 +157,17 @@ impl App {
             None => NavigationContext::None,
         };
 
+        let poll_tick_multiplier = config.poll_tick_multiplier();
+
         Self {
             config,
             environment_state: EnvironmentStateContainer::new(),
             nav_context,
-            dags: DagModel::new(),
+            dags: DagModel::new(poll_tick_multiplier),
             configs: ConfigModel::new_with_errors(&servers, errors),
-            dagruns: DagRunModel::new(),
-            task_instances: TaskInstanceModel::new(),
-            logs: LogModel::new(),
+            dagruns: DagRunModel::new(poll_tick_multiplier),
+            task_instances: TaskInstanceModel::new(poll_tick_multiplier),
+            logs: LogModel::new(poll_tick_multiplier),
             active_panel: if has_active_server {
                 Panel::Dag
             } else {

--- a/src/commands/config/model.rs
+++ b/src/commands/config/model.rs
@@ -7,6 +7,20 @@ use strum::EnumIter;
 use url::Url;
 
 #[derive(Parser, Debug)]
+#[clap(args_conflicts_with_subcommands = true)]
+pub struct ConfigArgs {
+    #[clap(subcommand)]
+    pub command: Option<ConfigCommand>,
+
+    /// API poll interval in milliseconds (minimum 500)
+    #[clap(long)]
+    pub poll_interval_ms: Option<u64>,
+
+    #[clap(short, long)]
+    pub file: Option<String>,
+}
+
+#[derive(Parser, Debug)]
 pub enum ConfigCommand {
     Add(AddCommand),
     #[clap(alias = "rm")]
@@ -16,6 +30,42 @@ pub enum ConfigCommand {
     List(ListCommand),
     Enable(ManagedServiceCommand),
     Disable(ManagedServiceCommand),
+}
+
+impl ConfigArgs {
+    pub async fn run(&self) -> Result<()> {
+        match &self.command {
+            Some(cmd) => cmd.run().await,
+            None => self.run_global_settings(),
+        }
+    }
+
+    fn run_global_settings(&self) -> Result<()> {
+        use std::path::PathBuf;
+
+        use crate::airflow::config::FlowrsConfig;
+
+        let path = self.file.as_ref().map(PathBuf::from);
+        let mut config = FlowrsConfig::from_file(path.as_ref())?;
+
+        let has_changes = self.poll_interval_ms.is_some();
+
+        if !has_changes {
+            println!("poll_interval_ms = {}", config.poll_interval_ms);
+            return Ok(());
+        }
+
+        if let Some(value) = self.poll_interval_ms {
+            if value < 500 {
+                anyhow::bail!("poll_interval_ms must be at least 500 (got {value})");
+            }
+            config.poll_interval_ms = value;
+            config.write_to_file()?;
+            println!("poll_interval_ms set to {value}");
+        }
+
+        Ok(())
+    }
 }
 
 impl ConfigCommand {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ mod ui;
 
 use airflow::config::paths::ConfigPaths;
 use anyhow::Result;
-use commands::config::model::ConfigCommand;
+use commands::config::model::ConfigArgs;
 use commands::run::RunCommand;
 
 pub static CONFIG_PATHS: LazyLock<ConfigPaths> = LazyLock::new(ConfigPaths::resolve);
@@ -33,8 +33,7 @@ struct FlowrsApp {
 #[derive(Parser)]
 enum FlowrsCommand {
     Run(RunCommand),
-    #[clap(subcommand)]
-    Config(ConfigCommand),
+    Config(ConfigArgs),
 }
 
 impl FlowrsApp {


### PR DESCRIPTION
Add `poll_interval_ms` top-level config option (default 2000ms) to control how often the TUI refreshes data from the Airflow API. Values below 500ms are clamped with a warning. Fully backwards compatible with existing configs.

Address #603 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable API polling interval setting, enabling users to customize how frequently the application checks for updates (with a minimum threshold of 500ms enforced)
  * Introduced a config command interface to manage polling interval settings globally

<!-- end of auto-generated comment: release notes by coderabbit.ai -->