### PR TITLE
perf(logs): cache syntect syntax/theme sets across DAG-code opens

### DIFF
--- a/src/app/model/dagruns/dag_code_view/mod.rs
+++ b/src/app/model/dagruns/dag_code_view/mod.rs
@@ -1,5 +1,7 @@
 mod render;
 
+use std::sync::LazyLock;
+
 use crossterm::event::KeyCode;
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
@@ -61,17 +63,21 @@ impl DagCodeView {
     }
 }
 
+// Loading the syntect defaults deserializes a few megabytes of bundled syntax
+// and theme data, so do it once instead of on every DAG-code view open.
+static SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(SyntaxSet::load_defaults_newlines);
+static THEME_SET: LazyLock<ThemeSet> = LazyLock::new(ThemeSet::load_defaults);
+
 fn code_to_lines(dag_code: &str) -> Vec<Line<'static>> {
-    let ps = SyntaxSet::load_defaults_newlines();
-    let ts = ThemeSet::load_defaults();
+    let ps = &*SYNTAX_SET;
     let syntax = ps
         .find_syntax_by_extension("py")
         .expect("Python syntax definition should be available in default syntax set");
-    let mut h = HighlightLines::new(syntax, &ts.themes["base16-ocean.dark"]);
+    let mut h = HighlightLines::new(syntax, &THEME_SET.themes["base16-ocean.dark"]);
     let mut lines: Vec<Line<'static>> = vec![];
     for line in LinesWithEndings::from(dag_code) {
         let line_spans: Vec<Span<'static>> = h
-            .highlight_line(line, &ps)
+            .highlight_line(line, ps)
             .expect("Syntax highlighting should succeed for valid Python code")
             .into_iter()
             .map(|(style, text)| {


### PR DESCRIPTION
## Summary

`code_to_lines` (called from `DagCodeView::new`, i.e. every time the user opens the DAG code view with `v`) called `SyntaxSet::load_defaults_newlines()` and `ThemeSet::load_defaults()` each time. Those deserialize a few megabytes of bundled syntax/theme data from a binary blob — wasteful to redo on every open.

## Change
Moved both into `LazyLock` statics, so the defaults are loaded once for the process lifetime.

## Not done here
`dag_code_view/render.rs` still does `self.lines.clone()` per frame. Avoiding that is awkward with ratatui's owned-`Text` model (`Paragraph` consumes a `Text`, so rendering by borrow isn't available without a larger rewrite) and the gain is far smaller than the syntect reload, so I left it. Happy to revisit if you want it.

`cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, and the unit suite are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)