### PR TITLE
feat: add DAG dependency graph visualization popup

### DIFF
--- a/src/airflow/graph.rs
+++ b/src/airflow/graph.rs
@@ -129,7 +129,7 @@ impl TaskGraph {
         tasks
     }
 
-    /// Returns true if the graph has any tasks.
+    /// Returns true if the graph contains no tasks.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.task_levels.is_empty()

--- a/src/airflow/graph.rs
+++ b/src/airflow/graph.rs
@@ -8,6 +8,8 @@ use super::model::common::{Task, TaskInstance};
 #[derive(Default, Debug, Clone)]
 pub struct TaskGraph {
     task_levels: HashMap<String, usize>,
+    downstream: HashMap<String, Vec<String>>,
+    max_level: usize,
 }
 
 impl TaskGraph {
@@ -75,13 +77,62 @@ impl TaskGraph {
             level += 1;
         }
 
-        Self { task_levels }
+        let max_level = task_levels.values().copied().max().unwrap_or(0);
+
+        // Store downstream edges (only for tasks that exist in the graph)
+        let mut downstream: HashMap<String, Vec<String>> = HashMap::new();
+        for task in tasks {
+            let edges: Vec<String> = task
+                .downstream_task_ids
+                .iter()
+                .filter(|id| task_levels.contains_key(id.as_str()))
+                .cloned()
+                .collect();
+            downstream.insert(task.task_id.clone(), edges);
+        }
+
+        Self {
+            task_levels,
+            downstream,
+            max_level,
+        }
     }
 
     /// Get the topological level of a task. Returns None if task not in graph.
     #[must_use]
     pub fn level(&self, task_id: &str) -> Option<usize> {
         self.task_levels.get(task_id).copied()
+    }
+
+    /// Get the maximum topological level in the graph.
+    #[must_use]
+    pub fn max_level(&self) -> usize {
+        self.max_level
+    }
+
+    /// Get downstream task IDs for a given task.
+    #[must_use]
+    pub fn downstream(&self, task_id: &str) -> &[String] {
+        self.downstream.get(task_id).map_or(&[], |v| v.as_slice())
+    }
+
+    /// Get all task IDs at a given level, sorted alphabetically.
+    #[must_use]
+    pub fn tasks_at_level(&self, level: usize) -> Vec<String> {
+        let mut tasks: Vec<String> = self
+            .task_levels
+            .iter()
+            .filter(|(_, &l)| l == level)
+            .map(|(id, _)| id.clone())
+            .collect();
+        tasks.sort();
+        tasks
+    }
+
+    /// Returns true if the graph has any tasks.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.task_levels.is_empty()
     }
 }
 

