### PR TITLE
fix(airflow): lint-clean expand_managed_services across feature combos; add cargo-hack CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,20 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
+  feature-combos:
+    name: Feature Combinations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-hack
+      # flowrs-airflow is the only feature-gated crate; verify every combination
+      # of its managed-service features compiles and lints cleanly.
+      - run: cargo hack --feature-powerset -p flowrs-airflow clippy --all-targets -- -D warnings
+
   test:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/crates/flowrs-airflow/src/managed_services/expand.rs
+++ b/crates/flowrs-airflow/src/managed_services/expand.rs
@@ -22,9 +22,28 @@ pub struct ManagedServiceConfig {
 
 /// Expands managed services by resolving their environments and returning server configs.
 /// Returns a tuple of (new servers, errors) where errors contains any non-fatal errors encountered.
+#[cfg_attr(
+    not(any(feature = "mwaa", feature = "astronomer", feature = "composer")),
+    allow(
+        clippy::unused_async,
+        reason = "the awaited service resolvers are gated behind async features"
+    )
+)]
 pub async fn expand_managed_services(
     config: ManagedServiceConfig,
 ) -> Result<(Vec<AirflowConfig>, Vec<String>)> {
+    #[cfg_attr(
+        not(any(
+            feature = "conveyor",
+            feature = "mwaa",
+            feature = "astronomer",
+            feature = "composer"
+        )),
+        allow(
+            unused_mut,
+            reason = "no service features are enabled, so all_servers is never extended"
+        )
+    )]
     let mut all_servers = Vec::new();
     let mut all_errors = Vec::new();
 


### PR DESCRIPTION
## Summary

`flowrs-airflow` failed `clippy -D warnings` under several managed-service feature combinations (e.g. no features, or `conveyor` alone). CI only ran `--all-features`, so it never caught this — but `flowrs-config` depends on `flowrs-airflow` with `default-features = false`, so the no-features build is a real path. Surfaced while working on #675.

Two lints in `expand.rs`:
- `clippy::unused_async` — the function is `async`, but its only `await` sites (`mwaa`/`astronomer`/`composer`) are feature-gated; `conveyor` is synchronous, so with no async feature the `async` is "unused".
- `unused_mut` on `all_servers` — it's only `.extend()`ed inside `#[cfg(feature = …)]` blocks, so with no service features it's never mutated.

## Changes
- Scoped `#[cfg_attr(not(any(…)), allow(…, reason = …))]` on exactly the combinations that trip each lint, so the allows are inert in the normal all-features build (a real `unused_mut`/`unused_async` there would still be caught).
- **Added a `Feature Combinations` CI job** running `cargo hack --feature-powerset -p flowrs-airflow clippy --all-targets -- -D warnings`, so this whole class of feature-combo breakage is caught going forward. `flowrs-airflow` is the only feature-gated crate.

## Verification
- `cargo hack --feature-powerset -p flowrs-airflow clippy --all-targets -- -D warnings` — all 17 combinations clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, unit tests — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved build and lint warnings when optional managed-service integrations are disabled.
  * Improved compatibility across configurations with different service features enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->