### PR TITLE
fix(config): validate token command exit status and non-empty output

### DIFF
--- a/src/commands/config/add.rs
+++ b/src/commands/config/add.rs
@@ -5,8 +5,8 @@ use log::info;
 use strum::IntoEnumIterator;
 
 use super::model::AddCommand;
-use crate::commands::config::model::{validate_endpoint, ConfigOption};
-use anyhow::{Context, Result};
+use crate::commands::config::model::{run_token_command, validate_endpoint, ConfigOption};
+use anyhow::Result;
 use flowrs_config::{
     AirflowAuth, AirflowConfig, AirflowVersion, BasicAuth, FlowrsConfig, TokenSource,
 };
@@ -59,13 +59,7 @@ impl AddCommand {
             ConfigOption::Token(_) => {
                 let cmd = inquire::Text::new("cmd").prompt()?;
                 info!("🔑 Running command: {cmd}");
-                let output = std::process::Command::new("sh")
-                    .arg("-c")
-                    .arg(&cmd)
-                    .output()
-                    .with_context(|| format!("Failed to execute token command: {cmd}"))?;
-                // Validate the command produces a token
-                let _token = String::from_utf8(output.stdout)?.trim().to_string();
+                run_token_command(&cmd)?;
 
                 AirflowConfig {
                     name,

--- a/src/commands/config/model.rs
+++ b/src/commands/config/model.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{Args, Parser};
 use flowrs_config::{FlowrsConfig, ManagedService, Theme};
 use inquire::validator::Validation;
@@ -188,5 +188,54 @@ pub fn validate_endpoint(
     match Url::parse(endpoint) {
         Ok(_) => Ok(Validation::Valid),
         Err(error) => Ok(Validation::Invalid(error.into())),
+    }
+}
+
+/// Run a token command via `sh -c` and return its trimmed standard output.
+///
+/// Only the command string is persisted; running it here validates that it
+/// actually yields a token, so a broken command is rejected at config time
+/// rather than saved and left to fail on every later API call.
+pub fn run_token_command(cmd: &str) -> Result<String> {
+    let output = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(cmd)
+        .output()
+        .with_context(|| format!("failed to run token command: {cmd}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("token command exited with {}: {}", output.status, stderr.trim());
+    }
+
+    let token = String::from_utf8(output.stdout)
+        .context("token command produced non-UTF-8 output")?
+        .trim()
+        .to_string();
+
+    if token.is_empty() {
+        anyhow::bail!("token command produced no output: {cmd}");
+    }
+
+    Ok(token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_command_returns_trimmed_output() {
+        assert_eq!(run_token_command("echo my-token").unwrap(), "my-token");
+    }
+
+    #[test]
+    fn token_command_errors_on_non_zero_exit() {
+        assert!(run_token_command("exit 1").is_err());
+    }
+
+    #[test]
+    fn token_command_errors_on_empty_output() {
+        assert!(run_token_command("true").is_err());
     }
 }

--- a/src/commands/config/update.rs
+++ b/src/commands/config/update.rs
@@ -5,10 +5,10 @@ use log::info;
 use strum::IntoEnumIterator;
 
 use super::model::UpdateCommand;
-use crate::commands::config::model::{validate_endpoint, ConfigOption};
+use crate::commands::config::model::{run_token_command, validate_endpoint, ConfigOption};
 use flowrs_config::{AirflowAuth, AirflowConfig, BasicAuth, FlowrsConfig, TokenSource};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 
 impl UpdateCommand {
     pub fn run(&self) -> Result<()> {
@@ -69,13 +69,7 @@ impl UpdateCommand {
             ConfigOption::Token(_) => {
                 let cmd = inquire::Text::new("cmd").prompt()?;
                 info!("🔑 Running command: {cmd}");
-                let output = std::process::Command::new("sh")
-                    .arg("-c")
-                    .arg(&cmd)
-                    .output()
-                    .with_context(|| format!("failed to run token command: {cmd}"))?;
-                // Validate the command produces a token
-                let _token = String::from_utf8(output.stdout)?;
+                run_token_command(&cmd)?;
                 airflow_config.auth = AirflowAuth::Token(TokenSource::Command { cmd });
             }
         }


### PR DESCRIPTION
## Summary

When adding or updating a `Token` server whose auth is a shell command, `config add`/`config update` ran the command but never checked whether it *worked*:

```rust
let output = std::process::Command::new("sh").arg("-c").arg(&cmd).output()...?;
// Validate the command produces a token   <-- comment lied
let _token = String::from_utf8(output.stdout)?;
```

Exit status was ignored and empty output was accepted, so a broken or misspelled auth command was saved to config silently — then failed on every later API call, far from where the mistake was made.

## Changes
- Added `run_token_command(cmd) -> Result<String>` in `model.rs` that runs the command and **rejects** it if it can't spawn, exits non-zero, or produces no token (stderr is included in the error).
- Replaced the duplicated, unchecked spawn logic in both `add.rs` and `update.rs` with a call to the shared helper — also de-duplicating the two copies.

## Tests
- `token_command_returns_trimmed_output`
- `token_command_errors_on_non_zero_exit`
- `token_command_errors_on_empty_output`

The validation lives in a plain function (not the interactive `run()`), so these drive real subprocesses (`echo` / `exit 1` / `true`) deterministically.

## Note on stacking
This is **stacked on #670** (`fix/config-update-unknown-name`) because both touch the token branch of `update.rs`; base it back to `main` once #670 merges. Diff shown here is row-6 only.

`cargo test -p flowrs-tui` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)