### PR TITLE
fix: enable rustls-tls-native-roots for managed Airflow TLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3043,6 +3043,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.40",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ chrono = "0.4.43"
 clap = { version = "^4.5", features = ["derive", "env"] }
 dirs = "6.0.0"
 log = { version = "0.4.29", features = ["std"] }
-reqwest = { version = "0.12.28", features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12.28", features = ["json", "rustls-tls", "rustls-tls-native-roots"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.148"
 strum = { version = "0.28.0", features = ["derive"] }


### PR DESCRIPTION
## Problem

When connecting flowrs to an AWS MWAA environment, all Airflow REST API requests fail at the TLS layer:

```
error sending request for url (https://<env>.c2.airflow.<region>.on.aws/api/v1/dags?...)
caused by [0]: client error (Connect)
caused by [1]: invalid peer certificate: UnknownIssuer
```

The same endpoint validates successfully via `curl`, browsers, and the AWS SDK — they all use the OS trust store, while flowrs (with the `rustls-tls` feature) only uses the `webpki-roots` bundle, which does not contain the Amazon-issued intermediate CAs required to verify MWAA webserver certificates.

This affects every managed Airflow service that fronts the webserver with a certificate chain not anchored in `webpki-roots`, e.g. AWS MWAA (`*.c2.airflow.<region>.on.aws`, `*.c3.airflow.<region>.on.aws`).

## Fix

Add the `rustls-tls-native-roots` feature to the workspace `reqwest` dependency. With this feature enabled, reqwest also loads the system's native root certificate store (macOS Keychain, Linux ca-certificates, Windows cert store) in addition to webpki-roots, so MWAA chains validate cleanly.

The change is strictly additive — users whose endpoints already validate against webpki-roots are unaffected. No code changes required.

## Test plan

- [x] Reproduced the `UnknownIssuer` failure on macOS 14 against two MWAA 2.10.3 environments
- [x] Built locally with the patch — both environments now connect and `fetch_dags` succeeds (2400 / 851 DAGs loaded respectively)
- [x] No code changes outside `Cargo.toml` / `Cargo.lock`

## Notes

Related to #632 (the `insecure` flag), which is a workaround for the same class of issue but disables certificate verification entirely. This PR fixes the root cause for the common managed-Airflow case without compromising TLS.