### PR TITLE
fix: Handle missing display_name fields and improve JSON parse error reporting for Airflow v2.8.1

### DIFF
--- a/crates/flowrs-airflow/src/client/v1/dag.rs
+++ b/crates/flowrs-airflow/src/client/v1/dag.rs
@@ -3,7 +3,7 @@ use log::{debug, info};
 use reqwest::Method;
 
 use super::model::dag::DagCollectionResponse;
-use super::V1Client;
+use super::{parse_json_response, V1Client};
 
 const PAGE_SIZE: usize = 50;
 
@@ -24,16 +24,7 @@ impl V1Client {
                 .error_for_status()?;
 
             let response_text = response.text().await?;
-            let page: DagCollectionResponse = match serde_json::from_str(&response_text) {
-                Ok(page) => page,
-                Err(e) => {
-                    return Err(anyhow::anyhow!(
-                        "Failed to parse DAGs response: {}. Response body (first 1000 chars): {}",
-                        e,
-                        response_text.chars().take(1000).collect::<String>()
-                    ));
-                }
-            };
+            let page: DagCollectionResponse = parse_json_response(&response_text, "DAGs response")?;
 
             total_entries = page.total_entries;
             let fetched_count = page.dags.len();

--- a/crates/flowrs-airflow/src/client/v1/dag.rs
+++ b/crates/flowrs-airflow/src/client/v1/dag.rs
@@ -23,7 +23,17 @@ impl V1Client {
                 .await?
                 .error_for_status()?;
 
-            let page: DagCollectionResponse = response.json().await?;
+            let response_text = response.text().await?;
+            let page: DagCollectionResponse = match serde_json::from_str(&response_text) {
+                Ok(page) => page,
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "Failed to parse DAGs response: {}. Response body (first 1000 chars): {}",
+                        e,
+                        response_text.chars().take(1000).collect::<String>()
+                    ));
+                }
+            };
 
             total_entries = page.total_entries;
             let fetched_count = page.dags.len();

--- a/crates/flowrs-airflow/src/client/v1/mod.rs
+++ b/crates/flowrs-airflow/src/client/v1/mod.rs
@@ -12,6 +12,23 @@ use reqwest::Method;
 
 use super::base::BaseClient;
 