--- a/src/app/model/dagruns/commands.rs
+++ b/src/app/model/dagruns/commands.rs
@@ -10,6 +10,11 @@ pub static DAGRUN_COMMAND_POP_UP: LazyLock<CommandPopUp> = LazyLock::new(|| {
             description: "Clear a DAG run",
         },
         Command {
+            name: "DAG Graph",
+            key_binding: "d",
+            description: "Show DAG task dependency graph",
+        },
+        Command {
             name: "Show",
             key_binding: "v",
             description: "Show DAG code",

--- a/src/app/model/dagruns/dag_code_view/render.rs
+++ b/src/app/model/dagruns/dag_code_view/render.rs
@@ -20,7 +20,7 @@ impl DagCodeView {
             .borders(Borders::ALL)
             .title(" DAG Code ")
             .border_style(t.border_style)
-            .style(t.surface_style)
+            .style(t.default_style)
             .title_style(t.title_style);
 
         #[allow(clippy::cast_possible_truncation)]

--- a/src/app/model/dagruns/mod.rs
+++ b/src/app/model/dagruns/mod.rs
@@ -151,6 +151,7 @@ impl DagRunModel {
             DagRunPopUp::Clear(p) => p.update(event, ctx),
             DagRunPopUp::Mark(p) => p.update(event, ctx),
             DagRunPopUp::Trigger(p) => p.update(event, ctx),
+            DagRunPopUp::Graph(p) => p.update(event, ctx),
         };
         debug!("Popup messages: {messages:?}");
 
@@ -202,6 +203,16 @@ impl DagRunModel {
             KeyCode::Char('?') => {
                 self.popup.show_commands(&DAGRUN_COMMAND_POP_UP);
                 KeyResult::Consumed
+            }
+            KeyCode::Char('d') => {
+                if let (Some(dag_id), Some(dag_run)) = (ctx.dag_id(), &self.current()) {
+                    KeyResult::ConsumedWith(vec![WorkerMessage::ShowDagGraph {
+                        dag_id: dag_id.clone(),
+                        dag_run_id: dag_run.dag_run_id.clone(),
+                    }])
+                } else {
+                    KeyResult::Consumed
+                }
             }
             KeyCode::Char('v') => {
                 if let Some(dag_id) = ctx.dag_id() {

--- a/src/app/model/dagruns/popup/mod.rs
+++ b/src/app/model/dagruns/popup/mod.rs
@@ -7,8 +7,11 @@ use clear::ClearDagRunPopup;
 use mark::MarkDagRunPopup;
 use trigger::TriggerDagRunPopUp;
 
+use crate::app::model::taskinstances::popup::graph::DagGraphPopup;
+
 pub enum DagRunPopUp {
     Clear(ClearDagRunPopup),
     Mark(MarkDagRunPopup),
     Trigger(TriggerDagRunPopUp),
+    Graph(DagGraphPopup),
 }

--- a/src/app/model/dagruns/popup/render.rs
+++ b/src/app/model/dagruns/popup/render.rs
@@ -23,7 +23,7 @@ impl Widget for &mut TriggerDagRunPopUp {
             .border_type(BorderType::Rounded)
             .borders(Borders::ALL)
             .border_style(t.border_style)
-            .style(t.surface_style);
+            .style(t.default_style);
 
         // Use inner area for content layout to avoid overlapping the border
         let inner = popup_block.inner(area);
@@ -71,7 +71,7 @@ impl Widget for &mut ClearDagRunPopup {
             .border_type(BorderType::Rounded)
             .borders(Borders::ALL)
             .border_style(t.border_style)
-            .style(t.surface_style);
+            .style(t.default_style);
 
         // Use inner area for content layout to avoid overlapping the border
         let inner = popup_block.inner(area);
@@ -131,7 +131,7 @@ impl Widget for &mut MarkDagRunPopup {
             .border_type(BorderType::Rounded)
             .borders(Borders::ALL)
             .border_style(t.border_style)
-            .style(t.surface_style);
+            .style(t.default_style);
 
         let text = Paragraph::new("Mark status as")
             .style(t.default_style)

--- a/src/app/model/dagruns/render.rs
+++ b/src/app/model/dagruns/render.rs
@@ -131,6 +131,7 @@ impl Widget for &mut DagRunModel {
             Some(DagRunPopUp::Clear(popup)) => popup.render(area, buf),
             Some(DagRunPopUp::Mark(popup)) => popup.render(area, buf),
             Some(DagRunPopUp::Trigger(popup)) => popup.render(area, buf),
+            Some(DagRunPopUp::Graph(popup)) => popup.render(area, buf),
             None => {}
         }
     }

--- a/src/app/model/popup/commands_help/render.rs
+++ b/src/app/model/popup/commands_help/render.rs
@@ -13,11 +13,15 @@ use super::CommandPopUp;
 
 impl Widget for &CommandPopUp<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
+        let t = theme();
         let popup_area = popup_area(area, 80, 80);
         let popup = Block::default()
             .border_type(BorderType::Rounded)
             .title(self.title.as_str())
-            .borders(Borders::ALL);
+            .title_style(t.title_style)
+            .borders(Borders::ALL)
+            .border_style(t.border_style)
+            .style(t.surface_style);
 
         Clear.render(popup_area, buf);
 

--- a/src/app/model/popup/commands_help/render.rs
+++ b/src/app/model/popup/commands_help/render.rs
@@ -21,7 +21,7 @@ impl Widget for &CommandPopUp<'_> {
             .title_style(t.title_style)
             .borders(Borders::ALL)
             .border_style(t.border_style)
-            .style(t.surface_style);
+            .style(t.default_style);
 
         Clear.render(popup_area, buf);
 

--- a/src/app/model/popup/error.rs
+++ b/src/app/model/popup/error.rs
@@ -45,7 +45,7 @@ impl Widget for &ErrorPopup {
             .title_style(Style::default().fg(error_color).add_modifier(Modifier::BOLD))
             .borders(Borders::ALL)
             .border_style(t.border_style)
-            .style(t.surface_style);
+            .style(t.default_style);
 
         Clear.render(popup_area, buf);
 

--- a/src/app/model/popup/error.rs
+++ b/src/app/model/popup/error.rs
@@ -42,7 +42,11 @@ impl Widget for &ErrorPopup {
         let popup = Block::default()
             .border_type(BorderType::Rounded)
             .title("Errors - Press <Esc> or <q> to close")
-            .title_style(Style::default().fg(error_color).add_modifier(Modifier::BOLD))
+            .title_style(
+                Style::default()
+                    .fg(error_color)
+                    .add_modifier(Modifier::BOLD),
+            )
             .borders(Borders::ALL)
             .border_style(t.border_style)
             .style(t.default_style);
@@ -60,10 +64,7 @@ impl Widget for &ErrorPopup {
                             .fg(error_color)
                             .add_modifier(Modifier::BOLD),
                     ),
-                    Span::styled(
-                        first_line.to_string(),
-                        Style::default().fg(t.text_primary),
-                    ),
+                    Span::styled(first_line.to_string(), Style::default().fg(t.text_primary)),
                 ]));
             }
             for line in lines {

--- a/src/app/model/popup/error.rs
+++ b/src/app/model/popup/error.rs
@@ -2,12 +2,13 @@ use anyhow::Error;
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span, Text},
     widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget, Wrap},
 };
 
 use super::popup_area;
+use crate::ui::theme::theme;
 
 pub struct ErrorPopup {
     pub errors: Vec<String>,
@@ -26,10 +27,6 @@ impl ErrorPopup {
     pub const fn from_strings(errors: Vec<String>) -> Self {
         Self { errors }
     }
-
-    pub const fn has_errors(&self) -> bool {
-        !self.errors.is_empty()
-    }
 }
 
 impl Widget for &ErrorPopup {
@@ -38,13 +35,17 @@ impl Widget for &ErrorPopup {
             return;
         }
 
+        let t = theme();
+        let error_color = t.state_failed;
+
         let popup_area = popup_area(area, 80, 50);
         let popup = Block::default()
             .border_type(BorderType::Rounded)
             .title("Errors - Press <Esc> or <q> to close")
-            .title_style(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD))
+            .title_style(Style::default().fg(error_color).add_modifier(Modifier::BOLD))
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(Color::Red));
+            .border_style(t.border_style)
+            .style(t.surface_style);
 
         Clear.render(popup_area, buf);
 
@@ -55,15 +56,20 @@ impl Widget for &ErrorPopup {
                 text.push_line(Line::from(vec![
                     Span::styled(
                         format!("Error {}: ", idx + 1),
-                        Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                        Style::default()
+                            .fg(error_color)
+                            .add_modifier(Modifier::BOLD),
                     ),
-                    Span::styled(first_line.to_string(), Style::default().fg(Color::White)),
+                    Span::styled(
+                        first_line.to_string(),
+                        Style::default().fg(t.text_primary),
+                    ),
                 ]));
             }
             for line in lines {
                 text.push_line(Line::from(Span::styled(
                     line.to_string(),
-                    Style::default().fg(Color::White),
+                    Style::default().fg(t.text_primary),
                 )));
             }
             if idx < self.errors.len() - 1 {

--- a/src/app/model/popup/warning.rs
+++ b/src/app/model/popup/warning.rs
@@ -1,12 +1,13 @@
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span, Text},
     widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget, Wrap},
 };
 
 use super::popup_area;
+use crate::ui::theme::theme;
 
 pub struct WarningPopup {
     pub warnings: Vec<String>,
@@ -16,10 +17,6 @@ impl WarningPopup {
     pub const fn new(warnings: Vec<String>) -> Self {
         Self { warnings }
     }
-
-    pub const fn has_warnings(&self) -> bool {
-        !self.warnings.is_empty()
-    }
 }
 
 impl Widget for &WarningPopup {
@@ -28,17 +25,21 @@ impl Widget for &WarningPopup {
             return;
         }
 
+        let t = theme();
+        let warning_color = t.state_up_for_retry;
+
         let popup_area = popup_area(area, 80, 50);
         let popup = Block::default()
             .border_type(BorderType::Rounded)
             .title("Warning - Press <Esc> or <q> to close")
             .title_style(
                 Style::default()
-                    .fg(Color::Yellow)
+                    .fg(warning_color)
                     .add_modifier(Modifier::BOLD),
             )
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(Color::Yellow));
+            .border_style(t.border_style)
+            .style(t.surface_style);
 
         Clear.render(popup_area, buf);
 
@@ -52,16 +53,15 @@ impl Widget for &WarningPopup {
                         Span::styled(
                             format!("Warning {}: ", idx + 1),
                             Style::default()
-                                .fg(Color::Yellow)
+                                .fg(warning_color)
                                 .add_modifier(Modifier::BOLD),
                         ),
-                        Span::styled(line, Style::default().fg(Color::White)),
+                        Span::styled(line, Style::default().fg(t.text_primary)),
                     ]));
                 } else {
-                    // Subsequent lines are just white text
                     text.push_line(Line::from(Span::styled(
                         line,
-                        Style::default().fg(Color::White),
+                        Style::default().fg(t.text_primary),
                     )));
                 }
             }

