### PR TITLE
refactor: convert #[allow] to #[expect] with reasons; enable allow_attributes_without_reason

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ toml = "1.1.2"
 # Shared lint configuration for every crate in the workspace. Crates opt in with
 # `[lints] workspace = true`. See the Microsoft Pragmatic Rust Guidelines
 # (M-STATIC-VERIFICATION). Higher-churn lints (missing_debug_implementations,
-# allow_attributes_without_reason, clone_on_ref_ptr) are intentionally deferred
-# to follow-up changes so this one stays warning-clean.
+# clone_on_ref_ptr) are intentionally deferred to follow-up changes so this one
+# stays warning-clean.
 [workspace.lints.rust]
 ambiguous_negative_literals = "warn"
 redundant_lifetimes = "warn"
@@ -40,7 +40,19 @@ pedantic = { level = "warn", priority = -1 }
 perf = { level = "warn", priority = -1 }
 style = { level = "warn", priority = -1 }
 suspicious = { level = "warn", priority = -1 }
+allow_attributes_without_reason = "warn"
 undocumented_unsafe_blocks = "warn"
+
+# Pedantic/nursery lints the project opts out of workspace-wide. These are
+# blanket policy choices, so they live here rather than as `#![allow]` on each
+# crate root: doc-completeness and must-use lints are noise for an application,
+# and the remaining style lints disagree with the codebase's conventions.
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+must_use_candidate = "allow"
+option_if_let_else = "allow"
+significant_drop_tightening = "allow"
+useless_let_if_seq = "allow"
 
 [package]
 name = "flowrs-tui"

--- a/crates/flowrs-airflow/src/client/v1/taskinstance.rs
+++ b/crates/flowrs-airflow/src/client/v1/taskinstance.rs
@@ -42,7 +42,11 @@ impl V1Client {
                 "Fetched {fetched_count} task instances, offset: {offset}, total: {total_entries}"
             );
 
-            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            #[expect(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "duration/count values from the API are small and non-negative in practice"
+            )]
             if fetched_count < limit || all_task_instances.len() >= total_entries as usize {
                 break;
             }

--- a/crates/flowrs-airflow/src/client/v2/model/dag.rs
+++ b/crates/flowrs-airflow/src/client/v2/model/dag.rs
@@ -7,7 +7,10 @@ pub struct DagList {
     pub total_entries: i64,
 }
 
-#[allow(clippy::struct_excessive_bools, clippy::struct_field_names)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "boolean flags mirror the Airflow API response schema"
+)]
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Dag {

--- a/crates/flowrs-airflow/src/client/v2/model/dagrun.rs
+++ b/crates/flowrs-airflow/src/client/v2/model/dagrun.rs
@@ -10,7 +10,6 @@ pub struct DagRunList {
     pub total_entries: i64,
 }
 
-#[allow(clippy::struct_field_names)]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DagRun {
     pub dag_run_id: String,

--- a/crates/flowrs-airflow/src/client/v2/model/taskinstance.rs
+++ b/crates/flowrs-airflow/src/client/v2/model/taskinstance.rs
@@ -91,7 +91,6 @@ pub struct Trigger {
     pub triggerer_id: Option<i64>,
 }
 
-#[allow(clippy::struct_field_names)]
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Job {
     pub id: i64,

--- a/crates/flowrs-airflow/src/client/v2/taskinstance.rs
+++ b/crates/flowrs-airflow/src/client/v2/taskinstance.rs
@@ -85,7 +85,11 @@ impl V2Client {
                 "Fetched {fetched_count} task instances (all), offset: {offset}, total: {total_entries}"
             );
 
-            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            #[expect(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "duration/count values from the API are small and non-negative in practice"
+            )]
             if fetched_count < limit || all_task_instances.len() >= total_entries as usize {
                 break;
             }

