### PR TITLE
fix(events): stop the event loop task when the receiver is gone

### DIFF
--- a/src/app/events/generator.rs
+++ b/src/app/events/generator.rs
@@ -26,11 +26,17 @@ impl EventGenerator {
                     .unwrap_or_else(|| Duration::from_secs(0));
                 if matches!(event::poll(timeout), Ok(true)) {
                     if let Ok(ev) = event::read() {
-                        let _ = tx_event_thread.send(FlowrsEvent::from(ev)).await;
+                        // A send error means the receiver is gone (the app is
+                        // exiting), so stop the loop instead of spinning forever.
+                        if tx_event_thread.send(FlowrsEvent::from(ev)).await.is_err() {
+                            break;
+                        }
                     }
                 }
                 if last_tick.elapsed() > tick_rate {
-                    let _ = tx_event_thread.send(FlowrsEvent::Tick).await;
+                    if tx_event_thread.send(FlowrsEvent::Tick).await.is_err() {
+                        break;
+                    }
                     last_tick = Instant::now();
                 }
             }


### PR DESCRIPTION
## Summary

The event-generator task ran `let _ = tx_event_thread.send(...).await` for both key and tick events, discarding the result. When the receiver (`rx_event`) is dropped as the app exits, every `send` errors — but the task ignored that and kept looping, calling `crossterm::event::poll`/`read` forever. That's a leaked task doing real work after the UI is gone.

(Note: with `send().await` a full 500-slot buffer applies backpressure rather than dropping, so the only failure mode here is a closed receiver.)

## Change
Break out of the loop when a send fails, so the task terminates cleanly once the receiver is gone.

No test: the loop is a spawned task driving real `crossterm` I/O, not unit-testable without a heavy seam; the change is a self-evident "stop when the channel closes." `cargo clippy --workspace --all-targets --all-features -- -D warnings` and `cargo fmt --all --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)