### PR TITLE
improve support for light theme

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,6 +1,6 @@
 use crate::app::state::{App, Panel};
 use crate::ui::tabs::{TabBar, TAB_BAR_HEIGHT};
-use crate::ui::theme::{HEADER_BG, HEADER_FG, TEXT_PRIMARY};
+use crate::ui::theme::{HEADER_BG, HEADER_FG, SURFACE_STYLE, TEXT_PRIMARY};
 use init_screen::render_init_screen;
 use ratatui::layout::{Constraint, Layout};
 use ratatui::style::{Modifier, Style};
@@ -24,6 +24,10 @@ pub fn draw_ui(f: &mut Frame, app: &Arc<Mutex<App>>) {
         render_init_screen(f, app.ticks);
         return;
     }
+
+    // Fill the entire frame with the dark surface background so the app
+    // looks correct even when running in a light-mode terminal.
+    f.render_widget(Block::default().style(SURFACE_STYLE), f.area());
 
     // Split area vertically: header (1 line), tab bar (3 lines), panel (remaining)
     let [top_line, tab_area, panel_area] = Layout::vertical([


### PR DESCRIPTION
I noticed that this TUI is hardcoded to be a dark theme.
I did try to add support for proper automatic theme switching, but that ended up being too big of an endeavour.
Due to this, I decided to go the path of least resistance, which was adding a permanent dark background, so that even with a light mode terminal, it would be possible to use the TUI reasonably.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced UI background rendering with consistent, full-frame styling across light and dark terminal themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->