### PR TITLE
fix: prevent panic when opening Airflow UI with empty log list

### DIFF
--- a/src/app/model/logs/mod.rs
+++ b/src/app/model/logs/mod.rs
@@ -271,29 +271,6 @@ mod tests {
     }
 
     #[test]
-    fn current_log_is_none_when_empty() {
-        let model = LogModel::default();
-        assert_eq!(model.current_index(), 0);
-        assert!(model.current_log().is_none());
-        assert_eq!(model.current_line_count(), 0);
-    }
-
-    #[test]
-    fn current_log_tracks_selection() {
-        let mut model = LogModel {
-            all: vec![log("try one\nline"), log("try two")],
-            ..Default::default()
-        };
-
-        assert_eq!(model.current_index(), 0);
-        assert_eq!(model.current_line_count(), 2);
-
-        model.current = 1;
-        assert_eq!(model.current_index(), 1);
-        assert_eq!(model.current_line_count(), 1);
-    }
-
-    #[test]
     fn current_index_wraps_when_selection_exceeds_len() {
         // After `update_logs` shrinks the list, a stale `current` must wrap into
         // range rather than point past the end (or panic).

--- a/src/app/model/logs/mod.rs
+++ b/src/app/model/logs/mod.rs
@@ -193,7 +193,7 @@ impl Model for LogModel {
                                         dag_run_id: dag_run_id.clone(),
                                         task_id: task_id.clone(),
                                         #[allow(clippy::cast_possible_truncation)]
-                                        task_try: (self.current + 1) as u32,
+                                        task_try: (self.current_index() + 1) as u32,
                                     })],
                                 );
                             }

--- a/src/app/model/logs/mod.rs
+++ b/src/app/model/logs/mod.rs
@@ -83,12 +83,26 @@ impl LogModel {
         self.all = logs;
     }
 
+    /// Index of the currently selected log (task try), wrapped into range.
+    ///
+    /// `current` can exceed `all.len()` after `update_logs` replaces the list
+    /// with fewer tries, so the selection is wrapped rather than assumed valid.
+    /// Returns 0 for an empty list; pair with [`current_log`](Self::current_log)
+    /// to distinguish "empty" from "first entry".
+    fn current_index(&self) -> usize {
+        self.current % self.all.len().max(1)
+    }
+
+    /// Returns the currently selected log (the task try being viewed), if any.
+    /// `None` when no logs are loaded.
+    fn current_log(&self) -> Option<&Log> {
+        self.all.get(self.current_index())
+    }
+
     /// Returns the total number of lines in the current log content
     pub(crate) fn current_line_count(&self) -> usize {
-        let Some(log) = self.all.get(self.current % self.all.len().max(1)) else {
-            return 0;
-        };
-        log.content.lines().count()
+        self.current_log()
+            .map_or(0, |log| log.content.lines().count())
     }
 }
 