--- a/src/app/model/popup/warning.rs
+++ b/src/app/model/popup/warning.rs
@@ -39,7 +39,7 @@ impl Widget for &WarningPopup {
             )
             .borders(Borders::ALL)
             .border_style(t.border_style)
-            .style(t.surface_style);
+            .style(t.default_style);
 
         Clear.render(popup_area, buf);
 

--- a/src/app/model/taskinstances/commands.rs
+++ b/src/app/model/taskinstances/commands.rs
@@ -24,6 +24,11 @@ pub static TASK_COMMAND_POP_UP: LazyLock<CommandPopUp> = LazyLock::new(|| {
             key_binding: "/",
             description: "Filter task instances",
         },
+        Command {
+            name: "DAG Graph",
+            key_binding: "d",
+            description: "Show DAG dependency graph",
+        },
     ];
 
     commands.append(&mut DefaultCommands::new().0);

--- a/src/app/model/taskinstances/mod.rs
+++ b/src/app/model/taskinstances/mod.rs
@@ -16,6 +16,7 @@ use super::{FilterableTable, KeyResult, Model, Popup};
 use crate::airflow::model::common::OpenItem;
 use crate::app::worker::WorkerMessage;
 use popup::clear::ClearTaskInstancePopup;
+use popup::graph::DagGraphPopup;
 use popup::mark::MarkTaskInstancePopup;
 use popup::TaskInstancePopUp;
 
