### PR TITLE
refactor: use Arc::clone over .clone(); enable clone_on_ref_ptr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,8 @@ toml = "1.1.2"
 
 # Shared lint configuration for every crate in the workspace. Crates opt in with
 # `[lints] workspace = true`. See the Microsoft Pragmatic Rust Guidelines
-# (M-STATIC-VERIFICATION). Higher-churn lints (missing_debug_implementations,
-# clone_on_ref_ptr) are intentionally deferred to follow-up changes so this one
-# stays warning-clean.
+# (M-STATIC-VERIFICATION). missing_debug_implementations is intentionally
+# deferred to a follow-up change so this one stays warning-clean.
 [workspace.lints.rust]
 ambiguous_negative_literals = "warn"
 redundant_lifetimes = "warn"
@@ -41,6 +40,7 @@ perf = { level = "warn", priority = -1 }
 style = { level = "warn", priority = -1 }
 suspicious = { level = "warn", priority = -1 }
 allow_attributes_without_reason = "warn"
+clone_on_ref_ptr = "warn"
 undocumented_unsafe_blocks = "warn"
 
 # Pedantic/nursery lints the project opts out of workspace-wide. These are

--- a/src/app.rs
+++ b/src/app.rs
@@ -24,8 +24,8 @@ where
     <B as Backend>::Error: 'static + std::marker::Send + std::marker::Sync,
 {
     let mut events = EventGenerator::new(200);
-    let ui_app = app.clone();
-    let worker_app = app.clone();
+    let ui_app = Arc::clone(&app);
+    let worker_app = Arc::clone(&app);
 
     let (tx_worker, rx_worker) = tokio::sync::mpsc::channel::<WorkerMessage>(100);
 

--- a/src/app/worker/mod.rs
+++ b/src/app/worker/mod.rs
@@ -130,8 +130,8 @@ impl Dispatcher {
             }
 
             // Spawn each message processing as a concurrent task
-            let app = self.app.clone();
-            let in_flight = in_flight.clone();
+            let app = Arc::clone(&self.app);
+            let in_flight = Arc::clone(&in_flight);
             tasks.spawn(async move {
                 if let Err(e) = process_message(app, message).await {
                     log::error!("Error processing message: {e}");
@@ -177,7 +177,7 @@ async fn process_message(app: Arc<Mutex<App>>, message: WorkerMessage) -> Result
         (
             app.environment_state
                 .get_active_environment()
-                .map(|env| env.client.clone()),
+                .map(|env| Arc::clone(&env.client)),
             app.environment_state.active_environment.clone(),
         )
     };


### PR DESCRIPTION
## Summary

Enables the `clone_on_ref_ptr` restriction lint (deferred from #674) and fixes the 5 sites it flags. Using `Arc::clone(&x)` instead of `x.clone()` on ref-counted pointers makes the reference-count bump explicit at the call site rather than looking like a deep clone.

## Changes
- `src/app.rs` — the two `app.clone()` in `run_app`.
- `src/app/worker/mod.rs` — `self.app`, `in_flight`, and `env.client` clones in the dispatcher loop.
- `Cargo.toml` — enable the lint; drop it from the deferred list (only `missing_debug_implementations` remains deferred).

No behavior change. `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, and the full unit suite are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)