### PR TITLE
chore: centralize lints in [workspace.lints] and lint the airflow crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,26 @@ time = { version = "0.3.47", features = ["serde", "serde-human-readable", "parsi
 tokio = { version = "1.51.1", features = ["rt-multi-thread", "sync", "macros"] }
 toml = "1.1.2"
 
+# Shared lint configuration for every crate in the workspace. Crates opt in with
+# `[lints] workspace = true`. See the Microsoft Pragmatic Rust Guidelines
+# (M-STATIC-VERIFICATION). Higher-churn lints (missing_debug_implementations,
+# allow_attributes_without_reason, clone_on_ref_ptr) are intentionally deferred
+# to follow-up changes so this one stays warning-clean.
+[workspace.lints.rust]
+ambiguous_negative_literals = "warn"
+redundant_lifetimes = "warn"
+trivial_numeric_casts = "warn"
+unsafe_op_in_unsafe_fn = "warn"
+unused_lifetimes = "warn"
+
+[workspace.lints.clippy]
+complexity = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+perf = { level = "warn", priority = -1 }
+style = { level = "warn", priority = -1 }
+suspicious = { level = "warn", priority = -1 }
+undocumented_unsafe_blocks = "warn"
+
 [package]
 name = "flowrs-tui"
 version = "0.13.0"
@@ -81,8 +101,8 @@ codegen-units = 1
 strip = true
 panic = "abort"
 
-[lints.clippy]
-pedantic = "warn"
+[lints]
+workspace = true
 
 
 [profile.dist]

--- a/crates/flowrs-airflow/Cargo.toml
+++ b/crates/flowrs-airflow/Cargo.toml
@@ -33,3 +33,6 @@ time = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
 url = "2.5.7"
+
+[lints]
+workspace = true

--- a/crates/flowrs-airflow/src/managed_services/expand.rs
+++ b/crates/flowrs-airflow/src/managed_services/expand.rs
@@ -12,7 +12,7 @@ use super::conveyor::get_conveyor_environment_servers;
 #[cfg(feature = "mwaa")]
 use super::mwaa::get_mwaa_environment_servers;
 
-/// Configuration for managed service expansion, decomposed from FlowrsConfig
+/// Configuration for managed service expansion, decomposed from `FlowrsConfig`
 /// so that flowrs-airflow does not depend on the config crate.
 pub struct ManagedServiceConfig {
     pub services: Vec<ManagedService>,

--- a/crates/flowrs-config/Cargo.toml
+++ b/crates/flowrs-config/Cargo.toml
@@ -17,5 +17,5 @@ serde.workspace = true
 strum.workspace = true
 toml.workspace = true
 
-[lints.clippy]
-pedantic = "warn"
+[lints]
+workspace = true


### PR DESCRIPTION
## Summary

Lint configuration was duplicated per-crate (`[lints.clippy] pedantic = "warn"` in the root and `flowrs-config`) and — critically — **`flowrs-airflow` had no lint config at all**, so the library crate was never held to `pedantic`. This centralizes everything in `[workspace.lints]` and opts every crate in, following M-STATIC-VERIFICATION.

## Changes
- Added `[workspace.lints]` to the root manifest and `[lints] workspace = true` to all three crates (root, `flowrs-config`, `flowrs-airflow`).
- Enabled the additional lints from the guideline that currently produce **zero** violations, so this is pure regression protection at no fix-up cost: clippy `perf` / `suspicious` / `complexity` / `style` / `undocumented_unsafe_blocks`, and rust `unsafe_op_in_unsafe_fn` / `unused_lifetimes` / `redundant_lifetimes` / `trivial_numeric_casts` / `ambiguous_negative_literals`.
- Fixed the one finding that surfaced from bringing `flowrs-airflow` under `pedantic` (a missing-backticks doc comment in `expand.rs`).

## Deliberately deferred
Three higher-churn lints from the guideline are **not** enabled here, to keep this change warning-clean and reviewable. Each is a focused follow-up:
- `allow_attributes_without_reason` — 63 sites; pairs with converting `#[allow]` → `#[expect(..., reason = ...)]`.
- `missing_debug_implementations` — 41 public types need `Debug`.
- `clone_on_ref_ptr` — 5 sites (`Arc::clone(&x)` over `x.clone()`).

A comment in the manifest records why they're deferred.

`cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean; full unit suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)