### PR TITLE
fix(config): fall back to a defined path when the home directory is unavailable

### DIFF
--- a/crates/flowrs-config/src/paths.rs
+++ b/crates/flowrs-config/src/paths.rs
@@ -46,16 +46,15 @@ impl ConfigPaths {
     /// Returns the XDG config path: `$XDG_CONFIG_HOME/flowrs/config.toml`
     /// Falls back to `~/.config/flowrs/config.toml` if `XDG_CONFIG_HOME` is unset or empty.
     fn xdg_config_path() -> PathBuf {
-        // Check XDG_CONFIG_HOME first, fall back to ~/.config (per XDG spec)
+        // Check XDG_CONFIG_HOME first, fall back to ~/.config (per XDG spec).
+        // If the home directory can't be determined (e.g. HOME is unset), fall
+        // back to the current directory rather than aborting during the
+        // CONFIG_PATHS static initialization.
         let base_dir = std::env::var("XDG_CONFIG_HOME")
             .ok()
             .filter(|s| !s.is_empty())
             .map_or_else(
-                || {
-                    home_dir()
-                        .expect("Could not determine user home directory")
-                        .join(".config")
-                },
+                || home_dir().unwrap_or_default().join(".config"),
                 PathBuf::from,
             );
 
@@ -64,9 +63,7 @@ impl ConfigPaths {
 
     /// Returns the legacy config path: `~/.flowrs`
     fn legacy_config_path() -> PathBuf {
-        home_dir()
-            .expect("Could not determine user home directory")
-            .join(".flowrs")
+        home_dir().unwrap_or_default().join(".flowrs")
     }
 
     /// Returns the XDG config directory (for creating if needed).


### PR DESCRIPTION
## Summary

`ConfigPaths::resolve()` — invoked from the `CONFIG_PATHS` `LazyLock` static — called `home_dir().expect("Could not determine user home directory")` in two places. If the home directory can't be determined (e.g. `HOME` unset), that aborts the whole app during static initialization, before any error handling runs. Under `panic = "abort"` it's a hard process abort. A missing home directory is an environmental condition, not a programming bug (M-PANIC-ON-BUG).

## Change
Replaced both `.expect()` calls with `home_dir().unwrap_or_default()`, so an undetermined home directory falls back to a current-directory-relative config path (`.config/flowrs/config.toml`, `.flowrs`) — a well-defined location — instead of aborting.

`resolve()` stays infallible, so none of the 21 `CONFIG_PATHS` use sites change.

## Note
The fallback is intentionally silent and minimal (no helper function, no warning) — an earlier draft with a dedicated helper and injected-`Option` tests was dropped as over-engineered for a one-call fallback. The trade-off: in the (rare) no-home case, config silently resolves relative to the working directory. If you'd prefer a `log::warn!` there so the relocation is visible, say so and I'll add it.

`cargo test -p flowrs-config` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration path handling when the home directory cannot be determined.
  * Prevented application crashes in environments where the `HOME` directory is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->