### PR TITLE
perf(events): read terminal events via async EventStream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,7 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
+ "futures-core",
  "mio",
  "parking_lot",
  "rustix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 strum = { version = "0.28.0", features = ["derive"] }
 time = { version = "0.3.47", features = ["serde", "serde-human-readable", "parsing", "macros"] }
-tokio = { version = "1.51.1", features = ["rt-multi-thread", "sync", "macros"] }
+tokio = { version = "1.51.1", features = ["rt-multi-thread", "sync", "macros", "time"] }
 toml = "1.1.2"
 
 # Shared lint configuration for every crate in the workspace. Crates opt in with
@@ -82,7 +82,7 @@ flowrs-config = { path = "crates/flowrs-config", version = "0.12.1" }
 flowrs-airflow = { path = "crates/flowrs-airflow", version = "0.11.1" }
 chrono = { workspace = true }
 clap = { workspace = true }
-crossterm = "0.29.0"
+crossterm = { version = "0.29.0", features = ["event-stream"] }
 dirs = { workspace = true }
 futures = "0.3.32"
 inquire = "0.9.3"

--- a/src/app/events/generator.rs
+++ b/src/app/events/generator.rs
@@ -1,8 +1,9 @@
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
+use crossterm::event::EventStream;
+use futures::StreamExt;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
-
-use crossterm::event;
+use tokio::time::{interval, MissedTickBehavior};
 
 use super::custom::FlowrsEvent;
 
@@ -18,26 +19,29 @@ impl EventGenerator {
 
         let tick_rate = Duration::from_millis(u64::from(tick_rate));
         let tx_event_thread = tx_event.clone();
+        // `EventStream` reads terminal events asynchronously (crossterm does the
+        // blocking read on its own thread), so this loop never blocks a tokio
+        // worker. Ticks come from an independent timer running alongside it.
         tokio::spawn(async move {
-            let mut last_tick = Instant::now();
+            let mut reader = EventStream::new();
+            let mut ticker = interval(tick_rate);
+            // Don't fire a burst of catch-up ticks if the loop is ever delayed.
+            ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
             loop {
-                let timeout = tick_rate
-                    .checked_sub(last_tick.elapsed())
-                    .unwrap_or_else(|| Duration::from_secs(0));
-                if matches!(event::poll(timeout), Ok(true)) {
-                    if let Ok(ev) = event::read() {
-                        // A send error means the receiver is gone (the app is
-                        // exiting), so stop the loop instead of spinning forever.
-                        if tx_event_thread.send(FlowrsEvent::from(ev)).await.is_err() {
-                            break;
-                        }
-                    }
-                }
-                if last_tick.elapsed() > tick_rate {
-                    if tx_event_thread.send(FlowrsEvent::Tick).await.is_err() {
-                        break;
-                    }
-                    last_tick = Instant::now();
+                let event = tokio::select! {
+                    _ = ticker.tick() => FlowrsEvent::Tick,
+                    maybe_event = reader.next() => match maybe_event {
+                        Some(Ok(ev)) => FlowrsEvent::from(ev),
+                        // A read error (terminal unusable) or a closed source both
+                        // mean there is nothing more to read, so stop the loop
+                        // rather than spin retrying.
+                        Some(Err(_)) | None => break,
+                    },
+                };
+                // A send error means the receiver is gone (the app is exiting),
+                // so stop the loop instead of spinning forever.
+                if tx_event_thread.send(event).await.is_err() {
+                    break;
                 }
             }
         });


### PR DESCRIPTION
## Summary

The terminal event loop ran a synchronous, blocking `crossterm::event::poll`/`read` loop. Even wrapped in `tokio::spawn`, that blocks a tokio **worker thread** for up to `tick_rate` (~200ms) on every iteration, forever — starving the async worker pool that the dispatcher and other tasks share (M-YIELD-POINTS / M-THROUGHPUT).

## Change
Rewritten to be fully async using `crossterm::event::EventStream`, which reads terminal events asynchronously (crossterm does the blocking read on its own internal thread). The task now just `.await`s and never blocks a worker:

- A `tokio::select!` picks between the next terminal event (`EventStream::next()`) and a `tokio::time::interval` tick.
- The tick interval uses `MissedTickBehavior::Skip` so a brief delay can't produce a burst of catch-up ticks.
- The receiver-gone break behaviour from #681 is preserved (stop on send error / stream close).

## Dependency changes
- `crossterm`: enable the `event-stream` feature.
- `tokio`: add the `time` feature (for `interval`). `futures` (already a dep) provides `StreamExt`.

No test: this is a spawned loop over real terminal I/O, not unit-testable without a heavy seam. `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, and the unit suite are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal keyboard/input responsiveness by handling terminal events asynchronously alongside periodic updates.
  * Prevented missed or duplicated timer ticks during busy periods by using async interval scheduling.
  * Improved graceful shutdown behavior when the terminal event stream closes or when internal event delivery is no longer possible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->