### PR TITLE
feat: Add insecure SSL connection option

### DIFF
--- a/crates/flowrs-airflow/src/client/base.rs
+++ b/crates/flowrs-airflow/src/client/base.rs
@@ -31,6 +31,7 @@ impl BaseClient {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(config.timeout_secs))
             .use_rustls_tls()
+            .danger_accept_invalid_certs(config.insecure)
             .build()?;
 
         let auth_provider = create_auth_provider(&config.auth)?;

--- a/crates/flowrs-airflow/src/client/base.rs
+++ b/crates/flowrs-airflow/src/client/base.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use log::debug;
+use log::{debug, warn};
 use reqwest::{Method, Url};
 use std::convert::TryFrom;
 use std::fmt;
@@ -28,6 +28,12 @@ impl fmt::Debug for BaseClient {
 
 impl BaseClient {
     pub fn new(config: AirflowConfig) -> Result<Self> {
+        if config.insecure {
+            warn!(
+                "TLS certificate verification is disabled for server '{}'",
+                config.name
+            );
+        }
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(config.timeout_secs))
             .use_rustls_tls()

--- a/crates/flowrs-airflow/src/config.rs
+++ b/crates/flowrs-airflow/src/config.rs
@@ -60,6 +60,9 @@ pub struct AirflowConfig {
     /// Request timeout in seconds. Defaults to 30 seconds if not specified.
     #[serde(default = "default_timeout")]
     pub timeout_secs: u64,
+    /// Whether to allow insecure SSL connections.
+    #[serde(default)]
+    pub insecure: bool,
 }
 
 pub const fn default_timeout() -> u64 {

--- a/crates/flowrs-airflow/src/managed_services/astronomer.rs
+++ b/crates/flowrs-airflow/src/managed_services/astronomer.rs
@@ -301,6 +301,7 @@ pub async fn get_astronomer_environment_servers() -> (Vec<AirflowConfig>, Vec<St
                 managed: Some(ManagedService::Astronomer),
                 version,
                 timeout_secs: 30,
+                insecure: false,
             });
         }
     }

--- a/crates/flowrs-airflow/src/managed_services/composer/client.rs
+++ b/crates/flowrs-airflow/src/managed_services/composer/client.rs
@@ -324,6 +324,7 @@ pub async fn get_composer_environment_servers(
                 managed: Some(ManagedService::Gcc),
                 version,
                 timeout_secs: 30,
+                insecure: false,
             });
         }
     }

--- a/crates/flowrs-airflow/src/managed_services/conveyor.rs
+++ b/crates/flowrs-airflow/src/managed_services/conveyor.rs
@@ -143,6 +143,7 @@ pub fn get_conveyor_environment_servers() -> Result<Vec<AirflowConfig>> {
                 managed: Some(ManagedService::Conveyor),
                 version,
                 timeout_secs: 30,
+                insecure: false,
             }
         })
         .collect();

--- a/crates/flowrs-airflow/src/managed_services/mwaa.rs
+++ b/crates/flowrs-airflow/src/managed_services/mwaa.rs
@@ -249,6 +249,7 @@ pub async fn get_mwaa_environment_servers() -> Result<Vec<AirflowConfig>> {
             managed: Some(ManagedService::Mwaa),
             version,
             timeout_secs: 30,
+            insecure: false,
         });
     }
 

--- a/crates/flowrs-config/src/lib.rs
+++ b/crates/flowrs-config/src/lib.rs
@@ -209,6 +209,7 @@ password = "airflow"
                 managed: None,
                 version: AirflowVersion::V2,
                 timeout_secs: default_timeout(),
+                insecure: false,
             }],
             managed_services: vec![ManagedService::Conveyor],
             active_server: None,

--- a/crates/flowrs-config/src/lib.rs
+++ b/crates/flowrs-config/src/lib.rs
@@ -182,6 +182,7 @@ name = "bla"
 endpoint = "http://localhost:8080"
 version = "V2"
 timeout_secs = 30
+insecure = false
 
 [servers.auth.Basic]
 username = "airflow"

--- a/src/commands/config/add.rs
+++ b/src/commands/config/add.rs
@@ -27,6 +27,10 @@ impl AddCommand {
             _ => AirflowVersion::V2,
         };
 
+        let insecure = inquire::Confirm::new("Allow insecure SSL connections? (danger)")
+            .with_default(false)
+            .prompt()?;
+
         let auth_type =
             Select::new("authentication type", ConfigOption::iter().collect()).prompt()?;
 
@@ -44,6 +48,7 @@ impl AddCommand {
                     managed: None,
                     version,
                     timeout_secs: 30,
+                    insecure,
                 }
             }
             ConfigOption::Token(_) => {
@@ -64,6 +69,7 @@ impl AddCommand {
                     managed: None,
                     version,
                     timeout_secs: 30,
+                    insecure,
                 }
             }
         };