@@ -105,6 +106,7 @@ impl TaskInstanceModel {
         let (key_event, messages) = match custom_popup {
             TaskInstancePopUp::Clear(p) => p.update(event, ctx),
             TaskInstancePopUp::Mark(p) => p.update(event, ctx),
+            TaskInstancePopUp::Graph(p) => p.update(event, ctx),
         };
         debug!("Popup messages: {messages:?}");
 
@@ -164,6 +166,15 @@ impl TaskInstanceModel {
                 } else {
                     KeyResult::Consumed
                 }
+            }
+            KeyCode::Char('d') => {
+                if let Some(graph) = &self.task_graph {
+                    if !graph.is_empty() {
+                        let popup = DagGraphPopup::new(graph, &self.table.filtered.items);
+                        self.popup.show_custom(TaskInstancePopUp::Graph(popup));
+                    }
+                }
+                KeyResult::Consumed
             }
             KeyCode::Char('o') => {
                 if let Some(task_instance) = self.table.current() {

--- a/src/app/model/taskinstances/mod.rs
+++ b/src/app/model/taskinstances/mod.rs
@@ -170,7 +170,7 @@ impl TaskInstanceModel {
             KeyCode::Char('d') => {
                 if let Some(graph) = &self.task_graph {
                     if !graph.is_empty() {
-                        let popup = DagGraphPopup::new(graph, &self.table.filtered.items);
+                        let popup = DagGraphPopup::new(graph, &self.table.all);
                         self.popup.show_custom(TaskInstancePopUp::Graph(popup));
                     }
                 }

--- a/src/app/model/taskinstances/popup/graph.rs
+++ b/src/app/model/taskinstances/popup/graph.rs
@@ -40,6 +40,8 @@ pub struct DagGraphPopup {
     pub scroll_y: u16,
     /// The content height of the graph in rows (used for popup sizing).
     pub content_height: u16,
+    /// The content width of the graph in columns (used for scroll clamping).
+    pub content_width: u16,
 }
 
 impl DagGraphPopup {
@@ -81,11 +83,15 @@ impl DagGraphPopup {
             x += w + HORIZONTAL_GAP;
         }
 
-        // Max tasks at any level (determines canvas height)
+        // Total content dimensions
         let max_tasks_at_level = levels.iter().map(Vec::len).max().unwrap_or(0) as u16;
         let content_height = 2 * MARGIN
             + max_tasks_at_level * NODE_HEIGHT
             + max_tasks_at_level.saturating_sub(1) * VERTICAL_SPACING;
+        let content_width = col_x
+            .last()
+            .zip(col_widths.last())
+            .map_or(0, |(&cx, &cw)| cx + cw + MARGIN);
 
         // Build nodes with positions, centering shorter columns vertically
         let mut nodes: Vec<GraphNode> = Vec::new();
@@ -134,6 +140,7 @@ impl DagGraphPopup {
             scroll_x: 0,
             scroll_y: 0,
             content_height,
+            content_width,
         }
     }
 
@@ -153,13 +160,13 @@ impl DagGraphPopup {
                     self.scroll_x = self.scroll_x.saturating_sub(SCROLL_STEP);
                 }
                 KeyCode::Right | KeyCode::Char('l') => {
-                    self.scroll_x += SCROLL_STEP;
+                    self.scroll_x = (self.scroll_x + SCROLL_STEP).min(self.content_width);
                 }
                 KeyCode::Up | KeyCode::Char('k') => {
                     self.scroll_y = self.scroll_y.saturating_sub(SCROLL_STEP);
                 }
                 KeyCode::Down | KeyCode::Char('j') => {
-                    self.scroll_y += SCROLL_STEP;
+                    self.scroll_y = (self.scroll_y + SCROLL_STEP).min(self.content_height);
                 }
                 _ => {}
             }

--- a/src/app/model/taskinstances/popup/graph.rs
+++ b/src/app/model/taskinstances/popup/graph.rs
@@ -1,0 +1,191 @@
+use std::collections::HashMap;
+
+use crossterm::event::KeyCode;
+use ratatui::style::{Color, Style};
+
+use crate::airflow::graph::TaskGraph;
+use crate::airflow::model::common::taskinstance::TaskInstanceState;
+use crate::airflow::model::common::TaskInstance;
+use crate::app::events::custom::FlowrsEvent;
+use crate::app::worker::WorkerMessage;
+use crate::ui::constants::AirflowStateColor;
+
+/// Height of each node in rows (top border + content + bottom border).
+const NODE_HEIGHT: u16 = 3;
+/// Padding inside the node on each side of the task name.
+pub const NODE_PADDING: u16 = 1;
+/// Vertical gap between nodes at the same level.
+const VERTICAL_SPACING: u16 = 2;
+/// Horizontal gap between columns for edge routing.
+const HORIZONTAL_GAP: u16 = 6;
+/// Margin around the entire graph.
+const MARGIN: u16 = 1;
+/// Scroll step for arrow keys.
+const SCROLL_STEP: u16 = 3;
+
+/// A node in the graph layout.
+pub struct GraphNode {
+    pub task_id: String,
+    pub x: u16,
+    pub y: u16,
+    pub width: u16,
+    pub border_color: Color,
+}
+
+/// Popup that visualizes the DAG task dependency graph.
+pub struct DagGraphPopup {
+    pub nodes: Vec<GraphNode>,
+    pub edges: Vec<(usize, usize)>,
+    pub scroll_x: u16,
+    pub scroll_y: u16,
+}
+
+impl DagGraphPopup {
+    /// Build a graph popup from the task graph and current task instance states.
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_possible_wrap
+    )]
+    pub fn new(graph: &TaskGraph, task_instances: &[TaskInstance]) -> Self {
+        // Map task_id -> state for coloring
+        let state_map: HashMap<&str, &TaskInstanceState> = task_instances
+            .iter()
+            .filter_map(|ti| ti.state.as_ref().map(|s| (ti.task_id.as_ref(), s)))
+            .collect();
+
+        let max_level = graph.max_level();
+
+        // Gather tasks per level
+        let levels: Vec<Vec<String>> = (0..=max_level).map(|l| graph.tasks_at_level(l)).collect();
+
+        // Column widths: max node width at each level
+        let col_widths: Vec<u16> = levels
+            .iter()
+            .map(|tasks| {
+                tasks
+                    .iter()
+                    .map(|t| t.len() as u16 + 2 + 2 * NODE_PADDING)
+                    .max()
+                    .unwrap_or(0)
+            })
+            .collect();
+
+        // Column x-positions
+        let mut col_x: Vec<u16> = Vec::with_capacity(levels.len());
+        let mut x = MARGIN;
+        for &w in &col_widths {
+            col_x.push(x);
+            x += w + HORIZONTAL_GAP;
+        }
+
+        // Max tasks at any level (determines canvas height)
+        let max_tasks_at_level = levels.iter().map(Vec::len).max().unwrap_or(0) as u16;
+
+        // Build nodes with positions, centering shorter columns vertically
+        let mut nodes: Vec<GraphNode> = Vec::new();
+        let mut task_to_idx: HashMap<String, usize> = HashMap::new();
+
+        for (level, tasks) in levels.iter().enumerate() {
+            let task_count = tasks.len() as u16;
+            // Offset to vertically center columns with fewer tasks
+            let total_col_height =
+                task_count * NODE_HEIGHT + task_count.saturating_sub(1) * VERTICAL_SPACING;
+            let total_max_height = max_tasks_at_level * NODE_HEIGHT
+                + max_tasks_at_level.saturating_sub(1) * VERTICAL_SPACING;
+            let y_offset = total_max_height.saturating_sub(total_col_height) / 2;
+
+            for (row, task_id) in tasks.iter().enumerate() {
+                let y = MARGIN + y_offset + row as u16 * (NODE_HEIGHT + VERTICAL_SPACING);
+                let width = col_widths[level];
+                let border_color: Color = state_map
+                    .get(task_id.as_str())
+                    .map_or(Color::DarkGray, |s| AirflowStateColor::from(*s).into());
+
+                task_to_idx.insert(task_id.clone(), nodes.len());
+                nodes.push(GraphNode {
+                    task_id: task_id.clone(),
+                    x: col_x[level],
+                    y,
+                    width,
+                    border_color,
+                });
+            }
+        }
+
+        // Build edge list
+        let mut edges: Vec<(usize, usize)> = Vec::new();
+        for (i, node) in nodes.iter().enumerate() {
+            for downstream_id in graph.downstream(&node.task_id) {
+                if let Some(&target_idx) = task_to_idx.get(downstream_id.as_str()) {
+                    edges.push((i, target_idx));
+                }
+            }
+        }
+
+        Self {
+            nodes,
+            edges,
+            scroll_x: 0,
+            scroll_y: 0,
+        }
+    }
+
+    /// Handle keyboard events (scrolling and dismiss).
+    /// Returns a key event on Esc/q to signal the parent to close the popup.
+    pub fn update(
+        &mut self,
+        event: &FlowrsEvent,
+        _ctx: &crate::app::state::NavigationContext,
+    ) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
+        if let FlowrsEvent::Key(key) = event {
+            match key.code {
+                KeyCode::Esc | KeyCode::Char('q') => {
+                    return (Some(FlowrsEvent::Key(*key)), vec![]);
+                }
+                KeyCode::Left | KeyCode::Char('h') => {
+                    self.scroll_x = self.scroll_x.saturating_sub(SCROLL_STEP);
+                }
+                KeyCode::Right | KeyCode::Char('l') => {
+                    self.scroll_x += SCROLL_STEP;
+                }
+                KeyCode::Up | KeyCode::Char('k') => {
+                    self.scroll_y = self.scroll_y.saturating_sub(SCROLL_STEP);
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    self.scroll_y += SCROLL_STEP;
+                }
+                _ => {}
+            }
+        }
+        (None, vec![])
+    }
+
+    /// Set a cell in the buffer if it falls within the visible area.
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_possible_wrap
+    )]
+    pub fn set_cell(
+        &self,
+        buf: &mut ratatui::buffer::Buffer,
+        area: ratatui::layout::Rect,
+        canvas_x: i32,
+        canvas_y: i32,
+        symbol: &str,
+        style: Style,
+    ) {
+        let screen_x = canvas_x - i32::from(self.scroll_x);
+        let screen_y = canvas_y - i32::from(self.scroll_y);
+        if screen_x >= 0
+            && screen_y >= 0
+            && screen_x < i32::from(area.width)
+            && screen_y < i32::from(area.height)
+        {
+            let cell = &mut buf[(area.x + screen_x as u16, area.y + screen_y as u16)];
+            cell.set_symbol(symbol);
+            cell.set_style(style);
+        }
+    }
+}

