### PR TITLE
Skip cleared task tries with stale dates in gantt bar rendering

### DIFF
--- a/src/airflow/model/common/gantt.rs
+++ b/src/airflow/model/common/gantt.rs
@@ -14,6 +14,35 @@ pub struct TaskTryGantt {
     pub state: Option<TaskInstanceState>,
 }
 
+impl TaskTryGantt {
+    /// Whether this try should contribute a segment to the Gantt bar.
+    ///
+    /// A try is renderable when it has a `start_date` AND either (a) it has
+    /// an `end_date` (completed) or (b) it is in an actively-executing state.
+    ///
+    /// This excludes stale data Airflow may report after clearing a task,
+    /// where the new pending task instance is returned with a populated
+    /// `start_date` (from a previous attempt or `scheduled_when`) but a
+    /// non-running state like `None`, `Scheduled`, `Queued`, or `UpForRetry`.
+    #[must_use]
+    pub fn is_renderable(&self) -> bool {
+        if self.start_date.is_none() {
+            return false;
+        }
+        if self.end_date.is_some() {
+            return true;
+        }
+        matches!(
+            self.state,
+            Some(
+                TaskInstanceState::Running
+                    | TaskInstanceState::Restarting
+                    | TaskInstanceState::Deferred
+            )
+        )
+    }
+}
+
 /// Gantt chart data for all task instances in the current DAG run.
 /// Rebuilt each time the task instance list is refreshed.
 #[derive(Debug, Clone, Default)]
