### PR TITLE
fix: asset-triggered DAGs appear with type 'unknown'

### DIFF
--- a/src/airflow/model/common/dagrun.rs
+++ b/src/airflow/model/common/dagrun.rs
@@ -57,6 +57,7 @@ pub enum RunType {
     Manual,
     Backfill,
     DatasetTriggered,
+    AssetTriggered,
     /// Catch-all for unknown/future run types returned by the API.
     #[default]
     #[serde(other)]
@@ -70,6 +71,7 @@ impl fmt::Display for RunType {
             Self::Manual => write!(f, "manual"),
             Self::Backfill => write!(f, "backfill"),
             Self::DatasetTriggered => write!(f, "dataset_triggered"),
+            Self::AssetTriggered => write!(f, "asset_triggered"),
             Self::Unknown => write!(f, "unknown"),
         }
     }
@@ -82,6 +84,7 @@ impl From<&str> for RunType {
             "manual" => Self::Manual,
             "backfill" => Self::Backfill,
             "dataset_triggered" => Self::DatasetTriggered,
+            "asset_triggered" => Self::AssetTriggered,
             _ => Self::Unknown,
         }
     }

--- a/src/app/model/filter/impls.rs
+++ b/src/app/model/filter/impls.rs
@@ -24,7 +24,7 @@ impl_filterable! {
     primary: dag_run_id => |s: &DagRun| Some(s.dag_run_id.to_string()),
     fields: [
         state: enum["running", "success", "failed", "queued", "up_for_retry"] => |s: &DagRun| Some(s.state.to_string()),
-        run_type: enum["scheduled", "manual", "backfill", "dataset_triggered"] => |s: &DagRun| Some(s.run_type.to_string()),
+        run_type: enum["scheduled", "manual", "backfill", "dataset_triggered", "asset_triggered"] => |s: &DagRun| Some(s.run_type.to_string()),
     ]
 }
 


### PR DESCRIPTION
Fixes #610 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for asset-triggered DAG runs, enabling workflows triggered by asset events.
  * Users can now filter DAG runs by the new "asset triggered" run type alongside existing filter options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->