--- a/src/app/model/taskinstances/popup/graph.rs
+++ b/src/app/model/taskinstances/popup/graph.rs
@@ -179,15 +179,13 @@ impl DagGraphPopup {
                     self.scroll_x = self.scroll_x.saturating_sub(SCROLL_STEP);
                 }
                 KeyCode::Right | KeyCode::Char('l') => {
-                    self.scroll_x =
-                        (self.scroll_x + SCROLL_STEP).min(self.max_scroll_x());
+                    self.scroll_x = (self.scroll_x + SCROLL_STEP).min(self.max_scroll_x());
                 }
                 KeyCode::Up | KeyCode::Char('k') => {
                     self.scroll_y = self.scroll_y.saturating_sub(SCROLL_STEP);
                 }
                 KeyCode::Down | KeyCode::Char('j') => {
-                    self.scroll_y =
-                        (self.scroll_y + SCROLL_STEP).min(self.max_scroll_y());
+                    self.scroll_y = (self.scroll_y + SCROLL_STEP).min(self.max_scroll_y());
                 }
                 _ => {}
             }

--- a/src/app/model/taskinstances/popup/graph.rs
+++ b/src/app/model/taskinstances/popup/graph.rs
@@ -42,6 +42,8 @@ pub struct DagGraphPopup {
     pub content_height: u16,
     /// The content width of the graph in columns (used for scroll clamping).
     pub content_width: u16,
+    /// Last known viewport dimensions (set during render, used for scroll clamping).
+    viewport: (u16, u16),
 }
 
 impl DagGraphPopup {
@@ -141,7 +143,24 @@ impl DagGraphPopup {
             scroll_y: 0,
             content_height,
             content_width,
+            viewport: (0, 0),
         }
+    }
+
+    /// Store the viewport dimensions from the last render pass so scroll
+    /// clamping in [`update`] can prevent scrolling past the content.
+    pub fn set_viewport(&mut self, width: u16, height: u16) {
+        self.viewport = (width, height);
+    }
+
+    /// Maximum horizontal scroll offset that keeps the last column visible.
+    fn max_scroll_x(&self) -> u16 {
+        self.content_width.saturating_sub(self.viewport.0)
+    }
+
+    /// Maximum vertical scroll offset that keeps the last row visible.
+    fn max_scroll_y(&self) -> u16 {
+        self.content_height.saturating_sub(self.viewport.1)
     }
 
     /// Handle keyboard events (scrolling and dismiss).
@@ -160,13 +179,15 @@ impl DagGraphPopup {
                     self.scroll_x = self.scroll_x.saturating_sub(SCROLL_STEP);
                 }
                 KeyCode::Right | KeyCode::Char('l') => {
-                    self.scroll_x = (self.scroll_x + SCROLL_STEP).min(self.content_width);
+                    self.scroll_x =
+                        (self.scroll_x + SCROLL_STEP).min(self.max_scroll_x());
                 }
                 KeyCode::Up | KeyCode::Char('k') => {
                     self.scroll_y = self.scroll_y.saturating_sub(SCROLL_STEP);
                 }
                 KeyCode::Down | KeyCode::Char('j') => {
-                    self.scroll_y = (self.scroll_y + SCROLL_STEP).min(self.content_height);
+                    self.scroll_y =
+                        (self.scroll_y + SCROLL_STEP).min(self.max_scroll_y());
                 }
                 _ => {}
             }