--- a/crates/flowrs-airflow/src/lib.rs
+++ b/crates/flowrs-airflow/src/lib.rs
@@ -1,9 +1,3 @@
-// Clippy pedantic allows - consistent with the rest of the workspace
-#![allow(clippy::missing_errors_doc)]
-#![allow(clippy::missing_panics_doc)]
-#![allow(clippy::must_use_candidate)]
-#![allow(clippy::option_if_let_else)]
-
 pub mod auth;
 pub mod client;
 pub mod config;

--- a/crates/flowrs-airflow/src/managed_services/expand.rs
+++ b/crates/flowrs-airflow/src/managed_services/expand.rs
@@ -23,7 +23,7 @@ pub struct ManagedServiceConfig {
 /// Expands managed services by resolving their environments and returning server configs.
 /// Returns a tuple of (new servers, errors) where errors contains any non-fatal errors encountered.
 pub async fn expand_managed_services(
-    #[allow(unused_variables)] config: ManagedServiceConfig,
+    config: ManagedServiceConfig,
 ) -> Result<(Vec<AirflowConfig>, Vec<String>)> {
     let mut all_servers = Vec::new();
     let mut all_errors = Vec::new();

--- a/crates/flowrs-config/src/lib.rs
+++ b/crates/flowrs-config/src/lib.rs
@@ -1,8 +1,3 @@
-// Clippy pedantic allows
-#![allow(clippy::missing_errors_doc)]
-#![allow(clippy::missing_panics_doc)]
-#![allow(clippy::must_use_candidate)]
-
 pub mod auth;
 pub mod paths;
 pub mod server;
@@ -87,7 +82,10 @@ impl FlowrsConfig {
         } else {
             self.poll_interval_ms
         };
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "poll interval divided by the tick rate is a small multiplier well within u32"
+        )]
         let multiplier = (interval / TICK_RATE_MS) as u32;
         multiplier.max(1)
     }

--- a/src/airflow/model/common/dag.rs
+++ b/src/airflow/model/common/dag.rs
@@ -4,7 +4,10 @@ use time::OffsetDateTime;
 use super::DagId;
 
 /// Common DAG model used by the application
-#[allow(clippy::struct_field_names)]
+#[allow(
+    clippy::struct_field_names,
+    reason = "field names mirror the Airflow API response schema"
+)]
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Dag {
     pub dag_id: DagId,

--- a/src/airflow/model/common/dagrun.rs
+++ b/src/airflow/model/common/dagrun.rs
@@ -89,7 +89,10 @@ impl From<&str> for RunType {
 }
 
 /// Common `DagRun` model used by the application
-#[allow(clippy::struct_field_names)]
+#[allow(
+    clippy::struct_field_names,
+    reason = "field names mirror the Airflow API response schema"
+)]
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DagRun {
     pub dag_id: DagId,

--- a/src/airflow/model/common/mod.rs
+++ b/src/airflow/model/common/mod.rs
@@ -10,7 +10,10 @@ pub mod taskinstance;
 
 // Re-export common types for easier access
 pub use dag::{Dag, DagList, Tag};
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    reason = "re-exported for API completeness; unused under some configurations"
+)]
 pub use dagrun::{DagRun, DagRunList, DagRunState, RunType};
 pub use dagstats::{DagStatistic, DagStatsResponse};
 pub use duration::{calculate_duration, format_duration};

--- a/src/airflow/model/common/open_item.rs
+++ b/src/airflow/model/common/open_item.rs
@@ -19,7 +19,6 @@ pub enum OpenItem {
         dag_id: DagId,
         dag_run_id: DagRunId,
         task_id: TaskId,
-        #[allow(dead_code)]
         task_try: u32,
     },
 }

