### PR TITLE
fix(airflow): drop dry_run from v2 task instance PATCH (fixes #662)

### DIFF
--- a/crates/flowrs-airflow/src/client/v2/taskinstance.rs
+++ b/crates/flowrs-airflow/src/client/v2/taskinstance.rs
@@ -143,7 +143,10 @@ impl V2Client {
                 &format!("dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}"),
             )
             .await?
-            .json(&serde_json::json!({"new_state": status, "dry_run": false}))
+            // Airflow 3's `/api/v2` PatchTaskInstanceBody uses a strict schema that
+            // forbids unknown fields; unlike the `/api/v1` endpoint it does not accept
+            // `dry_run` (dry-run is a separate endpoint), so sending it yields a 422.
+            .json(&serde_json::json!({"new_state": status}))
             .send()
             .await?
             .error_for_status()?;


### PR DESCRIPTION
## Summary

Marking a single task instance as success/failed/skipped against an Airflow 3 backend (`/api/v2`) failed with `422 Unprocessable Entity`, so the task was never marked. Marking an entire run worked fine.

## Root cause

`V2Client::patch_task_instance` sent this body to `PATCH /api/v2/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}`:

```json
{"new_state": "success", "dry_run": false}
```

Airflow 3's `PatchTaskInstanceBody` is a `StrictBaseModel` (`extra="forbid"`) and has **no `dry_run` field** — dry-run is a separate endpoint in v3. The unexpected `dry_run` key fails schema validation → 422.

Marking an entire run works because it uses `clearTaskInstances`, whose Airflow 3 schema (`ClearTaskInstancesBody`) still accepts `dry_run`.

## Fix

Drop `dry_run` from the v2 PATCH body, leaving `{"new_state": status}`. The v1 client (`/api/v1`, Airflow 2) is unchanged and still sends `dry_run: false`, which its schema requires (defaults to `true`).

## Testing

- `cargo build -p flowrs-airflow` — clean
- `cargo clippy -p flowrs-airflow --all-features -- -D warnings` — no warnings
- `cargo fmt --all --check` — clean

Fixes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoCseMyc5MDHFc151RyovJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoCseMyc5MDHFc151RyovJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task instance updates so changes are sent in a format accepted by the API.
  * Prevented update requests from including an unsupported field that could cause a 422 error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->