--- a/src/commands/config/add.rs
+++ b/src/commands/config/add.rs
@@ -27,10 +27,14 @@ impl AddCommand {
             _ => AirflowVersion::V2,
         };
 
-        let insecure = inquire::Confirm::new("Allow insecure SSL connections? (danger)")
-            .with_help_message("Disables TLS certificate verification (MITM risk). Use only for local/dev port-forwarded endpoints.")
-            .with_default(false)
-            .prompt()?;
+        let insecure = if self.insecure {
+            inquire::Confirm::new("Are you sure you want to allow insecure SSL connections? (danger)")
+                .with_help_message("Disables TLS certificate verification (MITM risk). Use only for local/dev port-forwarded endpoints.")
+                .with_default(false)
+                .prompt()?
+        } else {
+            false
+        };
 
         let auth_type =
             Select::new("authentication type", ConfigOption::iter().collect()).prompt()?;

--- a/src/commands/config/add.rs
+++ b/src/commands/config/add.rs
@@ -28,6 +28,7 @@ impl AddCommand {
         };
 
         let insecure = inquire::Confirm::new("Allow insecure SSL connections? (danger)")
+            .with_help_message("Disables TLS certificate verification (MITM risk). Use only for local/dev port-forwarded endpoints.")
             .with_default(false)
             .prompt()?;
 

--- a/src/commands/config/model.rs
+++ b/src/commands/config/model.rs
@@ -139,6 +139,8 @@ impl ConfigCommand {
 pub struct AddCommand {
     #[clap(short, long)]
     pub file: Option<String>,
+    #[clap(long)]
+    pub insecure: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -159,6 +161,8 @@ pub struct UpdateCommand {
     pub name: Option<String>,
     #[clap(short, long)]
     pub file: Option<String>,
+    #[clap(long)]
+    pub insecure: bool,
 }
 
 #[derive(EnumIter, Debug, Display)]

--- a/src/commands/config/update.rs
+++ b/src/commands/config/update.rs
@@ -45,9 +45,14 @@ impl UpdateCommand {
             .with_validator(validate_endpoint)
             .prompt()?;
 
-        let insecure = inquire::Confirm::new("Allow insecure SSL connections? (danger)")
-            .with_default(airflow_config.insecure)
-            .prompt()?;
+        let insecure = if self.insecure || airflow_config.insecure {
+            inquire::Confirm::new("Allow insecure SSL connections? (danger)")
+                .with_help_message("Disables TLS certificate verification (MITM risk). Use only for local/dev port-forwarded endpoints.")
+                .with_default(airflow_config.insecure)
+                .prompt()?
+        } else {
+            false
+        };
 
         let auth_type =
             Select::new("authentication type", ConfigOption::iter().collect()).prompt()?;

--- a/src/commands/config/update.rs
+++ b/src/commands/config/update.rs
@@ -45,11 +45,16 @@ impl UpdateCommand {
             .with_validator(validate_endpoint)
             .prompt()?;
 
+        let insecure = inquire::Confirm::new("Allow insecure SSL connections? (danger)")
+            .with_default(airflow_config.insecure)
+            .prompt()?;
+
         let auth_type =
             Select::new("authentication type", ConfigOption::iter().collect()).prompt()?;
 
         airflow_config.name = name;
         airflow_config.endpoint = endpoint;
+        airflow_config.insecure = insecure;
         match auth_type {
             ConfigOption::BasicAuth => {
                 let username = inquire::Text::new("username").prompt()?;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -69,6 +69,7 @@ pub fn create_test_client() -> anyhow::Result<Arc<dyn AirflowClient>> {
         managed: None,
         version,
         timeout_secs: 30,
+        insecure: false,
     };
 
     let client = FlowrsClient::new(&config)?;
@@ -91,6 +92,7 @@ pub async fn create_test_client_v3() -> anyhow::Result<Arc<dyn AirflowClient>> {
         managed: None,
         version: AirflowVersion::V3,
         timeout_secs: 30,
+        insecure: false,
     };
 
     let client = FlowrsClient::new(&config)?;


### PR DESCRIPTION
This commit introduces the ability to allow insecure SSL connections to Airflow.  Currently, we port-forward to our local Airflow instance running in Kubernetes, which is served over TLS.

- Added `insecure` field to `AirflowConfig` to allow insecure SSL connections.
- Updated `BaseClient` to use `danger_accept_invalid_certs` based on the `insecure` configuration.
- Added `insecure` option to `add` and `update` commands to allow users to configure insecure SSL connections.
- Set `insecure` to false by default for managed services.
- Set `insecure` to false in default config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable "allow insecure SSL" option for Airflow connections (CLI flags for add/update; defaults to off).
  * Managed-service discovery now explicitly marks discovered environments as non-insecure by default.

* **Behavior**
  * When insecure mode is enabled, the CLI emits a visible warning about reduced TLS certificate verification and may alter connection verification.

* **Tests**
  * Test fixtures updated to include the new insecure setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->