--- a/src/airflow/traits/dagrun.rs
+++ b/src/airflow/traits/dagrun.rs
@@ -10,7 +10,7 @@ pub trait DagRunOperations: Send + Sync {
     async fn list_dagruns(&self, dag_id: &str) -> Result<DagRunList>;
 
     /// List all DAG runs across all DAGs
-    #[allow(unused)]
+    #[allow(unused, reason = "trait method kept for API completeness")]
     async fn list_all_dagruns(&self) -> Result<DagRunList>;
 
     /// Mark a DAG run with a specific status

--- a/src/airflow/traits/mod.rs
+++ b/src/airflow/traits/mod.rs
@@ -29,7 +29,7 @@ pub trait AirflowClient:
     + TaskOperations
 {
     /// Get the Airflow version this client is configured for
-    #[allow(unused)]
+    #[allow(unused, reason = "trait method kept for API completeness")]
     fn get_version(&self) -> AirflowVersion;
 
     /// Build the appropriate web UI URL for opening an item in the browser.
@@ -37,6 +37,5 @@ pub trait AirflowClient:
     ///
     /// # Errors
     /// Returns an error if the URL cannot be constructed for the given item.
-    #[allow(unused)]
     fn build_open_url(&self, item: &OpenItem) -> Result<String>;
 }

--- a/src/airflow/traits/taskinstance.rs
+++ b/src/airflow/traits/taskinstance.rs
@@ -11,7 +11,7 @@ pub trait TaskInstanceOperations: Send + Sync {
         -> Result<TaskInstanceList>;
 
     /// List all task instances across all DAG runs
-    #[allow(unused)]
+    #[allow(unused, reason = "trait method kept for API completeness")]
     async fn list_all_taskinstances(&self) -> Result<TaskInstanceList>;
 
     /// List all tries for a specific task instance (for Gantt chart retry visualization)

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -43,7 +43,10 @@ impl KeyResult {
     }
 
     /// Convert to the `update()` return type
-    #[allow(clippy::match_same_arms)] // PassThrough and Ignored are semantically different
+    #[expect(
+        clippy::match_same_arms,
+        reason = "arms are semantically distinct even though they map to the same value"
+    )]
     pub fn into_result(self, event: &FlowrsEvent) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
         match self {
             KeyResult::Consumed => (None, vec![]),

--- a/src/app/model/dagruns/dag_code_view/render.rs
+++ b/src/app/model/dagruns/dag_code_view/render.rs
@@ -23,7 +23,10 @@ impl DagCodeView {
             .style(t.default_style)
             .title_style(t.title_style);
 
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
+        )]
         let code_text = Paragraph::new(self.lines.clone())
             .block(popup)
             .style(t.default_style)

--- a/src/app/model/dagruns/mod.rs
+++ b/src/app/model/dagruns/mod.rs
@@ -73,10 +73,11 @@ impl DagRunModel {
         };
 
         // Calculate how many characters should be filled
-        #[allow(
+        #[expect(
             clippy::cast_possible_truncation,
             clippy::cast_sign_loss,
-            clippy::cast_precision_loss
+            clippy::cast_precision_loss,
+            reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
         )]
         let filled_width = (ratio * width as f64).round() as usize;
         let empty_width = width.saturating_sub(filled_width);

--- a/src/app/model/dags/render.rs
+++ b/src/app/model/dags/render.rs
@@ -115,7 +115,10 @@ fn convert_datetimeoffset_to_human_readable_remaining_time(dt: OffsetDateTime) -
 
 fn format_remaining_time(dt: OffsetDateTime, now: OffsetDateTime) -> String {
     let duration = dt.unix_timestamp() - now.unix_timestamp();
-    #[allow(clippy::cast_sign_loss)]
+    #[expect(
+        clippy::cast_sign_loss,
+        reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
+    )]
     let duration = if duration < 0 { 0 } else { duration as u64 };
     let days = duration / (24 * 3600);
     let hours = (duration % (24 * 3600)) / 3600;

--- a/src/app/model/filter/matching.rs
+++ b/src/app/model/filter/matching.rs
@@ -16,7 +16,7 @@ fn item_matches<T: Filterable>(item: &T, conditions: &[FilterCondition]) -> bool
 }
 
 /// Check if an item matches all filter conditions (public API, used by tests)
-#[allow(dead_code)]
+#[allow(dead_code, reason = "public helper exercised only by tests")]
 pub fn matches<T: Filterable>(item: &T, conditions: &[FilterCondition]) -> bool {
     item_matches(item, conditions)
 }