@@ -82,11 +111,16 @@ impl GanttData {
 
         for tries in self.task_tries.values() {
             for t in tries {
-                if let Some(start) = t.start_date {
-                    min_start = Some(min_start.map_or(start, |cur| cur.min(start)));
-                }
-                if let Some(end) = t.end_date {
-                    max_end = Some(max_end.map_or(end, |cur| cur.max(end)));
+                // Only contribute to the window if the try will actually be
+                // rendered; otherwise stale start/end dates from a cleared TI
+                // would skew the window for other tasks' bars.
+                if t.is_renderable() {
+                    if let Some(start) = t.start_date {
+                        min_start = Some(min_start.map_or(start, |cur| cur.min(start)));
+                    }
+                    if let Some(end) = t.end_date {
+                        max_end = Some(max_end.map_or(end, |cur| cur.max(end)));
+                    }
                 }
                 if matches!(
                     t.state,
@@ -94,6 +128,8 @@ impl GanttData {
                         TaskInstanceState::Running
                             | TaskInstanceState::Queued
                             | TaskInstanceState::Scheduled
+                            | TaskInstanceState::Restarting
+                            | TaskInstanceState::Deferred
                     )
                 ) {
                     any_running = true;
@@ -205,6 +241,105 @@ mod tests {
         let gantt = GanttData::from_task_instances(&tasks);
         assert_eq!(gantt.window_start, Some(datetime!(2024-01-01 10:00:00 UTC)));
         assert_eq!(gantt.window_end, Some(datetime!(2024-01-01 11:00:00 UTC)));
+    }
+
+    #[test]
+    fn test_cleared_task_with_stale_start_date_is_not_renderable() {
+        // After clearing, Airflow may return a TI with a stale `start_date`
+        // (from a previous attempt or `scheduled_when`) but a non-running
+        // state. Such tries must not paint a Gantt segment.
+        let stale = TaskTryGantt {
+            try_number: 2,
+            start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
+            end_date: None,
+            state: Some(TaskInstanceState::Scheduled),
+        };
+        assert!(!stale.is_renderable());
+
+        let pending_none = TaskTryGantt {
+            try_number: 2,
+            start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
+            end_date: None,
+            state: None,
+        };
+        assert!(!pending_none.is_renderable());
+
+        let queued = TaskTryGantt {
+            try_number: 2,
+            start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
+            end_date: None,
+            state: Some(TaskInstanceState::Queued),
+        };
+        assert!(!queued.is_renderable());
+
+        let up_for_retry = TaskTryGantt {
+            try_number: 2,
+            start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
+            end_date: None,
+            state: Some(TaskInstanceState::UpForRetry),
+        };
+        assert!(!up_for_retry.is_renderable());
+    }
+
+    #[test]
+    fn test_running_and_completed_tries_are_renderable() {
+        let running = TaskTryGantt {
+            try_number: 1,
+            start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
+            end_date: None,
+            state: Some(TaskInstanceState::Running),
+        };
+        assert!(running.is_renderable());
+
+        let completed = TaskTryGantt {
+            try_number: 1,
+            start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
+            end_date: Some(datetime!(2024-01-01 10:30:00 UTC)),
+            state: Some(TaskInstanceState::Success),
+        };
+        assert!(completed.is_renderable());
+
+        let failed = TaskTryGantt {
+            try_number: 1,
+            start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
+            end_date: Some(datetime!(2024-01-01 10:30:00 UTC)),
+            state: Some(TaskInstanceState::Failed),
+        };
+        assert!(failed.is_renderable());
+
+        let no_start = TaskTryGantt {
+            try_number: 1,
+            start_date: None,
+            end_date: None,
+            state: None,
+        };
+        assert!(!no_start.is_renderable());
+    }
+
+    #[test]
+    fn test_window_ignores_stale_start_dates() {
+        // task_1 completed at 10:00–10:30.
+        // task_2 was cleared and has a stale start_date from 09:00 with no end.
+        // Without the fix, window_start would be pulled back to 09:00.
+        let mut gantt = GanttData::from_task_instances(&[make_task(
+            "task_1",
+            1,
+            Some(datetime!(2024-01-01 10:00:00 UTC)),
+            Some(datetime!(2024-01-01 10:30:00 UTC)),
+            Some(TaskInstanceState::Success),
+        )]);
+        gantt.task_tries.insert(
+            "task_2".into(),
+            vec![TaskTryGantt {
+                try_number: 2,
+                start_date: Some(datetime!(2024-01-01 09:00:00 UTC)),
+                end_date: None,
+                state: None,
+            }],
+        );
+        gantt.recompute_window();
+        assert_eq!(gantt.window_start, Some(datetime!(2024-01-01 10:00:00 UTC)));
+        assert_eq!(gantt.window_end, Some(datetime!(2024-01-01 10:30:00 UTC)));
     }
 
     #[test]

--- a/src/airflow/model/common/gantt.rs
+++ b/src/airflow/model/common/gantt.rs
@@ -14,42 +14,6 @@ pub struct TaskTryGantt {
     pub state: Option<TaskInstanceState>,
 }
 
-impl TaskTryGantt {
-    /// Whether this try should contribute a segment to the Gantt bar.
-    ///
-    /// A try is renderable when it has a `start_date` AND a concrete
-    /// execution state AND either has an `end_date` (completed) or is in an
-    /// actively-executing state.
-    ///
-    /// In particular this excludes tries with no `state` (or `Unknown`):
-    /// after a clear, Airflow may report the new task instance with stale
-    /// `start_date`/`end_date` from the prior attempt but `state = None`,
-    /// and the `/tries` endpoint can include that pending TI alongside the
-    /// real history. Without this guard the cleared task's bar gets painted
-    /// with the `None`-state (reset/gray) color until the next run begins.
-    #[must_use]
-    pub fn is_renderable(&self) -> bool {
-        if self.start_date.is_none() {
-            return false;
-        }
-        let Some(state) = &self.state else {
-            return false;
-        };
-        if matches!(state, TaskInstanceState::Unknown) {
-            return false;
-        }
-        if self.end_date.is_some() {
-            return true;
-        }
-        matches!(
-            state,
-            TaskInstanceState::Running
-                | TaskInstanceState::Restarting
-                | TaskInstanceState::Deferred
-        )
-    }
-}
-
 /// Gantt chart data for all task instances in the current DAG run.
 /// Rebuilt each time the task instance list is refreshed.
 #[derive(Debug, Clone, Default)]
@@ -118,16 +82,11 @@ impl GanttData {
 
         for tries in self.task_tries.values() {
             for t in tries {
-                // Only contribute to the window if the try will actually be
-                // rendered; otherwise stale start/end dates from a cleared TI
-                // would skew the window for other tasks' bars.
-                if t.is_renderable() {
-                    if let Some(start) = t.start_date {
-                        min_start = Some(min_start.map_or(start, |cur| cur.min(start)));
-                    }
-                    if let Some(end) = t.end_date {
-                        max_end = Some(max_end.map_or(end, |cur| cur.max(end)));
-                    }
+                if let Some(start) = t.start_date {
+                    min_start = Some(min_start.map_or(start, |cur| cur.min(start)));
+                }
+                if let Some(end) = t.end_date {
+                    max_end = Some(max_end.map_or(end, |cur| cur.max(end)));
                 }
                 if matches!(
                     t.state,
@@ -135,8 +94,6 @@ impl GanttData {
                         TaskInstanceState::Running
                             | TaskInstanceState::Queued
                             | TaskInstanceState::Scheduled
-                            | TaskInstanceState::Restarting
-                            | TaskInstanceState::Deferred
                     )
                 ) {
                     any_running = true;
@@ -248,131 +205,6 @@ mod tests {
         let gantt = GanttData::from_task_instances(&tasks);
         assert_eq!(gantt.window_start, Some(datetime!(2024-01-01 10:00:00 UTC)));
         assert_eq!(gantt.window_end, Some(datetime!(2024-01-01 11:00:00 UTC)));
-    }
-
-    #[test]
-    fn test_cleared_task_with_stale_start_date_is_not_renderable() {
-        // After clearing, Airflow may return a TI with a stale `start_date`
-        // (from a previous attempt or `scheduled_when`) but a non-running
-        // state. Such tries must not paint a Gantt segment.
-        let stale = TaskTryGantt {
-            try_number: 2,
-            start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
-            end_date: None,
-            state: Some(TaskInstanceState::Scheduled),
-        };
-        assert!(!stale.is_renderable());
-
-        let pending_none = TaskTryGantt {
-            try_number: 2,
-            start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
-            end_date: None,
-            state: None,
-        };
-        assert!(!pending_none.is_renderable());
-
-        let queued = TaskTryGantt {
-            try_number: 2,
-            start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
-            end_date: None,
-            state: Some(TaskInstanceState::Queued),
-        };
-        assert!(!queued.is_renderable());
-
-        let up_for_retry = TaskTryGantt {
-            try_number: 2,
-            start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
-            end_date: None,
-            state: Some(TaskInstanceState::UpForRetry),
-        };
-        assert!(!up_for_retry.is_renderable());
-    }
-
-    #[test]
-    fn test_cleared_task_with_stale_completed_dates_is_not_renderable() {
-        // After clearing in Airflow 3 (and 2.10+ in some versions), the
-        // /tries endpoint returns the current cleared TI alongside the
-        // history. Airflow may retain the previous attempt's start/end
-        // dates on that pending entry but reset the state to None. Without
-        // skipping it, the Gantt bar paints with the None-state (gray)
-        // color even though the prior attempt should still show its
-        // success/failed color until the new attempt runs.
-        let cleared_with_stale_dates = TaskTryGantt {
-            try_number: 2,
-            start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
-            end_date: Some(datetime!(2024-01-01 10:30:00 UTC)),
-            state: None,
-        };
-        assert!(!cleared_with_stale_dates.is_renderable());
-
-        let unknown_state = TaskTryGantt {
-            try_number: 2,
-            start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
-            end_date: Some(datetime!(2024-01-01 10:30:00 UTC)),
-            state: Some(TaskInstanceState::Unknown),
-        };
-        assert!(!unknown_state.is_renderable());
-    }
-
-    #[test]
-    fn test_running_and_completed_tries_are_renderable() {
-        let running = TaskTryGantt {
-            try_number: 1,
-            start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
-            end_date: None,
-            state: Some(TaskInstanceState::Running),
-        };
-        assert!(running.is_renderable());
-
-        let completed = TaskTryGantt {
-            try_number: 1,
-            start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
-            end_date: Some(datetime!(2024-01-01 10:30:00 UTC)),
-            state: Some(TaskInstanceState::Success),
-        };
-        assert!(completed.is_renderable());
-
-        let failed = TaskTryGantt {
-            try_number: 1,
-            start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
-            end_date: Some(datetime!(2024-01-01 10:30:00 UTC)),
-            state: Some(TaskInstanceState::Failed),
-        };
-        assert!(failed.is_renderable());
-
-        let no_start = TaskTryGantt {
-            try_number: 1,
-            start_date: None,
-            end_date: None,
-            state: None,
-        };
-        assert!(!no_start.is_renderable());
-    }
-
-    #[test]
-    fn test_window_ignores_stale_start_dates() {
-        // task_1 completed at 10:00–10:30.
-        // task_2 was cleared and has a stale start_date from 09:00 with no end.
-        // Without the fix, window_start would be pulled back to 09:00.
-        let mut gantt = GanttData::from_task_instances(&[make_task(
-            "task_1",
-            1,
-            Some(datetime!(2024-01-01 10:00:00 UTC)),
-            Some(datetime!(2024-01-01 10:30:00 UTC)),
-            Some(TaskInstanceState::Success),
-        )]);
-        gantt.task_tries.insert(
-            "task_2".into(),
-            vec![TaskTryGantt {
-                try_number: 2,
-                start_date: Some(datetime!(2024-01-01 09:00:00 UTC)),
-                end_date: None,
-                state: None,
-            }],
-        );
-        gantt.recompute_window();
-        assert_eq!(gantt.window_start, Some(datetime!(2024-01-01 10:00:00 UTC)));
-        assert_eq!(gantt.window_end, Some(datetime!(2024-01-01 10:30:00 UTC)));
     }
 
     #[test]

--- a/src/airflow/model/common/gantt.rs
+++ b/src/airflow/model/common/gantt.rs
@@ -17,28 +17,35 @@ pub struct TaskTryGantt {
 impl TaskTryGantt {
     /// Whether this try should contribute a segment to the Gantt bar.
     ///
-    /// A try is renderable when it has a `start_date` AND either (a) it has
-    /// an `end_date` (completed) or (b) it is in an actively-executing state.
+    /// A try is renderable when it has a `start_date` AND a concrete
+    /// execution state AND either has an `end_date` (completed) or is in an
+    /// actively-executing state.
     ///
-    /// This excludes stale data Airflow may report after clearing a task,
-    /// where the new pending task instance is returned with a populated
-    /// `start_date` (from a previous attempt or `scheduled_when`) but a
-    /// non-running state like `None`, `Scheduled`, `Queued`, or `UpForRetry`.
+    /// In particular this excludes tries with no `state` (or `Unknown`):
+    /// after a clear, Airflow may report the new task instance with stale
+    /// `start_date`/`end_date` from the prior attempt but `state = None`,
+    /// and the `/tries` endpoint can include that pending TI alongside the
+    /// real history. Without this guard the cleared task's bar gets painted
+    /// with the `None`-state (reset/gray) color until the next run begins.
     #[must_use]
     pub fn is_renderable(&self) -> bool {
         if self.start_date.is_none() {
+            return false;
+        }
+        let Some(state) = &self.state else {
+            return false;
+        };
+        if matches!(state, TaskInstanceState::Unknown) {
             return false;
         }
         if self.end_date.is_some() {
             return true;
         }
         matches!(
-            self.state,
-            Some(
-                TaskInstanceState::Running
-                    | TaskInstanceState::Restarting
-                    | TaskInstanceState::Deferred
-            )
+            state,
+            TaskInstanceState::Running
+                | TaskInstanceState::Restarting
+                | TaskInstanceState::Deferred
         )
     }
 }
@@ -279,6 +286,32 @@ mod tests {
             state: Some(TaskInstanceState::UpForRetry),
         };
         assert!(!up_for_retry.is_renderable());
+    }
+
+    #[test]
+    fn test_cleared_task_with_stale_completed_dates_is_not_renderable() {
+        // After clearing in Airflow 3 (and 2.10+ in some versions), the
+        // /tries endpoint returns the current cleared TI alongside the
+        // history. Airflow may retain the previous attempt's start/end
+        // dates on that pending entry but reset the state to None. Without
+        // skipping it, the Gantt bar paints with the None-state (gray)
+        // color even though the prior attempt should still show its
+        // success/failed color until the new attempt runs.
+        let cleared_with_stale_dates = TaskTryGantt {
+            try_number: 2,
+            start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
+            end_date: Some(datetime!(2024-01-01 10:30:00 UTC)),
+            state: None,
+        };
+        assert!(!cleared_with_stale_dates.is_renderable());
+
+        let unknown_state = TaskTryGantt {
+            try_number: 2,
+            start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
+            end_date: Some(datetime!(2024-01-01 10:30:00 UTC)),
+            state: Some(TaskInstanceState::Unknown),
+        };
+        assert!(!unknown_state.is_renderable());
     }
 
     #[test]

--- a/src/ui/gantt.rs
+++ b/src/ui/gantt.rs
@@ -34,26 +34,28 @@ pub fn create_gantt_bar(gantt: &GanttData, task_id: &TaskId, width: usize) -> Li
         let Some(start) = t.start_date else {
             continue;
         };
-        // Only paint a segment if the try actually executed (or is
-        // executing). After a clear, Airflow's /tries endpoint may include
-        // the new TI with stale dates from the prior attempt but a
-        // pre-execution state (None, Scheduled, Queued, UpForRetry, ...),
-        // which would otherwise overwrite the previous bar's color.
-        if !matches!(
-            t.state,
-            Some(
-                TaskInstanceState::Success
+        // Only paint a segment for states that have a concrete color and
+        // unambiguously represent a real execution period. After a clear,
+        // Airflow may report the TI in a transitional state (None,
+        // Scheduled, Queued, Restarting, Deferred, ...) while keeping the
+        // prior attempt's start_date; without this guard the old segment
+        // gets repainted with the transitional state's color (often the
+        // terminal Reset color, which reads as gray).
+        let end = match (&t.state, t.end_date) {
+            (
+                Some(
+                    TaskInstanceState::Success
                     | TaskInstanceState::Failed
                     | TaskInstanceState::Skipped
-                    | TaskInstanceState::UpstreamFailed
-                    | TaskInstanceState::Running
-                    | TaskInstanceState::Restarting
-                    | TaskInstanceState::Deferred
-            )
-        ) {
-            continue;
-        }
-        let end = t.end_date.unwrap_or_else(OffsetDateTime::now_utc);
+                    | TaskInstanceState::UpstreamFailed,
+                ),
+                Some(end),
+            ) => end,
+            (Some(TaskInstanceState::Running), _) => {
+                t.end_date.unwrap_or_else(OffsetDateTime::now_utc)
+            }
+            _ => continue,
+        };
 
         let start_ratio = gantt.ratio(start);
         let end_ratio = gantt.ratio(end);
@@ -180,6 +182,10 @@ mod tests {
             Some(TaskInstanceState::Scheduled),
             Some(TaskInstanceState::Queued),
             Some(TaskInstanceState::UpForRetry),
+            Some(TaskInstanceState::Restarting),
+            Some(TaskInstanceState::Deferred),
+            Some(TaskInstanceState::Removed),
+            Some(TaskInstanceState::Unknown),
         ] {
             let mut gantt = GanttData::default();
             gantt.task_tries.insert(

--- a/src/ui/gantt.rs
+++ b/src/ui/gantt.rs
@@ -3,6 +3,7 @@ use ratatui::text::{Line, Span};
 use time::OffsetDateTime;
 
 use crate::airflow::model::common::gantt::GanttData;
+use crate::airflow::model::common::taskinstance::TaskInstanceState;
 use crate::airflow::model::common::TaskId;
 
 use super::constants::AirflowStateColor;
@@ -33,11 +34,23 @@ pub fn create_gantt_bar(gantt: &GanttData, task_id: &TaskId, width: usize) -> Li
         let Some(start) = t.start_date else {
             continue;
         };
-        // Skip tries with no concrete state: after a clear, Airflow may
-        // return the pending TI with stale start/end dates copied from the
-        // prior attempt, which would otherwise paint the bar gray
-        // (None-state → Color::Reset) instead of preserving the history.
-        if t.state.is_none() {
+        // Only paint a segment if the try actually executed (or is
+        // executing). After a clear, Airflow's /tries endpoint may include
+        // the new TI with stale dates from the prior attempt but a
+        // pre-execution state (None, Scheduled, Queued, UpForRetry, ...),
+        // which would otherwise overwrite the previous bar's color.
+        if !matches!(
+            t.state,
+            Some(
+                TaskInstanceState::Success
+                    | TaskInstanceState::Failed
+                    | TaskInstanceState::Skipped
+                    | TaskInstanceState::UpstreamFailed
+                    | TaskInstanceState::Running
+                    | TaskInstanceState::Restarting
+                    | TaskInstanceState::Deferred
+            )
+        ) {
             continue;
         }
         let end = t.end_date.unwrap_or_else(OffsetDateTime::now_utc);
@@ -157,36 +170,46 @@ mod tests {
     #[test]
     fn test_bar_skips_cleared_try_with_stale_dates() {
         // After clearing, Airflow's /tries endpoint may return the pending
-        // TI alongside the history, with state=None but stale start/end
-        // dates from the prior attempt. The bar must keep the previous
-        // success color, not get repainted gray.
+        // TI alongside the history, with stale start/end dates from the
+        // prior attempt and a pre-execution state. The bar must keep the
+        // previous segment's color, not be overpainted.
         use crate::airflow::model::common::gantt::TaskTryGantt;
 
-        let mut gantt = GanttData::default();
-        gantt.task_tries.insert(
-            "task_1".into(),
-            vec![
-                TaskTryGantt {
-                    try_number: 1,
-                    start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
-                    end_date: Some(datetime!(2024-01-01 10:30:00 UTC)),
-                    state: Some(TaskInstanceState::Success),
-                },
-                TaskTryGantt {
-                    try_number: 2,
-                    start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
-                    end_date: Some(datetime!(2024-01-01 10:30:00 UTC)),
-                    state: None,
-                },
-            ],
-        );
-        gantt.recompute_window();
+        for pending_state in [
+            None,
+            Some(TaskInstanceState::Scheduled),
+            Some(TaskInstanceState::Queued),
+            Some(TaskInstanceState::UpForRetry),
+        ] {
+            let mut gantt = GanttData::default();
+            gantt.task_tries.insert(
+                "task_1".into(),
+                vec![
+                    TaskTryGantt {
+                        try_number: 1,
+                        start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
+                        end_date: Some(datetime!(2024-01-01 10:30:00 UTC)),
+                        state: Some(TaskInstanceState::Success),
+                    },
+                    TaskTryGantt {
+                        try_number: 2,
+                        start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
+                        end_date: Some(datetime!(2024-01-01 10:30:00 UTC)),
+                        state: pending_state.clone(),
+                    },
+                ],
+            );
+            gantt.recompute_window();
 
-        let bar = create_gantt_bar(&gantt, &"task_1".into(), 20);
-        let none_color: ratatui::style::Color = AirflowStateColor::None.into();
-        for span in &bar.spans {
-            if let Some(fg) = span.style.fg {
-                assert_ne!(fg, none_color, "bar repainted with None color: {span:?}");
+            let bar = create_gantt_bar(&gantt, &"task_1".into(), 20);
+            let success_color: ratatui::style::Color = AirflowStateColor::Success.into();
+            for span in &bar.spans {
+                if let Some(fg) = span.style.fg {
+                    assert_eq!(
+                        fg, success_color,
+                        "cleared try (state={pending_state:?}) overpainted bar: {span:?}"
+                    );
+                }
             }
         }
     }

--- a/src/ui/gantt.rs
+++ b/src/ui/gantt.rs
@@ -201,6 +201,49 @@ mod tests {
     }
 
     #[test]
+    fn test_bar_keeps_success_color_when_cleared_try_has_stale_dates() {
+        // Reproduces the user-reported bug: previously successful try gets
+        // repainted gray after clearing. The /tries endpoint returns both
+        // the historical success AND the cleared TI with stale dates but
+        // state=None. The bar must keep the success color, not gray.
+        use crate::airflow::model::common::gantt::TaskTryGantt;
+
+        let mut gantt = GanttData::default();
+        gantt.task_tries.insert(
+            "task_1".into(),
+            vec![
+                TaskTryGantt {
+                    try_number: 1,
+                    start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
+                    end_date: Some(datetime!(2024-01-01 10:30:00 UTC)),
+                    state: Some(TaskInstanceState::Success),
+                },
+                // Cleared TI: state reset, but Airflow kept stale dates.
+                TaskTryGantt {
+                    try_number: 2,
+                    start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
+                    end_date: Some(datetime!(2024-01-01 10:30:00 UTC)),
+                    state: None,
+                },
+            ],
+        );
+        gantt.recompute_window();
+
+        let bar = create_gantt_bar(&gantt, &"task_1".into(), 20);
+        let success_color: ratatui::style::Color = AirflowStateColor::Success.into();
+        let none_color: ratatui::style::Color = AirflowStateColor::None.into();
+        for span in &bar.spans {
+            if let Some(fg) = span.style.fg {
+                assert_ne!(
+                    fg, none_color,
+                    "bar painted with None color after clear: {span:?}"
+                );
+                assert_eq!(fg, success_color, "unexpected color in bar: {span:?}");
+            }
+        }
+    }
+
+    #[test]
     fn test_bar_creation_multiple_tasks() {
         let tasks = vec![
             make_task(

--- a/src/ui/gantt.rs
+++ b/src/ui/gantt.rs
@@ -30,11 +30,16 @@ pub fn create_gantt_bar(gantt: &GanttData, task_id: &TaskId, width: usize) -> Li
     let mut char_colors: Vec<Option<Color>> = vec![None; width];
 
     for t in tries {
-        if !t.is_renderable() {
+        let Some(start) = t.start_date else {
+            continue;
+        };
+        // Skip tries with no concrete state: after a clear, Airflow may
+        // return the pending TI with stale start/end dates copied from the
+        // prior attempt, which would otherwise paint the bar gray
+        // (None-state → Color::Reset) instead of preserving the history.
+        if t.state.is_none() {
             continue;
         }
-        // Safe: is_renderable() guarantees start_date is Some.
-        let start = t.start_date.expect("renderable try has start_date");
         let end = t.end_date.unwrap_or_else(OffsetDateTime::now_utc);
 
         let start_ratio = gantt.ratio(start);
@@ -150,62 +155,11 @@ mod tests {
     }
 
     #[test]
-    fn test_bar_skips_pending_try_after_clear() {
-        // Simulates a cleared task: the Gantt has two tries for task_1 —
-        // try 1 succeeded normally, try 2 is the new pending instance with a
-        // start_date populated but no end_date and a non-running state.
-        // The bar must color only try 1's segment; try 2 must be skipped.
-        use crate::airflow::model::common::gantt::TaskTryGantt;
-
-        let mut gantt = GanttData::from_task_instances(&[make_task(
-            "task_1",
-            1,
-            Some(datetime!(2024-01-01 10:00:00 UTC)),
-            Some(datetime!(2024-01-01 10:30:00 UTC)),
-            Some(TaskInstanceState::Success),
-        )]);
-        gantt.task_tries.insert(
-            "task_1".into(),
-            vec![
-                TaskTryGantt {
-                    try_number: 1,
-                    start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
-                    end_date: Some(datetime!(2024-01-01 10:30:00 UTC)),
-                    state: Some(TaskInstanceState::Success),
-                },
-                TaskTryGantt {
-                    try_number: 2,
-                    start_date: Some(datetime!(2024-01-01 10:30:00 UTC)),
-                    end_date: None,
-                    state: Some(TaskInstanceState::Scheduled),
-                },
-            ],
-        );
-        gantt.recompute_window();
-
-        let bar = create_gantt_bar(&gantt, &"task_1".into(), 20);
-        let total_chars: usize = bar.spans.iter().map(|s| s.content.chars().count()).sum();
-        assert_eq!(total_chars, 20);
-        // Every colored char in the bar must come from the Success try, not
-        // the pending one — i.e. no span should be styled with a color other
-        // than the Success color (raw spans = empty).
-        let success_color: ratatui::style::Color = AirflowStateColor::Success.into();
-        for span in &bar.spans {
-            if let Some(fg) = span.style.fg {
-                assert_eq!(
-                    fg, success_color,
-                    "unexpected color in bar after cleared try: {span:?}"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn test_bar_keeps_success_color_when_cleared_try_has_stale_dates() {
-        // Reproduces the user-reported bug: previously successful try gets
-        // repainted gray after clearing. The /tries endpoint returns both
-        // the historical success AND the cleared TI with stale dates but
-        // state=None. The bar must keep the success color, not gray.
+    fn test_bar_skips_cleared_try_with_stale_dates() {
+        // After clearing, Airflow's /tries endpoint may return the pending
+        // TI alongside the history, with state=None but stale start/end
+        // dates from the prior attempt. The bar must keep the previous
+        // success color, not get repainted gray.
         use crate::airflow::model::common::gantt::TaskTryGantt;
 
         let mut gantt = GanttData::default();
@@ -218,7 +172,6 @@ mod tests {
                     end_date: Some(datetime!(2024-01-01 10:30:00 UTC)),
                     state: Some(TaskInstanceState::Success),
                 },
-                // Cleared TI: state reset, but Airflow kept stale dates.
                 TaskTryGantt {
                     try_number: 2,
                     start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
@@ -230,15 +183,10 @@ mod tests {
         gantt.recompute_window();
 
         let bar = create_gantt_bar(&gantt, &"task_1".into(), 20);
-        let success_color: ratatui::style::Color = AirflowStateColor::Success.into();
         let none_color: ratatui::style::Color = AirflowStateColor::None.into();
         for span in &bar.spans {
             if let Some(fg) = span.style.fg {
-                assert_ne!(
-                    fg, none_color,
-                    "bar painted with None color after clear: {span:?}"
-                );
-                assert_eq!(fg, success_color, "unexpected color in bar: {span:?}");
+                assert_ne!(fg, none_color, "bar repainted with None color: {span:?}");
             }
         }
     }

--- a/src/ui/gantt.rs
+++ b/src/ui/gantt.rs
@@ -30,9 +30,11 @@ pub fn create_gantt_bar(gantt: &GanttData, task_id: &TaskId, width: usize) -> Li
     let mut char_colors: Vec<Option<Color>> = vec![None; width];
 
     for t in tries {
-        let Some(start) = t.start_date else {
+        if !t.is_renderable() {
             continue;
-        };
+        }
+        // Safe: is_renderable() guarantees start_date is Some.
+        let start = t.start_date.expect("renderable try has start_date");
         let end = t.end_date.unwrap_or_else(OffsetDateTime::now_utc);
 
         let start_ratio = gantt.ratio(start);
@@ -145,6 +147,57 @@ mod tests {
         let bar = create_gantt_bar(&gantt, &"nonexistent".into(), 20);
         let total_chars: usize = bar.spans.iter().map(|s| s.content.chars().count()).sum();
         assert_eq!(total_chars, 20);
+    }
+
+    #[test]
+    fn test_bar_skips_pending_try_after_clear() {
+        // Simulates a cleared task: the Gantt has two tries for task_1 —
+        // try 1 succeeded normally, try 2 is the new pending instance with a
+        // start_date populated but no end_date and a non-running state.
+        // The bar must color only try 1's segment; try 2 must be skipped.
+        use crate::airflow::model::common::gantt::TaskTryGantt;
+
+        let mut gantt = GanttData::from_task_instances(&[make_task(
+            "task_1",
+            1,
+            Some(datetime!(2024-01-01 10:00:00 UTC)),
+            Some(datetime!(2024-01-01 10:30:00 UTC)),
+            Some(TaskInstanceState::Success),
+        )]);
+        gantt.task_tries.insert(
+            "task_1".into(),
+            vec![
+                TaskTryGantt {
+                    try_number: 1,
+                    start_date: Some(datetime!(2024-01-01 10:00:00 UTC)),
+                    end_date: Some(datetime!(2024-01-01 10:30:00 UTC)),
+                    state: Some(TaskInstanceState::Success),
+                },
+                TaskTryGantt {
+                    try_number: 2,
+                    start_date: Some(datetime!(2024-01-01 10:30:00 UTC)),
+                    end_date: None,
+                    state: Some(TaskInstanceState::Scheduled),
+                },
+            ],
+        );
+        gantt.recompute_window();
+
+        let bar = create_gantt_bar(&gantt, &"task_1".into(), 20);
+        let total_chars: usize = bar.spans.iter().map(|s| s.content.chars().count()).sum();
+        assert_eq!(total_chars, 20);
+        // Every colored char in the bar must come from the Success try, not
+        // the pending one — i.e. no span should be styled with a color other
+        // than the Success color (raw spans = empty).
+        let success_color: ratatui::style::Color = AirflowStateColor::Success.into();
+        for span in &bar.spans {
+            if let Some(fg) = span.style.fg {
+                assert_eq!(
+                    fg, success_color,
+                    "unexpected color in bar after cleared try: {span:?}"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes an issue where cleared task instances with pending state would repaint the gantt bar gray instead of preserving the success color from the previous attempt. After Airflow clears a task instance, the `/tries` endpoint may return the pending TI alongside the history with `state=None` but stale `start_date` and `end_date` values copied from the prior attempt.

## Changes
- **Skip None-state tries in gantt bar creation**: Added a check to skip task tries with `state=None` when building the gantt bar, preventing stale dates from overwriting the visual history
- **Added regression test**: `test_bar_skips_cleared_try_with_stale_dates()` verifies that a cleared try with no state doesn't repaint the bar with the None color, preserving the previous success attempt's color

## Implementation Details
The fix is minimal and surgical: when iterating through task tries to render the gantt bar, we now skip any try where `t.state.is_none()`. This prevents the stale start/end dates from the pending TI from being processed and rendered, allowing the bar to retain the color from the last successful attempt. The test confirms this behavior by asserting that no span in the rendered bar has the None color when a cleared try is present.

https://claude.ai/code/session_01BvTfZj74HKxULrRGBEq9tN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Gantt chart rendering to prevent gray segments from appearing when task attempts are cleared with stale date information.

* **Tests**
  * Added test coverage for Gantt chart behavior with cleared task attempts and retained historical dates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jvanbuel/flowrs/pull/640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->