### PR TITLE
fix(worker): surface 'open in browser' failures to the user

### DIFF
--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -9,6 +9,7 @@ pub use navigation::NavigationContext;
 
 use crate::app::model::dagruns::DagRunModel;
 use crate::app::model::dags::DagModel;
+use crate::app::model::popup::error::ErrorPopup;
 use crate::app::model::popup::warning::WarningPopup;
 use environment_state::EnvironmentStateContainer;
 use flowrs_config::FlowrsConfig;
@@ -113,6 +114,17 @@ impl App {
             Panel::DAGRun => self.active_panel = Panel::Dag,
             Panel::TaskInstance => self.active_panel = Panel::DAGRun,
             Panel::Logs => self.active_panel = Panel::TaskInstance,
+        }
+    }
+
+    /// Show an error popup on whichever panel is currently active.
+    pub fn show_error(&mut self, errors: Vec<String>) {
+        match self.active_panel {
+            Panel::Config => self.configs.popup.show_error(errors),
+            Panel::Dag => self.dags.popup.show_error(errors),
+            Panel::DAGRun => self.dagruns.popup.show_error(errors),
+            Panel::TaskInstance => self.task_instances.popup.show_error(errors),
+            Panel::Logs => self.logs.error_popup = Some(ErrorPopup::from_strings(errors)),
         }
     }
 

--- a/src/app/worker/browser.rs
+++ b/src/app/worker/browser.rs
@@ -1,13 +1,23 @@
 use std::sync::{Arc, Mutex};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::airflow::model::common::OpenItem;
 use crate::airflow::traits::AirflowClient;
 use crate::app::state::App;
 
-/// Handle opening an item (DAG, DAG run, task instance, etc.) in the browser.
-pub fn handle_open_item(
+/// Open an item (DAG, DAG run, task instance, etc.) in the browser.
+///
+/// Any failure (no active server, an unbuildable URL, or the browser refusing
+/// to launch) is surfaced to the user via the active panel's error popup
+/// instead of being silently logged.
+pub fn handle_open_item(app: &Arc<Mutex<App>>, client: &Arc<dyn AirflowClient>, item: OpenItem) {
+    if let Err(e) = try_open_item(app, client, item) {
+        app.lock().unwrap().show_error(vec![e.to_string()]);
+    }
+}
+
+fn try_open_item(
     app: &Arc<Mutex<App>>,
     client: &Arc<dyn AirflowClient>,
     item: OpenItem,
@@ -37,8 +47,6 @@ pub fn handle_open_item(
     };
 
     let url = client.build_open_url(&final_item)?;
-    if let Err(e) = webbrowser::open(&url) {
-        log::error!("Failed to open browser with URL {url}: {e}");
-    }
+    webbrowser::open(&url).with_context(|| format!("failed to open browser for {url}"))?;
     Ok(())
 }

--- a/src/app/worker/mod.rs
+++ b/src/app/worker/mod.rs
@@ -302,7 +302,7 @@ async fn process_message(app: Arc<Mutex<App>>, message: WorkerMessage) -> Result
         }
         // Browser operations
         WorkerMessage::OpenItem(item) => {
-            browser::handle_open_item(&app, &client, item)?;
+            browser::handle_open_item(&app, &client, item);
         }
     }
 


### PR DESCRIPTION
## Summary

`handle_open_item` (the `o` / open-in-browser action) was the only worker handler that didn't surface its errors. `webbrowser::open` failures were swallowed with a `log::error!`, and the config-lookup / URL-build errors it propagated via `?` were only logged by the dispatcher (`worker/mod.rs:137`). Every other handler shows failures via `popup.show_error(...)`. Net effect: the user pressed "open", nothing happened, and there was zero on-screen feedback.

## Changes
- Added `App::show_error(errors)` that routes an error popup to whichever panel is currently active (`active_panel`) — including the `Logs` panel, which uses its own `error_popup` field rather than the shared `Popup<T>`.
- Split `handle_open_item` into a thin wrapper + `try_open_item`: the wrapper surfaces any failure through `App::show_error`, and `webbrowser::open` now propagates with context instead of being swallowed.
- Dropped the now-unnecessary `?` at the call site.

## Tests
- `show_error_targets_the_active_panel` — routes to the active panel's popup, leaves others untouched.
- `show_error_on_logs_panel_sets_the_log_error_popup` — covers the `Logs` special case.

The routing logic (the actual new behavior) is unit-tested against a real `App`. The `webbrowser::open` surfacing is covered by inspection — launching a real browser isn't unit-testable — but its error now flows through the same tested `show_error` path.

Full suite: 219 unit tests pass; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Browser-opening failures are now displayed in the active panel’s error popup instead of being logged silently.
  * Error messages are routed to the correct panel, including configuration, DAG, run, task, and logs views.
  * The worker continues operating after an item fails to open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->