--- a/src/app/model/filter/widget.rs
+++ b/src/app/model/filter/widget.rs
@@ -59,7 +59,10 @@ impl FilterStateMachine {
                 let mut cursor_offset: u16 = 0;
 
                 // Render confirmed conditions
-                #[allow(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
+                )]
                 for cond in conditions {
                     let cond_text = format!("{}: {} ", cond.field, cond.value);
                     cursor_offset += cond_text.len() as u16;
@@ -70,7 +73,10 @@ impl FilterStateMachine {
                 }
 
                 // Render primary field name with colon (like ValueInput)
-                #[allow(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
+                )]
                 if let Some(field) = self.primary_field() {
                     let field_prefix = format!("{field}: ");
                     cursor_offset += field_prefix.len() as u16;
@@ -82,7 +88,10 @@ impl FilterStateMachine {
 
                 // Render typed text
                 let typed = &autocomplete.typed;
-                #[allow(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
+                )]
                 {
                     cursor_offset += typed.len() as u16;
                 }
@@ -110,7 +119,10 @@ impl FilterStateMachine {
                 let mut cursor_offset: u16 = 0;
 
                 // Render confirmed conditions
-                #[allow(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
+                )]
                 for cond in conditions {
                     let cond_text = format!("{}: {} ", cond.field, cond.value);
                     cursor_offset += cond_text.len() as u16;
@@ -126,7 +138,10 @@ impl FilterStateMachine {
 
                 // Render typed attribute name
                 let typed = &autocomplete.typed;
-                #[allow(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
+                )]
                 {
                     cursor_offset += typed.len() as u16;
                 }
@@ -158,7 +173,10 @@ impl FilterStateMachine {
                 let mut cursor_offset: u16 = 0;
 
                 // Render confirmed conditions
-                #[allow(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
+                )]
                 for cond in conditions {
                     let cond_text = format!("{}: {} ", cond.field, cond.value);
                     cursor_offset += cond_text.len() as u16;
@@ -170,7 +188,10 @@ impl FilterStateMachine {
 
                 // Render field name with colon
                 let field_prefix = format!("{field}: ");
-                #[allow(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
+                )]
                 {
                     cursor_offset += field_prefix.len() as u16;
                 }
@@ -181,7 +202,10 @@ impl FilterStateMachine {
 
                 // Render typed value
                 let typed = &autocomplete.typed;
-                #[allow(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
+                )]
                 {
                     cursor_offset += typed.len() as u16;
                 }

--- a/src/app/model/logs/mod.rs
+++ b/src/app/model/logs/mod.rs
@@ -192,7 +192,10 @@ impl Model for LogModel {
                                         dag_id: dag_id.clone(),
                                         dag_run_id: dag_run_id.clone(),
                                         task_id: task_id.clone(),
-                                        #[allow(clippy::cast_possible_truncation)]
+                                        #[expect(
+                                            clippy::cast_possible_truncation,
+                                            reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
+                                        )]
                                         task_try: (self.current_index() + 1) as u32,
                                     })],
                                 );