+/// Parse a JSON response body, including a snippet of the body in the error on failure.
+///
+/// Some Airflow deployments return responses that don't match the documented schema
+/// (e.g. older v2.x versions omit `dag_display_name` / `task_display_name`). Surfacing
+/// the response body makes those parse failures actionable.
+pub(crate) fn parse_json_response<T: serde::de::DeserializeOwned>(
+    body: &str,
+    context: &str,
+) -> Result<T> {
+    serde_json::from_str(body).map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to parse {context}: {e}. Response body (first 1000 chars): {}",
+            body.chars().take(1000).collect::<String>()
+        )
+    })
+}
+
 /// API v1 client implementation (for Airflow v2, uses /api/v1 endpoint)
 #[derive(Debug)]
 pub struct V1Client {

--- a/crates/flowrs-airflow/src/client/v1/model/dag.rs
+++ b/crates/flowrs-airflow/src/client/v1/model/dag.rs
@@ -10,7 +10,7 @@ pub struct DagCollectionResponse {
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DagResponse {
     pub dag_id: String,
-    pub dag_display_name: String,
+    pub dag_display_name: Option<String>,
     pub root_dag_id: Option<String>,
     pub is_paused: Option<bool>,
     pub is_active: Option<bool>,

--- a/crates/flowrs-airflow/src/client/v1/model/taskinstance.rs
+++ b/crates/flowrs-airflow/src/client/v1/model/taskinstance.rs
@@ -10,7 +10,7 @@ pub struct TaskInstanceCollectionResponse {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TaskInstanceResponse {
     pub task_id: String,
-    pub task_display_name: String,
+    pub task_display_name: Option<String>,
     pub dag_id: String,
     pub dag_run_id: String,
     #[serde(with = "time::serde::iso8601")]

--- a/crates/flowrs-airflow/src/client/v1/taskinstance.rs
+++ b/crates/flowrs-airflow/src/client/v1/taskinstance.rs
@@ -3,7 +3,7 @@ use log::{debug, info};
 use reqwest::{Method, Response};
 
 use super::model;
-use super::V1Client;
+use super::{parse_json_response, V1Client};
 
 const PAGE_SIZE: usize = 100;
 
@@ -31,16 +31,8 @@ impl V1Client {
                 .error_for_status()?;
 
             let response_text = response.text().await?;
-            let page: model::taskinstance::TaskInstanceCollectionResponse = match serde_json::from_str(&response_text) {
-                Ok(page) => page,
-                Err(e) => {
-                    return Err(anyhow::anyhow!(
-                        "Failed to parse task instances response: {}. Response body (first 1000 chars): {}",
-                        e,
-                        response_text.chars().take(1000).collect::<String>()
-                    ));
-                }
-            };
+            let page: model::taskinstance::TaskInstanceCollectionResponse =
+                parse_json_response(&response_text, "task instances response")?;
 
             total_entries = page.total_entries;
             let fetched_count = page.task_instances.len();
@@ -88,16 +80,8 @@ impl V1Client {
                 .error_for_status()?;
 
             let response_text = response.text().await?;
-            let page: model::taskinstance::TaskInstanceCollectionResponse = match serde_json::from_str(&response_text) {
-                Ok(page) => page,
-                Err(e) => {
-                    return Err(anyhow::anyhow!(
-                        "Failed to parse all task instances response: {}. Response body (first 1000 chars): {}",
-                        e,
-                        response_text.chars().take(1000).collect::<String>()
-                    ));
-                }
-            };
+            let page: model::taskinstance::TaskInstanceCollectionResponse =
+                parse_json_response(&response_text, "all task instances response")?;
 
             total_entries = page.total_entries;
             let fetched_count = page.task_instances.len();
@@ -142,16 +126,8 @@ impl V1Client {
             .error_for_status()?;
 
         let response_text = response.text().await?;
-        let tries: model::taskinstance::TaskInstanceTriesResponse = match serde_json::from_str(&response_text) {
-            Ok(tries) => tries,
-            Err(e) => {
-                return Err(anyhow::anyhow!(
-                    "Failed to parse task instance tries response: {}. Response body (first 1000 chars): {}",
-                    e,
-                    response_text.chars().take(1000).collect::<String>()
-                ));
-            }
-        };
+        let tries: model::taskinstance::TaskInstanceTriesResponse =
+            parse_json_response(&response_text, "task instance tries response")?;
         debug!(
             "Fetched {} tries for task {task_id}",
             tries.task_instances.len()

--- a/crates/flowrs-airflow/src/client/v1/taskinstance.rs
+++ b/crates/flowrs-airflow/src/client/v1/taskinstance.rs
@@ -30,7 +30,17 @@ impl V1Client {
                 .await?
                 .error_for_status()?;
 
-            let page: model::taskinstance::TaskInstanceCollectionResponse = response.json().await?;
+            let response_text = response.text().await?;
+            let page: model::taskinstance::TaskInstanceCollectionResponse = match serde_json::from_str(&response_text) {
+                Ok(page) => page,
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "Failed to parse task instances response: {}. Response body (first 1000 chars): {}",
+                        e,
+                        response_text.chars().take(1000).collect::<String>()
+                    ));
+                }
+            };
 
             total_entries = page.total_entries;
             let fetched_count = page.task_instances.len();
@@ -77,7 +87,17 @@ impl V1Client {
                 .await?
                 .error_for_status()?;
 
-            let page: model::taskinstance::TaskInstanceCollectionResponse = response.json().await?;
+            let response_text = response.text().await?;
+            let page: model::taskinstance::TaskInstanceCollectionResponse = match serde_json::from_str(&response_text) {
+                Ok(page) => page,
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "Failed to parse all task instances response: {}. Response body (first 1000 chars): {}",
+                        e,
+                        response_text.chars().take(1000).collect::<String>()
+                    ));
+                }
+            };
 
             total_entries = page.total_entries;
             let fetched_count = page.task_instances.len();
@@ -121,7 +141,17 @@ impl V1Client {
             .await?
             .error_for_status()?;
 
-        let tries: model::taskinstance::TaskInstanceTriesResponse = response.json().await?;
+        let response_text = response.text().await?;
+        let tries: model::taskinstance::TaskInstanceTriesResponse = match serde_json::from_str(&response_text) {
+            Ok(tries) => tries,
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "Failed to parse task instance tries response: {}. Response body (first 1000 chars): {}",
+                    e,
+                    response_text.chars().take(1000).collect::<String>()
+                ));
+            }
+        };
         debug!(
             "Fetched {} tries for task {task_id}",
             tries.task_instances.len()

--- a/crates/flowrs-airflow/src/client/v2/model/taskinstance.rs
+++ b/crates/flowrs-airflow/src/client/v2/model/taskinstance.rs
@@ -30,7 +30,7 @@ pub struct TaskInstance {
     pub state: Option<String>,
     pub try_number: u32,
     pub max_tries: i64,
-    pub task_display_name: String,
+    pub task_display_name: Option<String>,
     pub hostname: Option<String>,
     pub unixname: Option<String>,
     pub pool: String,

--- a/src/airflow/client/convert_v1.rs
+++ b/src/airflow/client/convert_v1.rs
@@ -7,9 +7,10 @@ use crate::airflow::model::common::{
 };
 
 pub(crate) fn v1_dag_to_dag(value: flowrs_airflow::client::v1::model::dag::DagResponse) -> Dag {
+    let dag_id = value.dag_id.clone();
     Dag {
         dag_id: value.dag_id.into(),
-        dag_display_name: Some(value.dag_display_name),
+        dag_display_name: value.dag_display_name.or_else(|| Some(dag_id)),
         description: value.description,
         fileloc: value.fileloc,
         is_paused: value.is_paused.unwrap_or(false),

--- a/src/airflow/client/convert_v1.rs
+++ b/src/airflow/client/convert_v1.rs
@@ -10,7 +10,7 @@ pub(crate) fn v1_dag_to_dag(value: flowrs_airflow::client::v1::model::dag::DagRe
     let dag_id = value.dag_id.clone();
     Dag {
         dag_id: value.dag_id.into(),
-        dag_display_name: value.dag_display_name.or_else(|| Some(dag_id)),
+        dag_display_name: value.dag_display_name.or(Some(dag_id)),
         description: value.description,
         fileloc: value.fileloc,
         is_paused: value.is_paused.unwrap_or(false),


### PR DESCRIPTION
I am running airflow v2.8.1 in docker.
I've faced 2 issues:
- "Error 1: error decoding response body" when clicking open on config. Agent added explicit error message when this is happening
- My dags don't have dag_display_name or task_display_name

Let me know if this is any good

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error diagnostics when API responses fail to parse — error messages now include a snippet of the response body to aid troubleshooting.
  * Made DAG and task display names optional; when missing or null, the UI falls back to using the DAG/task identifier.
  * Hardened API response handling to better tolerate and surface unexpected or non-conforming payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->