### PR TITLE
refactor: reduce mutex lock hold times in worker handlers

### DIFF
--- a/src/app/model/taskinstances/mod.rs
+++ b/src/app/model/taskinstances/mod.rs
@@ -80,29 +80,19 @@ impl TaskInstanceModel {
     /// Rebuild Gantt data from the current task instance list.
     /// Returns task IDs that have retries (`try_number` > 1) for fetching detailed tries.
     pub fn rebuild_gantt(&mut self) -> Vec<TaskId> {
-        let (new_gantt, retried) = Self::build_gantt(&self.table.all, &self.gantt_data);
-        self.gantt_data = new_gantt;
-        retried
-    }
-
-    /// Build Gantt data from task instances without requiring `&mut self`.
-    /// This allows building the gantt outside a lock and swapping it in later.
-    /// Returns the new gantt data and task IDs that have retries.
-    pub fn build_gantt(
-        task_instances: &[TaskInstance],
-        existing_gantt: &GanttData,
-    ) -> (GanttData, Vec<TaskId>) {
-        let mut new_gantt = GanttData::from_task_instances(task_instances);
+        let mut new_gantt = GanttData::from_task_instances(&self.table.all);
 
         let mut seen = HashSet::new();
-        let retried: Vec<TaskId> = task_instances
+        let retried: Vec<TaskId> = self
+            .table
+            .all
             .iter()
             .filter(|ti| ti.try_number > 1 && seen.insert(ti.task_id.clone()))
             .map(|ti| ti.task_id.clone())
             .collect();
 
         for task_id in &retried {
-            if let Some(cached_tries) = existing_gantt.task_tries.get(task_id) {
+            if let Some(cached_tries) = self.gantt_data.task_tries.get(task_id) {
                 let new_tries = new_gantt.task_tries.get(task_id);
                 if cached_tries.len() > new_tries.map_or(0, Vec::len) {
                     new_gantt
@@ -113,7 +103,8 @@ impl TaskInstanceModel {
         }
 
         new_gantt.recompute_window();
-        (new_gantt, retried)
+        self.gantt_data = new_gantt;
+        retried
     }
 
     /// Mark a task instance with a new status (optimistic update)

--- a/src/app/model/taskinstances/mod.rs
+++ b/src/app/model/taskinstances/mod.rs
@@ -80,19 +80,29 @@ impl TaskInstanceModel {
     /// Rebuild Gantt data from the current task instance list.
     /// Returns task IDs that have retries (`try_number` > 1) for fetching detailed tries.
     pub fn rebuild_gantt(&mut self) -> Vec<TaskId> {
-        let mut new_gantt = GanttData::from_task_instances(&self.table.all);
+        let (new_gantt, retried) = Self::build_gantt(&self.table.all, &self.gantt_data);
+        self.gantt_data = new_gantt;
+        retried
+    }
+
+    /// Build Gantt data from task instances without requiring `&mut self`.
+    /// This allows building the gantt outside a lock and storing it later.
+    /// Returns the new gantt data and task IDs that have retries.
+    pub fn build_gantt(
+        task_instances: &[TaskInstance],
+        existing_gantt: &GanttData,
+    ) -> (GanttData, Vec<TaskId>) {
+        let mut new_gantt = GanttData::from_task_instances(task_instances);
 
         let mut seen = HashSet::new();
-        let retried: Vec<TaskId> = self
-            .table
-            .all
+        let retried: Vec<TaskId> = task_instances
             .iter()
             .filter(|ti| ti.try_number > 1 && seen.insert(ti.task_id.clone()))
             .map(|ti| ti.task_id.clone())
             .collect();
 
         for task_id in &retried {
-            if let Some(cached_tries) = self.gantt_data.task_tries.get(task_id) {
+            if let Some(cached_tries) = existing_gantt.task_tries.get(task_id) {
                 let new_tries = new_gantt.task_tries.get(task_id);
                 if cached_tries.len() > new_tries.map_or(0, Vec::len) {
                     new_gantt
@@ -103,8 +113,7 @@ impl TaskInstanceModel {
         }
 
         new_gantt.recompute_window();
-        self.gantt_data = new_gantt;
-        retried
+        (new_gantt, retried)
     }
 
     /// Mark a task instance with a new status (optimistic update)

--- a/src/app/model/taskinstances/mod.rs
+++ b/src/app/model/taskinstances/mod.rs
@@ -80,19 +80,29 @@ impl TaskInstanceModel {
     /// Rebuild Gantt data from the current task instance list.
     /// Returns task IDs that have retries (`try_number` > 1) for fetching detailed tries.
     pub fn rebuild_gantt(&mut self) -> Vec<TaskId> {
-        let mut new_gantt = GanttData::from_task_instances(&self.table.all);
+        let (new_gantt, retried) = Self::build_gantt(&self.table.all, &self.gantt_data);
+        self.gantt_data = new_gantt;
+        retried
+    }
+
+    /// Build Gantt data from task instances without requiring `&mut self`.
+    /// This allows building the gantt outside a lock and swapping it in later.
+    /// Returns the new gantt data and task IDs that have retries.
+    pub fn build_gantt(
+        task_instances: &[TaskInstance],
+        existing_gantt: &GanttData,
+    ) -> (GanttData, Vec<TaskId>) {
+        let mut new_gantt = GanttData::from_task_instances(task_instances);
 
         let mut seen = HashSet::new();
-        let retried: Vec<TaskId> = self
-            .table
-            .all
+        let retried: Vec<TaskId> = task_instances
             .iter()
             .filter(|ti| ti.try_number > 1 && seen.insert(ti.task_id.clone()))
             .map(|ti| ti.task_id.clone())
             .collect();
 
         for task_id in &retried {
-            if let Some(cached_tries) = self.gantt_data.task_tries.get(task_id) {
+            if let Some(cached_tries) = existing_gantt.task_tries.get(task_id) {
                 let new_tries = new_gantt.task_tries.get(task_id);
                 if cached_tries.len() > new_tries.map_or(0, Vec::len) {
                     new_gantt
@@ -103,8 +113,7 @@ impl TaskInstanceModel {
         }
 
         new_gantt.recompute_window();
-        self.gantt_data = new_gantt;
-        retried
+        (new_gantt, retried)
     }
 
     /// Mark a task instance with a new status (optimistic update)

--- a/src/app/model/taskinstances/mod.rs
+++ b/src/app/model/taskinstances/mod.rs
@@ -2,8 +2,6 @@ pub mod commands;
 pub mod popup;
 mod render;
 
-use std::collections::HashSet;
-
 use commands::TASK_COMMAND_POP_UP;
 use crossterm::event::KeyCode;
 use log::debug;
@@ -75,45 +73,6 @@ impl TaskInstanceModel {
         if let Some(graph) = &self.task_graph {
             sort_task_instances(&mut self.table.all, graph);
         }
-    }
-
-    /// Rebuild Gantt data from the current task instance list.
-    /// Returns task IDs that have retries (`try_number` > 1) for fetching detailed tries.
-    pub fn rebuild_gantt(&mut self) -> Vec<TaskId> {
-        let (new_gantt, retried) = Self::build_gantt(&self.table.all, &self.gantt_data);
-        self.gantt_data = new_gantt;
-        retried
-    }
-
-    /// Build Gantt data from task instances without requiring `&mut self`.
-    /// This allows building the gantt outside a lock and storing it later.
-    /// Returns the new gantt data and task IDs that have retries.
-    pub fn build_gantt(
-        task_instances: &[TaskInstance],
-        existing_gantt: &GanttData,
-    ) -> (GanttData, Vec<TaskId>) {
-        let mut new_gantt = GanttData::from_task_instances(task_instances);
-
-        let mut seen = HashSet::new();
-        let retried: Vec<TaskId> = task_instances
-            .iter()
-            .filter(|ti| ti.try_number > 1 && seen.insert(ti.task_id.clone()))
-            .map(|ti| ti.task_id.clone())
-            .collect();
-
-        for task_id in &retried {
-            if let Some(cached_tries) = existing_gantt.task_tries.get(task_id) {
-                let new_tries = new_gantt.task_tries.get(task_id);
-                if cached_tries.len() > new_tries.map_or(0, Vec::len) {
-                    new_gantt
-                        .task_tries
-                        .insert(task_id.clone(), cached_tries.clone());
-                }
-            }
-        }
-
-        new_gantt.recompute_window();
-        (new_gantt, retried)
     }
 
     /// Mark a task instance with a new status (optimistic update)

--- a/src/app/worker/dags.rs
+++ b/src/app/worker/dags.rs
@@ -75,36 +75,32 @@ pub async fn handle_update_dags_and_stats(
             client.get_dag_stats(refs).await
         });
 
-        {
-            let mut app = app.lock().unwrap();
-            match dag_list_result {
-                Ok(dag_list) => {
-                    if let Some(env) = app.environment_state.environments.get_mut(env_name) {
-                        env.replace_dags(dag_list.dags);
-                    }
+        let mut app = app.lock().unwrap();
+
+        match dag_list_result {
+            Ok(dag_list) => {
+                if let Some(env) = app.environment_state.environments.get_mut(env_name) {
+                    env.replace_dags(dag_list.dags);
                 }
-                Err(e) => {
-                    app.dags.popup.show_error(vec![e.to_string()]);
-                }
+            }
+            Err(e) => {
+                app.dags.popup.show_error(vec![e.to_string()]);
             }
         }
 
-        {
-            let mut app = app.lock().unwrap();
-            match dag_stats_result {
-                Ok(dag_stats) => {
-                    if let Some(env) = app.environment_state.environments.get_mut(env_name) {
-                        for dag_stats in dag_stats.dags {
-                            env.update_dag_stats(
-                                &DagId::from(dag_stats.dag_id.clone()),
-                                dag_stats.stats,
-                            );
-                        }
+        match dag_stats_result {
+            Ok(dag_stats) => {
+                if let Some(env) = app.environment_state.environments.get_mut(env_name) {
+                    for dag_stats in dag_stats.dags {
+                        env.update_dag_stats(
+                            &DagId::from(dag_stats.dag_id.clone()),
+                            dag_stats.stats,
+                        );
                     }
                 }
-                Err(e) => {
-                    log::error!("Failed to fetch dag stats: {e}");
-                }
+            }
+            Err(e) => {
+                log::error!("Failed to fetch dag stats: {e}");
             }
         }
     }

--- a/src/app/worker/dags.rs
+++ b/src/app/worker/dags.rs
@@ -75,32 +75,36 @@ pub async fn handle_update_dags_and_stats(
             client.get_dag_stats(refs).await
         });
 
-        let mut app = app.lock().unwrap();
-
-        match dag_list_result {
-            Ok(dag_list) => {
-                if let Some(env) = app.environment_state.environments.get_mut(env_name) {
-                    env.replace_dags(dag_list.dags);
+        {
+            let mut app = app.lock().unwrap();
+            match dag_list_result {
+                Ok(dag_list) => {
+                    if let Some(env) = app.environment_state.environments.get_mut(env_name) {
+                        env.replace_dags(dag_list.dags);
+                    }
                 }
-            }
-            Err(e) => {
-                app.dags.popup.show_error(vec![e.to_string()]);
+                Err(e) => {
+                    app.dags.popup.show_error(vec![e.to_string()]);
+                }
             }
         }
 
-        match dag_stats_result {
-            Ok(dag_stats) => {
-                if let Some(env) = app.environment_state.environments.get_mut(env_name) {
-                    for dag_stats in dag_stats.dags {
-                        env.update_dag_stats(
-                            &DagId::from(dag_stats.dag_id.clone()),
-                            dag_stats.stats,
-                        );
+        {
+            let mut app = app.lock().unwrap();
+            match dag_stats_result {
+                Ok(dag_stats) => {
+                    if let Some(env) = app.environment_state.environments.get_mut(env_name) {
+                        for dag_stats in dag_stats.dags {
+                            env.update_dag_stats(
+                                &DagId::from(dag_stats.dag_id.clone()),
+                                dag_stats.stats,
+                            );
+                        }
                     }
                 }
-            }
-            Err(e) => {
-                log::error!("Failed to fetch dag stats: {e}");
+                Err(e) => {
+                    log::error!("Failed to fetch dag stats: {e}");
+                }
             }
         }
     }

--- a/src/app/worker/logs.rs
+++ b/src/app/worker/logs.rs
@@ -26,8 +26,9 @@ pub async fn handle_update_task_logs(
         join_all((1..=task_try).map(|i| client.get_task_logs(dag_id, dag_run_id, task_id, i)))
             .await;
 
-    let mut app = app.lock().unwrap();
+    // Collect logs and errors outside the lock
     let mut collected_logs = Vec::new();
+    let mut errors = Vec::new();
     for log in logs {
         match log {
             Ok(log) => {
@@ -36,9 +37,15 @@ pub async fn handle_update_task_logs(
             }
             Err(e) => {
                 debug!("Error getting logs: {e}");
-                app.logs.error_popup = Some(ErrorPopup::from_strings(vec![e.to_string()]));
+                errors.push(e.to_string());
             }
         }
+    }
+
+    let mut app = app.lock().unwrap();
+
+    if !errors.is_empty() {
+        app.logs.error_popup = Some(ErrorPopup::from_strings(errors));
     }
 
     // Store logs in the originating environment, not the active one

--- a/src/app/worker/taskinstances.rs
+++ b/src/app/worker/taskinstances.rs
@@ -1,11 +1,12 @@
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
+use futures::future::join_all;
 use log::debug;
 
-use crate::airflow::model::common::{DagId, DagRunId, TaskId, TaskInstanceState};
+use crate::airflow::model::common::{DagId, DagRunId, GanttData, TaskId, TaskInstanceState};
 use crate::airflow::traits::AirflowClient;
 use crate::app::model::taskinstances::popup::mark::MarkState;
-use crate::app::model::taskinstances::TaskInstanceModel;
 use crate::app::state::App;
 
 /// Handle updating the list of task instances for a specific DAG run.
@@ -13,8 +14,9 @@ use crate::app::state::App;
 /// `env_name` identifies which environment initiated this request, ensuring
 /// results are written to the correct environment even if the active one changes.
 ///
-/// After syncing task instances, this also rebuilds the Gantt chart data and
-/// fetches detailed try history for tasks that have retries.
+/// Fetches task instances, then fetches detailed try history for any retried
+/// tasks, builds the Gantt chart from complete data, and stores everything
+/// atomically under a single lock.
 pub async fn handle_update_task_instances(
     app: &Arc<Mutex<App>>,
     client: &Arc<dyn AirflowClient>,
@@ -22,10 +24,9 @@ pub async fn handle_update_task_instances(
     dag_run_id: &DagRunId,
     env_name: &str,
 ) {
-    let task_instances = client.list_task_instances(dag_id, dag_run_id).await;
-
-    let task_instances = match task_instances {
-        Ok(task_instances) => task_instances.task_instances,
+    // 1. Fetch task instances (no lock)
+    let task_instances = match client.list_task_instances(dag_id, dag_run_id).await {
+        Ok(list) => list.task_instances,
         Err(e) => {
             log::error!("Error getting task instances: {e:?}");
             let mut app = app.lock().unwrap();
@@ -34,30 +35,42 @@ pub async fn handle_update_task_instances(
         }
     };
 
-    // Snapshot existing gantt data for cache merging, then build new gantt outside the lock
-    let existing_gantt = {
-        let app = app.lock().unwrap();
-        app.task_instances.gantt_data.clone()
-    };
-    let (new_gantt, retried_task_ids) =
-        TaskInstanceModel::build_gantt(&task_instances, &existing_gantt);
+    // 2. Identify retried tasks and fetch their tries concurrently (no lock)
+    let mut seen = HashSet::new();
+    let retried_task_ids: Vec<&TaskId> = task_instances
+        .iter()
+        .filter(|ti| ti.try_number > 1 && seen.insert(&ti.task_id))
+        .map(|ti| &ti.task_id)
+        .collect();
 
-    // Store everything atomically under a single lock
-    let retried_task_ids = {
-        let mut app = app.lock().unwrap();
-        if let Some(env) = app.environment_state.environments.get_mut(env_name) {
-            env.replace_task_instances(dag_id, dag_run_id, task_instances);
-        }
-        if app.environment_state.active_environment.as_deref() == Some(env_name) {
-            app.sync_panel(&crate::app::state::Panel::TaskInstance);
-        }
-        app.task_instances.gantt_data = new_gantt;
+    let tries_results = join_all(
         retried_task_ids
-    };
+            .iter()
+            .map(|task_id| client.list_task_instance_tries(dag_id, dag_run_id, task_id)),
+    )
+    .await;
 
-    // Fetch detailed tries for tasks that have retried (try_number > 1)
-    if !retried_task_ids.is_empty() {
-        handle_update_task_instance_tries(app, client, dag_id, dag_run_id, retried_task_ids).await;
+    // 3. Build gantt from task instances, then overlay detailed tries (no lock)
+    let mut gantt = GanttData::from_task_instances(&task_instances);
+    for (task_id, result) in retried_task_ids.iter().zip(tries_results) {
+        match result {
+            Ok(tries) => {
+                gantt.update_tries(task_id, tries);
+            }
+            Err(e) => {
+                log::warn!("Failed to fetch tries for task {task_id}: {e}");
+            }
+        }
+    }
+
+    // 4. Store everything atomically under a single lock
+    let mut app = app.lock().unwrap();
+    if let Some(env) = app.environment_state.environments.get_mut(env_name) {
+        env.replace_task_instances(dag_id, dag_run_id, task_instances);
+    }
+    if app.environment_state.active_environment.as_deref() == Some(env_name) {
+        app.sync_panel(&crate::app::state::Panel::TaskInstance);
+        app.task_instances.gantt_data = gantt;
     }
 }
 
@@ -103,33 +116,5 @@ pub async fn handle_mark_task_instance(
         debug!("Error marking task_instance: {e}");
         let mut app = app.lock().unwrap();
         app.task_instances.popup.show_error(vec![e.to_string()]);
-    }
-}
-
-/// Handle fetching task instance tries for tasks with retries (`try_number` > 1).
-/// Updates the Gantt chart data with full retry history for each task.
-pub async fn handle_update_task_instance_tries(
-    app: &Arc<Mutex<App>>,
-    client: &Arc<dyn AirflowClient>,
-    dag_id: &DagId,
-    dag_run_id: &DagRunId,
-    task_ids: Vec<TaskId>,
-) {
-    debug!("Fetching tries for {} tasks with retries", task_ids.len());
-
-    for task_id in &task_ids {
-        match client
-            .list_task_instance_tries(dag_id, dag_run_id, task_id)
-            .await
-        {
-            Ok(tries) => {
-                let mut app = app.lock().unwrap();
-                app.task_instances.gantt_data.update_tries(task_id, tries);
-            }
-            Err(e) => {
-                log::warn!("Failed to fetch tries for task {task_id}: {e}");
-                // Non-fatal: the Gantt chart will still show the current try
-            }
-        }
     }
 }

--- a/src/app/worker/taskinstances.rs
+++ b/src/app/worker/taskinstances.rs
@@ -5,6 +5,7 @@ use log::debug;
 use crate::airflow::model::common::{DagId, DagRunId, TaskId, TaskInstanceState};
 use crate::airflow::traits::AirflowClient;
 use crate::app::model::taskinstances::popup::mark::MarkState;
+use crate::app::model::taskinstances::TaskInstanceModel;
 use crate::app::state::App;
 
 /// Handle updating the list of task instances for a specific DAG run.
@@ -22,7 +23,9 @@ pub async fn handle_update_task_instances(
     env_name: &str,
 ) {
     let task_instances = client.list_task_instances(dag_id, dag_run_id).await;
-    let retried_task_ids = {
+
+    // Extract data needed for gantt construction under a short lock, then build outside
+    let (task_instance_list, existing_gantt) = {
         let mut app = app.lock().unwrap();
         match task_instances {
             Ok(task_instances) => {
@@ -34,8 +37,10 @@ pub async fn handle_update_task_instances(
                 if app.environment_state.active_environment.as_deref() == Some(env_name) {
                     app.sync_panel(&crate::app::state::Panel::TaskInstance);
                 }
-                // Rebuild Gantt data from current task instances and collect retried task IDs
-                app.task_instances.rebuild_gantt()
+                // Snapshot data needed for gantt construction
+                let all = app.task_instances.table.all.clone();
+                let gantt = app.task_instances.gantt_data.clone();
+                (all, gantt)
             }
             Err(e) => {
                 log::error!("Error getting task instances: {e:?}");
@@ -44,6 +49,16 @@ pub async fn handle_update_task_instances(
             }
         }
     };
+
+    // Build gantt data outside the lock
+    let (new_gantt, retried_task_ids) =
+        TaskInstanceModel::build_gantt(&task_instance_list, &existing_gantt);
+
+    // Swap in the new gantt data under a brief lock
+    {
+        let mut app = app.lock().unwrap();
+        app.task_instances.gantt_data = new_gantt;
+    }
 
     // Fetch detailed tries for tasks that have retried (try_number > 1)
     if !retried_task_ids.is_empty() {

--- a/src/app/worker/taskinstances.rs
+++ b/src/app/worker/taskinstances.rs
@@ -5,7 +5,6 @@ use log::debug;
 use crate::airflow::model::common::{DagId, DagRunId, TaskId, TaskInstanceState};
 use crate::airflow::traits::AirflowClient;
 use crate::app::model::taskinstances::popup::mark::MarkState;
-use crate::app::model::taskinstances::TaskInstanceModel;
 use crate::app::state::App;
 
 /// Handle updating the list of task instances for a specific DAG run.
@@ -23,9 +22,7 @@ pub async fn handle_update_task_instances(
     env_name: &str,
 ) {
     let task_instances = client.list_task_instances(dag_id, dag_run_id).await;
-
-    // Extract data needed for gantt construction under a short lock, then build outside
-    let (task_instance_list, existing_gantt) = {
+    let retried_task_ids = {
         let mut app = app.lock().unwrap();
         match task_instances {
             Ok(task_instances) => {
@@ -37,10 +34,8 @@ pub async fn handle_update_task_instances(
                 if app.environment_state.active_environment.as_deref() == Some(env_name) {
                     app.sync_panel(&crate::app::state::Panel::TaskInstance);
                 }
-                // Snapshot data needed for gantt construction
-                let all = app.task_instances.table.all.clone();
-                let gantt = app.task_instances.gantt_data.clone();
-                (all, gantt)
+                // Rebuild Gantt data from current task instances and collect retried task IDs
+                app.task_instances.rebuild_gantt()
             }
             Err(e) => {
                 log::error!("Error getting task instances: {e:?}");
@@ -49,16 +44,6 @@ pub async fn handle_update_task_instances(
             }
         }
     };
-
-    // Build gantt data outside the lock
-    let (new_gantt, retried_task_ids) =
-        TaskInstanceModel::build_gantt(&task_instance_list, &existing_gantt);
-
-    // Swap in the new gantt data under a brief lock
-    {
-        let mut app = app.lock().unwrap();
-        app.task_instances.gantt_data = new_gantt;
-    }
 
     // Fetch detailed tries for tasks that have retried (try_number > 1)
     if !retried_task_ids.is_empty() {

--- a/src/app/worker/taskinstances.rs
+++ b/src/app/worker/taskinstances.rs
@@ -5,6 +5,7 @@ use log::debug;
 use crate::airflow::model::common::{DagId, DagRunId, TaskId, TaskInstanceState};
 use crate::airflow::traits::AirflowClient;
 use crate::app::model::taskinstances::popup::mark::MarkState;
+use crate::app::model::taskinstances::TaskInstanceModel;
 use crate::app::state::App;
 
 /// Handle updating the list of task instances for a specific DAG run.
@@ -22,27 +23,36 @@ pub async fn handle_update_task_instances(
     env_name: &str,
 ) {
     let task_instances = client.list_task_instances(dag_id, dag_run_id).await;
+
+    let task_instances = match task_instances {
+        Ok(task_instances) => task_instances.task_instances,
+        Err(e) => {
+            log::error!("Error getting task instances: {e:?}");
+            let mut app = app.lock().unwrap();
+            app.task_instances.popup.show_error(vec![e.to_string()]);
+            return;
+        }
+    };
+
+    // Snapshot existing gantt data for cache merging, then build new gantt outside the lock
+    let existing_gantt = {
+        let app = app.lock().unwrap();
+        app.task_instances.gantt_data.clone()
+    };
+    let (new_gantt, retried_task_ids) =
+        TaskInstanceModel::build_gantt(&task_instances, &existing_gantt);
+
+    // Store everything atomically under a single lock
     let retried_task_ids = {
         let mut app = app.lock().unwrap();
-        match task_instances {
-            Ok(task_instances) => {
-                // Replace task instances in the originating environment, not the active one
-                if let Some(env) = app.environment_state.environments.get_mut(env_name) {
-                    env.replace_task_instances(dag_id, dag_run_id, task_instances.task_instances);
-                }
-                // Only sync panel data if this environment is still active
-                if app.environment_state.active_environment.as_deref() == Some(env_name) {
-                    app.sync_panel(&crate::app::state::Panel::TaskInstance);
-                }
-                // Rebuild Gantt data from current task instances and collect retried task IDs
-                app.task_instances.rebuild_gantt()
-            }
-            Err(e) => {
-                log::error!("Error getting task instances: {e:?}");
-                app.task_instances.popup.show_error(vec![e.to_string()]);
-                return;
-            }
+        if let Some(env) = app.environment_state.environments.get_mut(env_name) {
+            env.replace_task_instances(dag_id, dag_run_id, task_instances);
         }
+        if app.environment_state.active_environment.as_deref() == Some(env_name) {
+            app.sync_panel(&crate::app::state::Panel::TaskInstance);
+        }
+        app.task_instances.gantt_data = new_gantt;
+        retried_task_ids
     };
 
     // Fetch detailed tries for tasks that have retried (try_number > 1)


### PR DESCRIPTION
Move expensive operations outside lock scopes to minimize contention
between the event loop and async worker tasks:

- taskinstances: extract build_gantt as a static method so gantt
  construction happens outside the lock, with only the final swap
  holding the mutex
- dags: split the warm-cache path into two separate lock scopes so
  DAG list and stats updates don't hold a single long lock
- logs: collect and process log results outside the lock, acquiring
  it only to store results and display errors

https://claude.ai/code/session_01QDDurT2gk9qvJzQA71fzwd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when collecting logs and task updates to avoid UI blocking and reduce intermittent errors.

* **Performance**
  * Faster, more reliable task instance updates via concurrent fetching and atomic state updates, reducing UI stalls.

* **Refactor**
  * Consolidated task update processing and simplified Gantt/chart update flow for more consistent timeline rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->