--- a/src/app/model/logs/render.rs
+++ b/src/app/model/logs/render.rs
@@ -62,7 +62,10 @@ impl Widget for &mut LogModel {
             let line_count = self.current_line_count();
             let scroll_pos = self.scroll_mode.position(line_count);
 
-            #[allow(clippy::cast_possible_truncation)]
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
+            )]
             let paragraph = Paragraph::new(content)
                 .block(
                     Block::default()

--- a/src/app/model/popup/mod.rs
+++ b/src/app/model/popup/mod.rs
@@ -102,7 +102,6 @@ impl<T> Widget for &Popup<T> {
 }
 
 /// helper function to create a centered rect using up certain percentage of the available rect `r`
-#[allow(dead_code)]
 pub fn popup_area(area: Rect, percent_x: u16, percent_y: u16) -> Rect {
     let vertical = Layout::vertical([Constraint::Percentage(percent_y)]).flex(Flex::Center);
     let horizontal = Layout::horizontal([Constraint::Percentage(percent_x)]).flex(Flex::Center);

--- a/src/app/model/taskinstances/popup/graph.rs
+++ b/src/app/model/taskinstances/popup/graph.rs
@@ -48,10 +48,9 @@ pub struct DagGraphPopup {
 
 impl DagGraphPopup {
     /// Build a graph popup from the task graph and current task instance states.
-    #[allow(
+    #[expect(
         clippy::cast_possible_truncation,
-        clippy::cast_sign_loss,
-        clippy::cast_possible_wrap
+        reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
     )]
     pub fn new(graph: &TaskGraph, task_instances: &[TaskInstance]) -> Self {
         // Map task_id -> state for coloring
@@ -194,10 +193,10 @@ impl DagGraphPopup {
     }
 
     /// Set a cell in the buffer if it falls within the visible area.
-    #[allow(
+    #[expect(
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss,
-        clippy::cast_possible_wrap
+        reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
     )]
     pub fn set_cell(
         &self,

--- a/src/app/model/taskinstances/popup/render.rs
+++ b/src/app/model/taskinstances/popup/render.rs
@@ -160,7 +160,11 @@ impl Widget for &mut MarkTaskInstancePopup {
 }
 
 impl Widget for &mut DagGraphPopup {
-    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap,
+        reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
+    )]
     fn render(self, area: Rect, buffer: &mut Buffer) {
         let t = theme();
         // +2 for block borders, +1 for title bottom line

--- a/src/app/model/taskinstances/render.rs
+++ b/src/app/model/taskinstances/render.rs
@@ -23,7 +23,10 @@ impl Widget for &mut TaskInstanceModel {
         let legend = Paragraph::new(gantt_legend_line())
             .wrap(Wrap { trim: true })
             .alignment(Alignment::Center);
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
+        )]
         let legend_height = legend.line_count(panel_area.width).max(1) as u16;
 
         let [content_area, legend_area] =

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -46,7 +46,7 @@ pub enum Panel {
 }
 
 impl App {
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "constructor used only in tests")]
     pub fn new(config: FlowrsConfig) -> Self {
         Self::new_with_errors_and_warnings(config, vec![], vec![])
     }

--- a/src/commands/config/model.rs
+++ b/src/commands/config/model.rs
@@ -181,7 +181,10 @@ pub struct ManagedServiceCommand {
 
 type Command = Option<String>;
 
-#[allow(clippy::unnecessary_wraps)]
+#[allow(
+    clippy::unnecessary_wraps,
+    reason = "signature kept uniform with the inquire validator interface"
+)]
 pub fn validate_endpoint(
     endpoint: &str,
 ) -> Result<Validation, Box<dyn std::error::Error + Send + Sync>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,4 @@
 // Library exports for integration tests and external usage
-//
-// Clippy pedantic allows - these are library documentation concerns, not relevant for a TUI application
-#![allow(clippy::missing_errors_doc)]
-#![allow(clippy::missing_panics_doc)]
-#![allow(clippy::must_use_candidate)]
-// The option_if_let_else lint often reduces readability by forcing map_or_else
-#![allow(clippy::option_if_let_else)]
-// Drop timing hints are often too aggressive for typical application code
-#![allow(clippy::significant_drop_tightening)]
-// The useless_let_if_seq lint often reduces readability
-#![allow(clippy::useless_let_if_seq)]
 
 use std::sync::LazyLock;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,3 @@
-// Clippy pedantic/nursery allows for this TUI application
-#![allow(clippy::missing_errors_doc)]
-#![allow(clippy::missing_panics_doc)]
-#![allow(clippy::must_use_candidate)]
-#![allow(clippy::option_if_let_else)]
-#![allow(clippy::significant_drop_tightening)]
-#![allow(clippy::useless_let_if_seq)]
-
 use std::sync::LazyLock;
 
 use clap::Parser;

