### PR TITLE
Update README w/ Homebrew instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Flowrs is a TUI application for [Apache Airflow](https://airflow.apache.org/). I
 You can install `flowrs` via Homebrew if you're on macOS / Linux / WSL2:
 
 ```
-brew tap jvanbuel/flowrs
 brew install flowrs
 ```
 
@@ -55,4 +54,4 @@ If you're self-hosting an Airflow instance, or your favorite managed service is 
 
 This creates an entry in your configuration file at `$XDG_CONFIG_HOME/flowrs/config.toml` (following the XDG Base Directory Specification, which defaults to `~/.config/flowrs/config.toml`). For backwards compatibility, flowrs also reads from `~/.flowrs` if the XDG location doesn't exist. If you have multiple Airflow servers configured, you can easily switch between them in `flowrs` configuration screen.
 
-Only basic authentication and bearer token authentication are supported. When selecting the bearer token option, you can either provide a static token or a command that generates a token.
+Flowrs supports authenticating with HTTP Basic Auth or using bearer tokens. When selecting the bearer token option, you can either provide a static token or a command that generates a token.


### PR DESCRIPTION
Flowrs is now [available][] directly via [Homebrew][].

[available]: https://github.com/Homebrew/homebrew-core/commit/544d23ef7ef6753cb69bc8fce328bd9d0ac1ec87

[Homebrew]: https://brew.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed Homebrew tap installation instruction from setup documentation, simplifying installation steps.
  * Clarified authentication documentation with explicit description of supported methods: HTTP Basic Auth or bearer tokens (static or command-generated).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->