@@ -168,7 +182,7 @@ impl Model for LogModel {
                         };
                     }
                     KeyCode::Char('o') => {
-                        if self.all.get(self.current % self.all.len().max(1)).is_some() {
+                        if self.current_log().is_some() {
                             if let (Some(dag_id), Some(dag_run_id), Some(task_id)) =
                                 (ctx.dag_id(), ctx.dag_run_id(), ctx.task_id())
                             {
@@ -247,5 +261,49 @@ mod tests {
         // Must not panic and must not emit an OpenItem message for empty logs.
         let (_, messages) = model.update(&event, &ctx);
         assert!(messages.is_empty());
+    }
+
+    fn log(content: &str) -> Log {
+        Log {
+            continuation_token: None,
+            content: content.to_string(),
+        }
+    }
+
+    #[test]
+    fn current_log_is_none_when_empty() {
+        let model = LogModel::default();
+        assert_eq!(model.current_index(), 0);
+        assert!(model.current_log().is_none());
+        assert_eq!(model.current_line_count(), 0);
+    }
+
+    #[test]
+    fn current_log_tracks_selection() {
+        let mut model = LogModel {
+            all: vec![log("try one\nline"), log("try two")],
+            ..Default::default()
+        };
+
+        assert_eq!(model.current_index(), 0);
+        assert_eq!(model.current_line_count(), 2);
+
+        model.current = 1;
+        assert_eq!(model.current_index(), 1);
+        assert_eq!(model.current_line_count(), 1);
+    }
+
+    #[test]
+    fn current_index_wraps_when_selection_exceeds_len() {
+        // After `update_logs` shrinks the list, a stale `current` must wrap into
+        // range rather than point past the end (or panic).
+        let mut model = LogModel {
+            current: 3,
+            ..Default::default()
+        };
+        model.update_logs(vec![log("a"), log("b")]);
+
+        assert_eq!(model.current_index(), 1); // 3 % 2
+        assert!(model.current_log().is_some());
     }
 }

--- a/src/app/model/logs/mod.rs
+++ b/src/app/model/logs/mod.rs
@@ -168,7 +168,7 @@ impl Model for LogModel {
                         };
                     }
                     KeyCode::Char('o') => {
-                        if self.all.get(self.current % self.all.len()).is_some() {
+                        if self.all.get(self.current % self.all.len().max(1)).is_some() {
                             if let (Some(dag_id), Some(dag_run_id), Some(task_id)) =
                                 (ctx.dag_id(), ctx.dag_run_id(), ctx.task_id())
                             {
@@ -216,5 +216,36 @@ impl Model for LogModel {
         }
 
         (None, vec![])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    use super::*;
+    use crate::app::state::NavigationContext;
+
+    /// Regression test: pressing `o` to open the Airflow UI while the log list
+    /// is empty must not panic. Previously `self.current % self.all.len()`
+    /// computed a remainder with a zero divisor when `all` was empty.
+    #[test]
+    fn open_ui_with_empty_logs_does_not_panic() {
+        let mut model = LogModel::default();
+        assert!(model.all.is_empty());
+
+        let ctx = NavigationContext::Task {
+            environment: "env".to_string(),
+            dag_id: "dag".into(),
+            dag_run_id: "run".into(),
+            task_id: "task".into(),
+            task_try: 1,
+        };
+
+        let event = FlowrsEvent::Key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::empty()));
+
+        // Must not panic and must not emit an OpenItem message for empty logs.
+        let (_, messages) = model.update(&event, &ctx);
+        assert!(messages.is_empty());
     }
 }

--- a/src/app/model/logs/render.rs
+++ b/src/app/model/logs/render.rs
@@ -41,7 +41,7 @@ impl Widget for &mut LogModel {
                     .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
                     .border_style(t.border_style),
             )
-            .select(self.current % self.all.len())
+            .select(self.current_index())
             .highlight_style(Style::default().fg(t.accent).add_modifier(Modifier::BOLD))
             .style(t.default_style);
 
@@ -53,7 +53,7 @@ impl Widget for &mut LogModel {
             .constraints([Constraint::Length(3), Constraint::Min(0)])
             .split(area);
 
-        if let Some(log) = self.all.get(self.current % self.all.len()) {
+        if let Some(log) = self.all.get(self.current_index()) {
             let mut content = Text::default();
             for line in log.content.lines() {
                 content.push_line(Line::raw(line));

--- a/src/app/model/logs/render.rs
+++ b/src/app/model/logs/render.rs
@@ -53,7 +53,7 @@ impl Widget for &mut LogModel {
             .constraints([Constraint::Length(3), Constraint::Min(0)])
             .split(area);
 
-        if let Some(log) = self.all.get(self.current_index()) {
+        if let Some(log) = self.current_log() {
             let mut content = Text::default();
             for line in log.content.lines() {
                 content.push_line(Line::raw(line));
@@ -61,7 +61,6 @@ impl Widget for &mut LogModel {
 
             let line_count = self.current_line_count();
             let scroll_pos = self.scroll_mode.position(line_count);
-            self.vertical_scroll_state = self.vertical_scroll_state.position(scroll_pos);
 
             #[allow(clippy::cast_possible_truncation)]
             let paragraph = Paragraph::new(content)
@@ -84,6 +83,10 @@ impl Widget for &mut LogModel {
 
             // Render the selected log's content
             paragraph.render(chunks[1], buffer);
+
+            // The log borrow (held by `content`) has ended, so the scroll state
+            // can now be updated before rendering the scrollbar.
+            self.vertical_scroll_state = self.vertical_scroll_state.position(scroll_pos);
 
             let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
                 .begin_symbol(Some("↑"))


### PR DESCRIPTION
Pressing `o` in the logs panel computed `self.current % self.all.len()`,
which panics with a divide-by-zero when the log list is empty (integer
remainder with a zero divisor). Guard the divisor with `.max(1)`, matching
the existing logic in `current_line_count`, so an empty list yields no
selected log and no OpenItem message instead of crashing.

Add a regression test covering the empty-log case.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EL1DCwwPYs6f5dd1qZoZCv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when opening log details while no logs are available.
  * Improved log and tab selection to remain consistent when the available logs list changes size.
  * Fixed key-based navigation so opening log details safely handles empty or shrinking log lists without invalid actions.
* **Tests**
  * Added regression coverage for empty-log navigation and correct wrapping after log list updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->