--- a/src/ui/gantt.rs
+++ b/src/ui/gantt.rs
@@ -39,16 +39,18 @@ pub fn create_gantt_bar(gantt: &GanttData, task_id: &TaskId, width: usize) -> Li
         let start_ratio = gantt.ratio(seg_start);
         let end_ratio = gantt.ratio(seg_end);
 
-        #[allow(
+        #[expect(
             clippy::cast_possible_truncation,
             clippy::cast_sign_loss,
-            clippy::cast_precision_loss
+            clippy::cast_precision_loss,
+            reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
         )]
         let start_col = ((start_ratio * width as f64).floor() as usize).min(width);
-        #[allow(
+        #[expect(
             clippy::cast_possible_truncation,
             clippy::cast_sign_loss,
-            clippy::cast_precision_loss
+            clippy::cast_precision_loss,
+            reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
         )]
         let end_col = ((end_ratio * width as f64)
             .ceil()

--- a/src/ui/init_screen.rs
+++ b/src/ui/init_screen.rs
@@ -12,9 +12,15 @@ pub fn render_init_screen(f: &mut Frame, index: u32) {
 
     let area = center(
         f.area(),
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
+        )]
         Constraint::Length(text.width() as u16),
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
+        )]
         Constraint::Length(text.height() as u16),
     );
 

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -67,7 +67,10 @@ impl TabBar {
 }
 
 impl Widget for TabBar {
-    #[allow(clippy::cast_possible_truncation)] // Tab widths are small, truncation won't occur
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "tab widths are small, truncation won't occur"
+    )]
     fn render(self, area: Rect, buf: &mut Buffer) {
         if area.height < 3 {
             return; // Need at least 3 rows for tabs + border

--- a/src/ui/theme/mod.rs
+++ b/src/ui/theme/mod.rs
@@ -15,8 +15,11 @@ use flowrs_config::Theme as ThemePreset;
 use ratatui::style::{Color, Style};
 
 /// Complete theme definition with all colors and pre-built styles.
+#[allow(
+    dead_code,
+    reason = "color fields kept for completeness; not all are read yet"
+)]
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct Theme {
     pub text_primary: Color,
     /// Muted foreground for secondary/confirmed text (e.g. applied filter conditions).

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,8 @@
 // Functions are used across different test files but appear unused when compiling each test separately
-#![allow(dead_code)]
+#![allow(
+    dead_code,
+    reason = "helpers are shared across test files and look unused when each is compiled separately"
+)]
 
 use std::env;
 use std::sync::Arc;


### PR DESCRIPTION
## Re-applies #675, which never reached `main`

#675 was stacked on #674's branch and merged **into that branch**, not `main`. When #674 was squash-merged, the squash captured only #674's own diff, so #675's commits were left behind on the (now-deleted) branch — `main` currently has 62 `#[allow]` and 0 `#[expect]`, and `allow_attributes_without_reason` is still deferred. This PR brings that work back, rebased cleanly onto current `main`.

## Contents (unchanged from #675)
- Enables the `allow_attributes_without_reason` restriction lint.
- Blanket crate-root `#![allow(clippy::…)]` opt-outs moved into `[workspace.lints]` config; the `#![allow]` lines deleted.
- Item-level `#[allow]` → `#[expect(..., reason = "…")]` where the lint reliably fires (27 sites).
- Kept as `#[allow(..., reason = "…")]` where `#[expect]` would be unfulfilled under `--all-targets` (10 conditional cases).
- Deleted 8 stale suppressions that no longer fired.

## Verification
`cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, and the full unit suite (222 tests) are clean on current `main`.

> Note: to avoid re-introducing the stacked-squash pitfall, this is an independent PR based directly on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code-quality checks by replacing broad lint suppressions with targeted, documented expectations.
  * Removed redundant warning suppressions where they were no longer needed.
  * Clarified intentional exceptions for API compatibility, test helpers, safe numeric conversions, and schema-aligned field names.
  * No user-facing functionality, behavior, or public APIs changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->