--- a/src/app/model/taskinstances/popup/graph.rs
+++ b/src/app/model/taskinstances/popup/graph.rs
@@ -38,6 +38,8 @@ pub struct DagGraphPopup {
     pub edges: Vec<(usize, usize)>,
     pub scroll_x: u16,
     pub scroll_y: u16,
+    /// The content height of the graph in rows (used for popup sizing).
+    pub content_height: u16,
 }
 
 impl DagGraphPopup {
@@ -81,6 +83,9 @@ impl DagGraphPopup {
 
         // Max tasks at any level (determines canvas height)
         let max_tasks_at_level = levels.iter().map(Vec::len).max().unwrap_or(0) as u16;
+        let content_height = 2 * MARGIN
+            + max_tasks_at_level * NODE_HEIGHT
+            + max_tasks_at_level.saturating_sub(1) * VERTICAL_SPACING;
 
         // Build nodes with positions, centering shorter columns vertically
         let mut nodes: Vec<GraphNode> = Vec::new();
@@ -128,6 +133,7 @@ impl DagGraphPopup {
             edges,
             scroll_x: 0,
             scroll_y: 0,
+            content_height,
         }
     }
 

--- a/src/app/model/taskinstances/popup/mod.rs
+++ b/src/app/model/taskinstances/popup/mod.rs
@@ -1,11 +1,14 @@
 pub mod clear;
+pub mod graph;
 pub mod mark;
 mod render;
 
 use clear::ClearTaskInstancePopup;
+use graph::DagGraphPopup;
 use mark::MarkTaskInstancePopup;
 
 pub enum TaskInstancePopUp {
     Clear(ClearTaskInstancePopup),
     Mark(MarkTaskInstancePopup),
+    Graph(DagGraphPopup),
 }

--- a/src/app/model/taskinstances/popup/render.rs
+++ b/src/app/model/taskinstances/popup/render.rs
@@ -25,7 +25,7 @@ impl Widget for &mut ClearTaskInstancePopup {
             .border_type(BorderType::Rounded)
             .borders(Borders::ALL)
             .border_style(t.border_style)
-            .style(t.surface_style);
+            .style(t.default_style);
 
         // Use inner area for content layout to avoid overlapping the border
         let inner = popup_block.inner(area);
@@ -85,7 +85,7 @@ impl Widget for &mut MarkTaskInstancePopup {
             .border_type(BorderType::Rounded)
             .borders(Borders::ALL)
             .border_style(t.border_style)
-            .style(t.surface_style);
+            .style(t.default_style);
 
         let text = Paragraph::new("Mark status as")
             .style(t.default_style)

--- a/src/app/model/taskinstances/popup/render.rs
+++ b/src/app/model/taskinstances/popup/render.rs
@@ -183,11 +183,12 @@ impl Widget for &mut DagGraphPopup {
             .border_type(BorderType::Rounded)
             .borders(Borders::ALL)
             .border_style(t.border_style)
-            .style(t.surface_style);
+            .style(t.default_style);
 
         Clear.render(popup, buffer);
         let inner = block.inner(popup);
         block.render(popup, buffer);
+        self.set_viewport(inner.width, inner.height);
 
         let edge_style = Style::default().fg(t.border_default);
 

--- a/src/app/model/taskinstances/popup/render.rs
+++ b/src/app/model/taskinstances/popup/render.rs
@@ -1,6 +1,7 @@
 use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Flex, Layout, Rect},
+    style::Style,
     widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget},
 };
 
@@ -10,6 +11,7 @@ use crate::{
 };
 
 use super::clear::ClearTaskInstancePopup;
+use super::graph::DagGraphPopup;
 use super::mark::{MarkState, MarkTaskInstancePopup};
 
 impl Widget for &mut ClearTaskInstancePopup {
@@ -153,5 +155,120 @@ impl Widget for &mut MarkTaskInstancePopup {
         success_btn.render(success, buffer);
         failed_btn.render(failed, buffer);
         skipped_btn.render(skipped, buffer);
+    }
+}
+
+impl Widget for &mut DagGraphPopup {
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    fn render(self, area: Rect, buffer: &mut Buffer) {
+        let t = theme();
+        let popup = popup_area(area, 90, 85);
+
+        let block = Block::default()
+            .title(" DAG Graph ")
+            .title_bottom(" [←↑↓→/hjkl] scroll  [Esc] close ")
+            .border_type(BorderType::Rounded)
+            .borders(Borders::ALL)
+            .border_style(t.border_style)
+            .style(t.surface_style);
+
+        Clear.render(popup, buffer);
+        let inner = block.inner(popup);
+        block.render(popup, buffer);
+
+        let edge_style = Style::default().fg(t.border_default);
+
+        // Draw edges first (behind nodes)
+        for &(src_idx, tgt_idx) in &self.edges {
+            let src = &self.nodes[src_idx];
+            let tgt = &self.nodes[tgt_idx];
+
+            // Connection points: right-center of source, left-center of target
+            let src_x = i32::from(src.x) + i32::from(src.width);
+            let src_y = i32::from(src.y) + 1;
+            let tgt_x = i32::from(tgt.x);
+            let tgt_y = i32::from(tgt.y) + 1;
+
+            if src_y == tgt_y {
+                // Same row: straight horizontal line with arrow
+                for x in src_x..tgt_x {
+                    let sym = if x == tgt_x - 1 { "▶" } else { "─" };
+                    self.set_cell(buffer, inner, x, src_y, sym, edge_style);
+                }
+            } else {
+                // Route: horizontal → vertical → horizontal
+                let route_x = src_x + (tgt_x - src_x) / 2;
+
+                // Horizontal from source to routing column
+                for x in src_x..route_x {
+                    self.set_cell(buffer, inner, x, src_y, "─", edge_style);
+                }
+
+                if tgt_y > src_y {
+                    // Going down
+                    self.set_cell(buffer, inner, route_x, src_y, "╮", edge_style);
+                    for y in (src_y + 1)..tgt_y {
+                        self.set_cell(buffer, inner, route_x, y, "│", edge_style);
+                    }
+                    self.set_cell(buffer, inner, route_x, tgt_y, "╰", edge_style);
+                } else {
+                    // Going up
+                    self.set_cell(buffer, inner, route_x, src_y, "╯", edge_style);
+                    for y in (tgt_y + 1)..src_y {
+                        self.set_cell(buffer, inner, route_x, y, "│", edge_style);
+                    }
+                    self.set_cell(buffer, inner, route_x, tgt_y, "╭", edge_style);
+                }
+
+                // Horizontal from routing column to target with arrow
+                for x in (route_x + 1)..tgt_x {
+                    let sym = if x == tgt_x - 1 { "▶" } else { "─" };
+                    self.set_cell(buffer, inner, x, tgt_y, sym, edge_style);
+                }
+            }
+        }
+
+        // Draw nodes (on top of edges)
+        let text_style = t.default_style;
+        for node in &self.nodes {
+            let border_style = Style::default().fg(node.border_color);
+            let nx = i32::from(node.x);
+            let ny = i32::from(node.y);
+            let nw = i32::from(node.width);
+
+            // Top border: ╭───╮
+            self.set_cell(buffer, inner, nx, ny, "╭", border_style);
+            for dx in 1..nw - 1 {
+                self.set_cell(buffer, inner, nx + dx, ny, "─", border_style);
+            }
+            self.set_cell(buffer, inner, nx + nw - 1, ny, "╮", border_style);
+
+            // Content row: │ name │
+            self.set_cell(buffer, inner, nx, ny + 1, "│", border_style);
+            // Clear interior
+            for dx in 1..nw - 1 {
+                self.set_cell(buffer, inner, nx + dx, ny + 1, " ", text_style);
+            }
+            // Write task name (left-aligned with padding)
+            let name_start = nx + 1 + i32::from(super::graph::NODE_PADDING);
+            for (i, ch) in node.task_id.chars().enumerate() {
+                self.set_cell(
+                    buffer,
+                    inner,
+                    name_start + i as i32,
+                    ny + 1,
+                    &ch.to_string(),
+                    text_style,
+                );
+            }
+            self.set_cell(buffer, inner, nx + nw - 1, ny + 1, "│", border_style);
+
+            // Bottom border: ╰───╯
+            self.set_cell(buffer, inner, nx, ny + 2, "╰", border_style);
+            for dx in 1..nw - 1 {
+                self.set_cell(buffer, inner, nx + dx, ny + 2, "─", border_style);
+            }
+            self.set_cell(buffer, inner, nx + nw - 1, ny + 2, "╯", border_style);
+        }
     }
 }

--- a/src/app/model/taskinstances/popup/render.rs
+++ b/src/app/model/taskinstances/popup/render.rs
@@ -4,6 +4,7 @@ use ratatui::{
     style::Style,
     widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget},
 };
