### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.12.11](https://github.com/jvanbuel/flowrs/compare/flowrs-tui-v0.12.10...flowrs-tui-v0.12.11) - 2026-07-10
+## [0.13.0](https://github.com/jvanbuel/flowrs/compare/flowrs-tui-v0.12.10...flowrs-tui-v0.13.0) - 2026-07-10
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.11](https://github.com/jvanbuel/flowrs/compare/flowrs-tui-v0.12.10...flowrs-tui-v0.12.11) - 2026-07-10
+
+### Added
+
+- wrap enum values in the trigger popup and edit them on Enter
+- editable params table for the DAG trigger popup
+- trigger DAG runs with custom configuration params
+
+### Fixed
+
+- show invalid-JSON in red and re-fetch dag params on popup open
+- flag invalid JSON in examples params too
+- don't open the text editor for enum params
+- keep trigger popup Yes/No visible and size value column to content
+- truncate long keys by display width and wrap ghost text
+- address CodeRabbit review on trigger popup
+- address CodeRabbit review on trigger popup ([#624](https://github.com/jvanbuel/flowrs/pull/624))
+
+### Other
+
+- simplify trigger table row building
+- split the dag-run popup rendering into logical units
+- keep only the blank-buttons regression test
+- fix cargo fmt on trigger popup render
+- Update src/app/model/dagruns/popup/render.rs
+
 ## [0.12.10](https://github.com/jvanbuel/flowrs/compare/flowrs-tui-v0.12.9...flowrs-tui-v0.12.10) - 2026-07-09
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-airflow"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-config"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-tui"
-version = "0.12.10"
+version = "0.12.11"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -2238,9 +2238,9 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -3047,9 +3047,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3059,9 +3059,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-airflow"
-version = "0.10.9"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-config"
-version = "0.11.8"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-tui"
-version = "0.12.11"
+version = "0.13.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ toml = "1.1.2"
 
 [package]
 name = "flowrs-tui"
-version = "0.12.10"
+version = "0.12.11"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Flowrs is a Terminal User Interface (TUI) for Apache Airflow"
@@ -46,8 +46,8 @@ ansi-to-tui = { version = "8.0.1" }
 anyhow = { workspace = true }
 catppuccin = { workspace = true }
 async-trait = { workspace = true }
-flowrs-config = { path = "crates/flowrs-config", version = "0.11.7" }
-flowrs-airflow = { path = "crates/flowrs-airflow", version = "0.10.8" }
+flowrs-config = { path = "crates/flowrs-config", version = "0.11.8" }
+flowrs-airflow = { path = "crates/flowrs-airflow", version = "0.10.9" }
 chrono = { workspace = true }
 clap = { workspace = true }
 crossterm = "0.29.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ toml = "1.1.2"
 
 [package]
 name = "flowrs-tui"
-version = "0.12.11"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Flowrs is a Terminal User Interface (TUI) for Apache Airflow"
@@ -46,8 +46,8 @@ ansi-to-tui = { version = "8.0.1" }
 anyhow = { workspace = true }
 catppuccin = { workspace = true }
 async-trait = { workspace = true }
-flowrs-config = { path = "crates/flowrs-config", version = "0.11.8" }
-flowrs-airflow = { path = "crates/flowrs-airflow", version = "0.10.9" }
+flowrs-config = { path = "crates/flowrs-config", version = "0.12.0" }
+flowrs-airflow = { path = "crates/flowrs-airflow", version = "0.11.0" }
 chrono = { workspace = true }
 clap = { workspace = true }
 crossterm = "0.29.0"

--- a/crates/flowrs-airflow/CHANGELOG.md
+++ b/crates/flowrs-airflow/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.9](https://github.com/jvanbuel/flowrs/compare/flowrs-airflow-v0.10.8...flowrs-airflow-v0.10.9) - 2026-07-10
+
+### Added
+
+- editable params table for the DAG trigger popup
+- trigger DAG runs with custom configuration params
+
 ## [0.10.8](https://github.com/jvanbuel/flowrs/compare/flowrs-airflow-v0.10.7...flowrs-airflow-v0.10.8) - 2026-07-09
 
 ### Fixed

--- a/crates/flowrs-airflow/CHANGELOG.md
+++ b/crates/flowrs-airflow/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.10.9](https://github.com/jvanbuel/flowrs/compare/flowrs-airflow-v0.10.8...flowrs-airflow-v0.10.9) - 2026-07-10
+## [0.11.0](https://github.com/jvanbuel/flowrs/compare/flowrs-airflow-v0.10.8...flowrs-airflow-v0.11.0) - 2026-07-10
 
 ### Added
 

--- a/crates/flowrs-airflow/Cargo.toml
+++ b/crates/flowrs-airflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-airflow"
-version = "0.10.9"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Airflow API client library"

--- a/crates/flowrs-airflow/Cargo.toml
+++ b/crates/flowrs-airflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-airflow"
-version = "0.10.8"
+version = "0.10.9"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Airflow API client library"

--- a/crates/flowrs-config/CHANGELOG.md
+++ b/crates/flowrs-config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.8](https://github.com/jvanbuel/flowrs/compare/flowrs-config-v0.11.7...flowrs-config-v0.11.8) - 2026-07-10
+
+### Other
+
+- updated the following local packages: flowrs-airflow
+
 ## [0.11.7](https://github.com/jvanbuel/flowrs/compare/flowrs-config-v0.11.6...flowrs-config-v0.11.7) - 2026-07-09
 
 ### Other

--- a/crates/flowrs-config/CHANGELOG.md
+++ b/crates/flowrs-config/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.11.8](https://github.com/jvanbuel/flowrs/compare/flowrs-config-v0.11.7...flowrs-config-v0.11.8) - 2026-07-10
+## [0.12.0](https://github.com/jvanbuel/flowrs/compare/flowrs-config-v0.11.7...flowrs-config-v0.12.0) - 2026-07-10
 
 ### Other
 

--- a/crates/flowrs-config/Cargo.toml
+++ b/crates/flowrs-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-config"
-version = "0.11.8"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Configuration types for flowrs"
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/jvanbuel/flowrs"
 
 [dependencies]
-flowrs-airflow = { path = "../flowrs-airflow", version = "0.10.9", default-features = false }
+flowrs-airflow = { path = "../flowrs-airflow", version = "0.11.0", default-features = false }
 anyhow.workspace = true
 clap.workspace = true
 dirs.workspace = true

--- a/crates/flowrs-config/Cargo.toml
+++ b/crates/flowrs-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-config"
-version = "0.11.7"
+version = "0.11.8"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Configuration types for flowrs"
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/jvanbuel/flowrs"
 
 [dependencies]
-flowrs-airflow = { path = "../flowrs-airflow", version = "0.10.8", default-features = false }
+flowrs-airflow = { path = "../flowrs-airflow", version = "0.10.9", default-features = false }
 anyhow.workspace = true
 clap.workspace = true
 dirs.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `flowrs-airflow`: 0.10.8 -> 0.10.9
* `flowrs-tui`: 0.12.10 -> 0.12.11
* `flowrs-config`: 0.11.7 -> 0.11.8

<details><summary><i><b>Changelog</b></i></summary><p>

## `flowrs-airflow`

<blockquote>

## [0.10.9](https://github.com/jvanbuel/flowrs/compare/flowrs-airflow-v0.10.8...flowrs-airflow-v0.10.9) - 2026-07-10

### Added

- editable params table for the DAG trigger popup
- trigger DAG runs with custom configuration params
</blockquote>

## `flowrs-tui`

<blockquote>

## [0.12.11](https://github.com/jvanbuel/flowrs/compare/flowrs-tui-v0.12.10...flowrs-tui-v0.12.11) - 2026-07-10

### Added

- wrap enum values in the trigger popup and edit them on Enter
- editable params table for the DAG trigger popup
- trigger DAG runs with custom configuration params

### Fixed

- show invalid-JSON in red and re-fetch dag params on popup open
- flag invalid JSON in examples params too
- don't open the text editor for enum params
- keep trigger popup Yes/No visible and size value column to content
- truncate long keys by display width and wrap ghost text
- address CodeRabbit review on trigger popup
- address CodeRabbit review on trigger popup ([#624](https://github.com/jvanbuel/flowrs/pull/624))

### Other

- simplify trigger table row building
- split the dag-run popup rendering into logical units
- keep only the blank-buttons regression test
- fix cargo fmt on trigger popup render
- Update src/app/model/dagruns/popup/render.rs
</blockquote>

## `flowrs-config`

<blockquote>

## [0.11.8](https://github.com/jvanbuel/flowrs/compare/flowrs-config-v0.11.7...flowrs-config-v0.11.8) - 2026-07-10

### Other

- updated the following local packages: flowrs-airflow
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added editable parameters to the DAG trigger popup, including improved enum value handling.
  * Enabled triggering DAG runs with custom configuration parameters via the popup.

* **Bug Fixes**
  * Improved invalid JSON display (highlighted) and re-fetching of DAG parameters when reopening the popup (with examples).
  * Prevented text-editor access for enum parameters; preserved popup Yes/No controls, sizing behavior, and improved long-key truncation/wrapping.

* **Documentation**
  * Updated release notes/changelogs for the above enhancements and fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->