### PR TITLE
style(tui): unify popup chrome, round the logs pane, theme filter greys

### DIFF
--- a/src/app/model/filter/widget.rs
+++ b/src/app/model/filter/widget.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     buffer::Buffer,
     layout::{Position, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, BorderType, Borders, Paragraph, Widget},
 };
@@ -63,7 +63,10 @@ impl FilterStateMachine {
                 for cond in conditions {
                     let cond_text = format!("{}: {} ", cond.field, cond.value);
                     cursor_offset += cond_text.len() as u16;
-                    spans.push(Span::styled(cond_text, Style::default().fg(Color::Gray)));
+                    spans.push(Span::styled(
+                        cond_text,
+                        Style::default().fg(theme().text_muted),
+                    ));
                 }
 
                 // Render primary field name with colon (like ValueInput)
@@ -92,7 +95,7 @@ impl FilterStateMachine {
                 if let Some(ghost) = autocomplete.ghost_suffix() {
                     spans.push(Span::styled(
                         ghost.to_string(),
-                        Style::default().fg(Color::DarkGray),
+                        Style::default().fg(theme().text_ghost),
                     ));
                 }
 
@@ -111,7 +114,10 @@ impl FilterStateMachine {
                 for cond in conditions {
                     let cond_text = format!("{}: {} ", cond.field, cond.value);
                     cursor_offset += cond_text.len() as u16;
-                    spans.push(Span::styled(cond_text, Style::default().fg(Color::Gray)));
+                    spans.push(Span::styled(
+                        cond_text,
+                        Style::default().fg(theme().text_muted),
+                    ));
                 }
 
                 // Render colon prefix
@@ -135,7 +141,7 @@ impl FilterStateMachine {
                 if let Some(ghost) = autocomplete.ghost_suffix() {
                     spans.push(Span::styled(
                         ghost.to_string(),
-                        Style::default().fg(Color::DarkGray),
+                        Style::default().fg(theme().text_ghost),
                     ));
                 }
 
@@ -156,7 +162,10 @@ impl FilterStateMachine {
                 for cond in conditions {
                     let cond_text = format!("{}: {} ", cond.field, cond.value);
                     cursor_offset += cond_text.len() as u16;
-                    spans.push(Span::styled(cond_text, Style::default().fg(Color::Gray)));
+                    spans.push(Span::styled(
+                        cond_text,
+                        Style::default().fg(theme().text_muted),
+                    ));
                 }
 
                 // Render field name with colon
@@ -185,7 +194,7 @@ impl FilterStateMachine {
                 if let Some(ghost) = autocomplete.ghost_suffix() {
                     spans.push(Span::styled(
                         ghost.to_string(),
-                        Style::default().fg(Color::DarkGray),
+                        Style::default().fg(theme().text_ghost),
                     ));
                 }
 

--- a/src/app/model/logs/render.rs
+++ b/src/app/model/logs/render.rs
@@ -67,7 +67,7 @@ impl Widget for &mut LogModel {
             let paragraph = Paragraph::new(content)
                 .block(
                     Block::default()
-                        .border_type(BorderType::Plain)
+                        .border_type(BorderType::Rounded)
                         .borders(Borders::ALL)
                         .title(" Content ")
                         .title_bottom(if self.scroll_mode.is_following() {

--- a/src/app/model/popup/commands_help/render.rs
+++ b/src/app/model/popup/commands_help/render.rs
@@ -3,10 +3,11 @@ use ratatui::{
     layout::Rect,
     style::{Modifier, Style},
     text::{Line, Span, Text},
-    widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget, Wrap},
+    widgets::{Clear, Paragraph, Widget, Wrap},
 };
 
 use crate::app::model::popup::popup_area;
+use crate::ui::common::titled_popup_block;
 use crate::ui::theme::theme;
 
 use super::CommandPopUp;
@@ -15,13 +16,7 @@ impl Widget for &CommandPopUp<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let t = theme();
         let popup_area = popup_area(area, 80, 80);
-        let popup = Block::default()
-            .border_type(BorderType::Rounded)
-            .title(self.title.as_str())
-            .title_style(t.title_style)
-            .borders(Borders::ALL)
-            .border_style(t.border_style)
-            .style(t.default_style);
+        let popup = titled_popup_block(&self.title, t.purple);
 
         Clear.render(popup_area, buf);
 

--- a/src/app/model/popup/error.rs
+++ b/src/app/model/popup/error.rs
@@ -4,10 +4,11 @@ use ratatui::{
     layout::Rect,
     style::{Modifier, Style},
     text::{Line, Span, Text},
-    widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget, Wrap},
+    widgets::{Clear, Paragraph, Widget, Wrap},
 };
 
 use super::popup_area;
+use crate::ui::common::titled_popup_block;
 use crate::ui::theme::theme;
 
 pub struct ErrorPopup {
@@ -39,17 +40,7 @@ impl Widget for &ErrorPopup {
         let error_color = t.state_failed;
 
         let popup_area = popup_area(area, 80, 50);
-        let popup = Block::default()
-            .border_type(BorderType::Rounded)
-            .title("Errors - Press <Esc> or <q> to close")
-            .title_style(
-                Style::default()
-                    .fg(error_color)
-                    .add_modifier(Modifier::BOLD),
-            )
-            .borders(Borders::ALL)
-            .border_style(t.border_style)
-            .style(t.default_style);
+        let popup = titled_popup_block("Errors - Press <Esc> or <q> to close", error_color);
 
         Clear.render(popup_area, buf);
 

--- a/src/app/model/popup/warning.rs
+++ b/src/app/model/popup/warning.rs
@@ -3,10 +3,11 @@ use ratatui::{
     layout::Rect,
     style::{Modifier, Style},
     text::{Line, Span, Text},
-    widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget, Wrap},
+    widgets::{Clear, Paragraph, Widget, Wrap},
 };
 
 use super::popup_area;
+use crate::ui::common::titled_popup_block;
 use crate::ui::theme::theme;
 
 pub struct WarningPopup {
@@ -29,17 +30,7 @@ impl Widget for &WarningPopup {
         let warning_color = t.state_up_for_retry;
 
         let popup_area = popup_area(area, 80, 50);
-        let popup = Block::default()
-            .border_type(BorderType::Rounded)
-            .title("Warning - Press <Esc> or <q> to close")
-            .title_style(
-                Style::default()
-                    .fg(warning_color)
-                    .add_modifier(Modifier::BOLD),
-            )
-            .borders(Borders::ALL)
-            .border_style(t.border_style)
-            .style(t.default_style);
+        let popup = titled_popup_block("Warning - Press <Esc> or <q> to close", warning_color);
 
         Clear.render(popup_area, buf);
 

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -1,10 +1,28 @@
 use ratatui::{
-    style::Style,
+    style::{Color, Modifier, Style},
     text::{Line, Span},
+    widgets::{Block, BorderType, Borders},
 };
 
 use super::constants::AirflowStateColor;
 use super::theme::theme;
+
+/// Builds a modal popup `Block` with the shared popup chrome: rounded, fully
+/// bordered, themed border and background, and a title padded with a single
+/// space on each side (`" title "`) styled bold in `accent`.
+///
+/// Centralizing this keeps every popup's title color language and padding
+/// consistent instead of each popup rolling its own `Block` and spacing.
+pub fn titled_popup_block(title: &str, accent: Color) -> Block<'static> {
+    let t = theme();
+    Block::default()
+        .border_type(BorderType::Rounded)
+        .borders(Borders::ALL)
+        .border_style(t.border_style)
+        .style(t.default_style)
+        .title(format!(" {title} "))
+        .title_style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
+}
 
 pub fn create_headers<'a>(
     headers: impl IntoIterator<Item = &'a str>,

--- a/src/ui/theme/mod.rs
+++ b/src/ui/theme/mod.rs
@@ -19,6 +19,10 @@ use ratatui::style::{Color, Style};
 #[allow(dead_code)]
 pub struct Theme {
     pub text_primary: Color,
+    /// Muted foreground for secondary/confirmed text (e.g. applied filter conditions).
+    pub text_muted: Color,
+    /// Dim foreground for placeholder/ghost text (e.g. autocomplete suggestions).
+    pub text_ghost: Color,
     pub purple: Color,
     pub purple_dim: Color,
     pub accent: Color,

--- a/src/ui/theme/presets/catppuccin.rs
+++ b/src/ui/theme/presets/catppuccin.rs
@@ -7,6 +7,8 @@ impl Theme {
         let c = &catppuccin::PALETTE.latte.colors;
         Self::build(&ThemePalette {
             text_primary: c.text.into(),
+            text_muted: c.subtext0.into(),
+            text_ghost: c.overlay0.into(),
             purple: c.mauve.into(),
             purple_dim: c.overlay1.into(),
             accent: c.teal.into(),
@@ -38,6 +40,8 @@ impl Theme {
         let c = &catppuccin::PALETTE.frappe.colors;
         Self::build(&ThemePalette {
             text_primary: c.text.into(),
+            text_muted: c.subtext0.into(),
+            text_ghost: c.overlay0.into(),
             purple: c.mauve.into(),
             purple_dim: c.overlay2.into(),
             accent: c.teal.into(),
@@ -69,6 +73,8 @@ impl Theme {
         let c = &catppuccin::PALETTE.macchiato.colors;
         Self::build(&ThemePalette {
             text_primary: c.text.into(),
+            text_muted: c.subtext0.into(),
+            text_ghost: c.overlay0.into(),
             purple: c.mauve.into(),
             purple_dim: c.overlay2.into(),
             accent: c.teal.into(),
@@ -100,6 +106,8 @@ impl Theme {
         let c = &catppuccin::PALETTE.mocha.colors;
         Self::build(&ThemePalette {
             text_primary: c.text.into(),
+            text_muted: c.subtext0.into(),
+            text_ghost: c.overlay0.into(),
             purple: c.mauve.into(),
             purple_dim: c.overlay2.into(),
             accent: c.teal.into(),

--- a/src/ui/theme/presets/dark.rs
+++ b/src/ui/theme/presets/dark.rs
@@ -8,6 +8,8 @@ impl Theme {
     pub fn dark() -> Self {
         Self::build(&ThemePalette {
             text_primary: Color::Rgb(220, 220, 230),    // #DCDCE6
+            text_muted: Color::Rgb(130, 132, 148),      // #828494
+            text_ghost: Color::Rgb(84, 86, 104),        // #545668
             purple: Color::Rgb(138, 118, 255),          // #8A76FF
             purple_dim: Color::Rgb(90, 80, 160),        // #5A50A0
             accent: Color::Rgb(0, 220, 160),            // #00DCA0

--- a/src/ui/theme/presets/light.rs
+++ b/src/ui/theme/presets/light.rs
@@ -8,6 +8,8 @@ impl Theme {
     pub fn light() -> Self {
         Self::build(&ThemePalette {
             text_primary: Color::Rgb(46, 46, 58),               // #2E2E3A
+            text_muted: Color::Rgb(120, 120, 132),              // #787884
+            text_ghost: Color::Rgb(170, 170, 182),              // #AAAAB6
             purple: Color::Rgb(110, 86, 230),                   // #6E56E6
             purple_dim: Color::Rgb(155, 143, 204),              // #9B8FCC
             accent: Color::Rgb(0, 140, 100),                    // #008C64

--- a/src/ui/theme/presets/mod.rs
+++ b/src/ui/theme/presets/mod.rs
@@ -8,6 +8,8 @@ use super::Theme;
 
 pub(super) struct ThemePalette {
     pub(super) text_primary: Color,
+    pub(super) text_muted: Color,
+    pub(super) text_ghost: Color,
     pub(super) purple: Color,
     pub(super) purple_dim: Color,
     pub(super) accent: Color,
@@ -37,6 +39,8 @@ impl Theme {
     pub(super) fn build(p: &ThemePalette) -> Self {
         Self {
             text_primary: p.text_primary,
+            text_muted: p.text_muted,
+            text_ghost: p.text_ghost,
             purple: p.purple,
             purple_dim: p.purple_dim,
             accent: p.accent,


### PR DESCRIPTION
Three consistency fixes from the TUI style review:

- Logs "Content" box now uses BorderType::Rounded instead of the lone
  BorderType::Plain, matching the 25 other rounded blocks in the app.
- Filter widget no longer hardcodes Color::Gray / Color::DarkGray. Added
  `text_muted` and `text_ghost` theme tokens (tuned per preset) so applied
  filter conditions and autocomplete ghost text follow the active theme
  (dark, light, and all four Catppuccin flavors).
- Added a shared `titled_popup_block` helper and adopted it in the command,
  warning, and error popups, giving every modal the same bold-accent title
  style and consistent `" title "` padding.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01K2LtF9CNucLMKDhjiLL7GT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Filter condition and placeholder text now use theme-specific muted and ghost colors for improved visual hierarchy.
  * Log panels now display rounded borders.
  * Popup windows use consistent rounded borders, spacing, and accent-colored titles.

* **New Features**
  * Light, dark, and Catppuccin themes now provide dedicated colors for secondary and placeholder text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->