+use std::cmp::min;
 
 use crate::{
     app::model::popup::{popup_area, themed_button},
@@ -162,7 +163,19 @@ impl Widget for &mut DagGraphPopup {
     #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
     fn render(self, area: Rect, buffer: &mut Buffer) {
         let t = theme();
-        let popup = popup_area(area, 90, 85);
+        // +2 for block borders, +1 for title bottom line
+        let needed_height = self.content_height + 3;
+        let max_height = area.height * 85 / 100;
+        let popup_height = min(needed_height, max_height);
+        let popup = {
+            let vertical =
+                Layout::vertical([Constraint::Length(popup_height)]).flex(Flex::Center);
+            let horizontal =
+                Layout::horizontal([Constraint::Percentage(90)]).flex(Flex::Center);
+            let [area] = vertical.areas(area);
+            let [area] = horizontal.areas(area);
+            area
+        };
 
         let block = Block::default()
             .title(" DAG Graph ")

--- a/src/app/model/taskinstances/popup/render.rs
+++ b/src/app/model/taskinstances/popup/render.rs
@@ -168,10 +168,8 @@ impl Widget for &mut DagGraphPopup {
         let max_height = area.height * 85 / 100;
         let popup_height = min(needed_height, max_height);
         let popup = {
-            let vertical =
-                Layout::vertical([Constraint::Length(popup_height)]).flex(Flex::Center);
-            let horizontal =
-                Layout::horizontal([Constraint::Percentage(90)]).flex(Flex::Center);
+            let vertical = Layout::vertical([Constraint::Length(popup_height)]).flex(Flex::Center);
+            let horizontal = Layout::horizontal([Constraint::Percentage(90)]).flex(Flex::Center);
             let [area] = vertical.areas(area);
             let [area] = horizontal.areas(area);
             area

--- a/src/app/model/taskinstances/popup/render.rs
+++ b/src/app/model/taskinstances/popup/render.rs
@@ -177,7 +177,7 @@ impl Widget for &mut DagGraphPopup {
 
         let block = Block::default()
             .title(" DAG Graph ")
-            .title_bottom(" [←↑↓→/hjkl] scroll  [Esc] close ")
+            .title_bottom(" [←↑↓→/hjkl] scroll  [Esc/q] close ")
             .border_type(BorderType::Rounded)
             .borders(Borders::ALL)
             .border_style(t.border_style)

--- a/src/app/model/taskinstances/render.rs
+++ b/src/app/model/taskinstances/render.rs
@@ -81,6 +81,7 @@ impl Widget for &mut TaskInstanceModel {
         match self.popup.custom_mut() {
             Some(TaskInstancePopUp::Clear(popup)) => popup.render(area, buffer),
             Some(TaskInstancePopUp::Mark(popup)) => popup.render(area, buffer),
+            Some(TaskInstancePopUp::Graph(popup)) => popup.render(area, buffer),
             None => {}
         }
     }

--- a/src/app/worker/mod.rs
+++ b/src/app/worker/mod.rs
@@ -290,10 +290,7 @@ async fn process_message(app: Arc<Mutex<App>>, message: WorkerMessage) -> Result
         WorkerMessage::UpdateTasks { dag_id } => {
             tasks::handle_update_tasks(&app, &client, &dag_id).await;
         }
-        WorkerMessage::ShowDagGraph {
-            dag_id,
-            dag_run_id,
-        } => {
+        WorkerMessage::ShowDagGraph { dag_id, dag_run_id } => {
             tasks::handle_show_dag_graph(&app, &client, &dag_id, &dag_run_id).await;
         }
         // Browser operations

--- a/src/app/worker/mod.rs
+++ b/src/app/worker/mod.rs
@@ -71,6 +71,10 @@ pub enum WorkerMessage {
     UpdateTasks {
         dag_id: DagId,
     },
+    ShowDagGraph {
+        dag_id: DagId,
+        dag_run_id: DagRunId,
+    },
     OpenItem(OpenItem),
 }
 
@@ -285,6 +289,12 @@ async fn process_message(app: Arc<Mutex<App>>, message: WorkerMessage) -> Result
         // Task operations
         WorkerMessage::UpdateTasks { dag_id } => {
             tasks::handle_update_tasks(&app, &client, &dag_id).await;
+        }
+        WorkerMessage::ShowDagGraph {
+            dag_id,
+            dag_run_id,
+        } => {
+            tasks::handle_show_dag_graph(&app, &client, &dag_id, &dag_run_id).await;
         }
         // Browser operations
         WorkerMessage::OpenItem(item) => {

--- a/src/app/worker/tasks.rs
+++ b/src/app/worker/tasks.rs
@@ -4,6 +4,8 @@ use log::debug;
 
 use crate::airflow::graph::TaskGraph;
 use crate::airflow::traits::AirflowClient;
+use crate::app::model::dagruns::popup::DagRunPopUp;
+use crate::app::model::taskinstances::popup::graph::DagGraphPopup;
 use crate::app::state::App;
 
 /// Handle fetching task definitions and building the task graph
@@ -28,6 +30,43 @@ pub async fn handle_update_tasks(
             // Graceful degradation: log warning but don't show error popup
             log::warn!("Failed to fetch tasks for {dag_id}: {e}");
             // Task instances will remain unsorted
+        }
+    }
+}
+
+/// Handle showing the DAG graph popup from the dagrun panel.
+///
+/// Fetches tasks and task instances (same data as entering a dagrun),
+/// then builds the graph popup and displays it on the dagrun panel.
+pub async fn handle_show_dag_graph(
+    app: &Arc<Mutex<App>>,
+    client: &Arc<dyn AirflowClient>,
+    dag_id: &str,
+    dag_run_id: &str,
+) {
+    debug!("Fetching tasks and instances for DAG graph: {dag_id}/{dag_run_id}");
+
+    let (tasks_result, instances_result) = tokio::join!(
+        client.list_tasks(dag_id),
+        client.list_task_instances(dag_id, dag_run_id),
+    );
+
+    match (tasks_result, instances_result) {
+        (Ok(task_list), Ok(instance_list)) => {
+            let graph = TaskGraph::from_tasks(&task_list.tasks);
+            if graph.is_empty() {
+                return;
+            }
+            let popup = DagGraphPopup::new(&graph, &instance_list.task_instances);
+            let mut app = app.lock().unwrap();
+            app.dagruns.popup.show_custom(DagRunPopUp::Graph(popup));
+        }
+        (Err(e), _) | (_, Err(e)) => {
+            log::warn!("Failed to fetch data for DAG graph: {e}");
+            let mut app = app.lock().unwrap();
+            app.dagruns
+                .popup
+                .show_error(vec![format!("Failed to load DAG graph: {e}")]);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add a visual DAG graph popup to the Task Instance panel, accessible via the `d` keybinding
- Nodes are arranged left-to-right by topological level with edges showing dependencies using Unicode box-drawing characters
- Node borders are colored according to the task instance's run status (success=green, failed=red, running=lime, etc.)
- Supports scrolling with arrow keys / `hjkl` for large DAGs, dismiss with `Esc`/`q`
- Extends `TaskGraph` to store downstream edge adjacency info for graph rendering

### Example layout
```
╭──────────╮      ╭──────────╮      ╭──────────╮
│  task_a   │─────▶│  task_b   │─────▶│  task_d   │
╰──────────╯   ╭──╰──────────╯      ╰──────────╯
               │  ╭──────────╮
               ╰─▶│  task_c   │
                  ╰──────────╯
```

## Test plan

- [x] All 77 existing tests pass (`cargo test --workspace --lib --bins`)
- [x] Clippy clean (`cargo clippy --workspace --all-targets --all-features -- -D warnings`)
- [x] Formatting clean (`cargo fmt --all --check`)
- [ ] Manual testing: navigate to Task Instance panel, press `d` to open graph popup
- [ ] Verify node border colors match task instance states
- [ ] Verify scrolling works with arrow keys and hjkl
- [ ] Verify Esc/q closes the popup
- [ ] Test with DAGs of varying complexity (linear, diamond, wide fan-out)

https://claude.ai/code/session_01VDvkEkmwLijX7TicpXdofU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DAG dependency graph popup: open with "d" in task and dagrun views; scroll with arrows or h/j/k/l; nodes color-coded by state; graph can be opened from selected DAG run.

* **Bug Fixes / UX**
  * Graph loading errors now show an error popup when data can’t be fetched.
  * Popups and help UI now use theme-driven styling for titles, borders, and text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->