### PR TITLE
perf(dagruns): parse the row time format once, not per row per frame

### DIFF
--- a/src/app/model/dagruns/render.rs
+++ b/src/app/model/dagruns/render.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use ratatui::layout::{Constraint, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -12,6 +14,12 @@ use crate::ui::TIME_FORMAT;
 
 use super::popup::DagRunPopUp;
 use super::DagRunModel;
+
+// Parse the row time format once rather than on every row of every frame.
+static ROW_TIME_FORMAT: LazyLock<format_description::OwnedFormatItem> = LazyLock::new(|| {
+    format_description::parse_owned::<2>(TIME_FORMAT)
+        .expect("TIME_FORMAT constant should be a valid time format")
+});
 
 impl Widget for &mut DagRunModel {
     fn render(self, area: Rect, buf: &mut ratatui::prelude::Buffer) {
@@ -78,11 +86,8 @@ impl Widget for &mut DagRunModel {
                         Style::default().add_modifier(Modifier::BOLD),
                     )),
                     Line::from(if let Some(date) = item.logical_date {
-                        date.format(
-                            &format_description::parse_borrowed::<2>(TIME_FORMAT)
-                                .expect("TIME_FORMAT constant should be a valid time format"),
-                        )
-                        .expect("Date formatting with TIME_FORMAT should succeed")
+                        date.format(&ROW_TIME_FORMAT)
+                            .expect("Date formatting with TIME_FORMAT should succeed")
                     } else {
                         "None".to_string()
                     }),


### PR DESCRIPTION
## Summary

In the DAG-runs table render, each row's logical-date cell parsed the `TIME_FORMAT` string via `format_description::parse_borrowed::<2>(TIME_FORMAT)` **inside** the per-row `.map()` closure — so the format was re-parsed once per DAG run, on every frame.

## Change
Parse it once into a `LazyLock<OwnedFormatItem>` at module level and reference that in the closure. Same output; the parse (and its `expect`) now happen once for the process lifetime instead of on every rendered row.

`cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, and the unit suite are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)