### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.5](https://github.com/jvanbuel/flowrs/compare/flowrs-tui-v0.12.4...flowrs-tui-v0.12.5) - 2026-05-15
+
+### Fixed
+
+- enable rustls-tls-native-roots for managed Airflow TLS
+
 ## [0.12.4](https://github.com/jvanbuel/flowrs/compare/flowrs-tui-v0.12.3...flowrs-tui-v0.12.4) - 2026-05-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -187,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -602,6 +602,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -1171,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-airflow"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-config"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1209,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-tui"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -2612,18 +2621,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3406,11 +3415,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3425,9 +3435,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4763,9 +4773,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
@@ -4933,9 +4943,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ toml = "1.1.2"
 
 [package]
 name = "flowrs-tui"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Flowrs is a Terminal User Interface (TUI) for Apache Airflow"
@@ -46,8 +46,8 @@ ansi-to-tui = { version = "8.0.1" }
 anyhow = { workspace = true }
 catppuccin = { workspace = true }
 async-trait = { workspace = true }
-flowrs-config = { path = "crates/flowrs-config", version = "0.11.2" }
-flowrs-airflow = { path = "crates/flowrs-airflow", version = "0.10.3" }
+flowrs-config = { path = "crates/flowrs-config", version = "0.11.3" }
+flowrs-airflow = { path = "crates/flowrs-airflow", version = "0.10.4" }
 chrono = { workspace = true }
 clap = { workspace = true }
 crossterm = "0.29.0"

--- a/crates/flowrs-airflow/CHANGELOG.md
+++ b/crates/flowrs-airflow/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.4](https://github.com/jvanbuel/flowrs/compare/flowrs-airflow-v0.10.3...flowrs-airflow-v0.10.4) - 2026-05-15
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.10.3](https://github.com/jvanbuel/flowrs/compare/flowrs-airflow-v0.10.2...flowrs-airflow-v0.10.3) - 2026-05-10
 
 ### Fixed

--- a/crates/flowrs-airflow/Cargo.toml
+++ b/crates/flowrs-airflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-airflow"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Airflow API client library"

--- a/crates/flowrs-config/CHANGELOG.md
+++ b/crates/flowrs-config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.3](https://github.com/jvanbuel/flowrs/compare/flowrs-config-v0.11.2...flowrs-config-v0.11.3) - 2026-05-15
+
+### Other
+
+- updated the following local packages: flowrs-airflow
+
 ## [0.11.2](https://github.com/jvanbuel/flowrs/compare/flowrs-config-v0.11.1...flowrs-config-v0.11.2) - 2026-05-10
 
 ### Other

--- a/crates/flowrs-config/Cargo.toml
+++ b/crates/flowrs-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-config"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Configuration types for flowrs"
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/jvanbuel/flowrs"
 
 [dependencies]
-flowrs-airflow = { path = "../flowrs-airflow", version = "0.10.3", default-features = false }
+flowrs-airflow = { path = "../flowrs-airflow", version = "0.10.4", default-features = false }
 anyhow.workspace = true
 clap.workspace = true
 dirs.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `flowrs-airflow`: 0.10.3 -> 0.10.4
* `flowrs-tui`: 0.12.4 -> 0.12.5
* `flowrs-config`: 0.11.2 -> 0.11.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `flowrs-airflow`

<blockquote>

## [0.10.4](https://github.com/jvanbuel/flowrs/compare/flowrs-airflow-v0.10.3...flowrs-airflow-v0.10.4) - 2026-05-15

### Other

- update Cargo.toml dependencies
</blockquote>

## `flowrs-tui`

<blockquote>

## [0.12.5](https://github.com/jvanbuel/flowrs/compare/flowrs-tui-v0.12.4...flowrs-tui-v0.12.5) - 2026-05-15

### Fixed

- enable rustls-tls-native-roots for managed Airflow TLS
</blockquote>

## `flowrs-config`

<blockquote>

## [0.11.3](https://github.com/jvanbuel/flowrs/compare/flowrs-config-v0.11.2...flowrs-config-v0.11.3) - 2026-05-15

### Other

- updated the following local packages: flowrs-airflow
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TLS support for managed Airflow deployments

* **Chores**
  * Updated dependencies across packages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jvanbuel/flowrs/pull/639)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->