### PR TITLE
perf(app): dispatch panel updates via an App method, borrowing the nav context

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4,9 +4,8 @@ use anyhow::Result;
 use crossterm::event::{KeyCode, KeyModifiers};
 use events::{custom::FlowrsEvent, generator::EventGenerator};
 use log::debug;
-use model::Model;
 use ratatui::{prelude::Backend, Terminal};
-use state::{App, Panel};
+use state::App;
 use worker::{Dispatcher, WorkerMessage};
 
 use crate::airflow::client::FlowrsClient;
@@ -103,17 +102,7 @@ where
             }
 
             // Then handle panel specific events, and send messages to the event channel
-            let (fall_through_event, messages) = {
-                let mut app = app.lock().unwrap();
-                let ctx = app.nav_context.clone();
-                match app.active_panel {
-                    Panel::Config => app.configs.update(&event, &ctx),
-                    Panel::Dag => app.dags.update(&event, &ctx),
-                    Panel::DAGRun => app.dagruns.update(&event, &ctx),
-                    Panel::TaskInstance => app.task_instances.update(&event, &ctx),
-                    Panel::Logs => app.logs.update(&event, &ctx),
-                }
-            };
+            let (fall_through_event, messages) = app.lock().unwrap().update_active_panel(&event);
 
             // Set context IDs on target panels before sending messages to the worker.
             // Data sync from environment_state happens via sync_panel_data() on

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -7,10 +7,13 @@ pub mod environment_state;
 
 pub use navigation::NavigationContext;
 
+use crate::app::events::custom::FlowrsEvent;
 use crate::app::model::dagruns::DagRunModel;
 use crate::app::model::dags::DagModel;
 use crate::app::model::popup::error::ErrorPopup;
 use crate::app::model::popup::warning::WarningPopup;
+use crate::app::model::Model;
+use crate::app::worker::WorkerMessage;
 use environment_state::EnvironmentStateContainer;
 use flowrs_config::FlowrsConfig;
 use throbber_widgets_tui::ThrobberState;
@@ -115,6 +118,23 @@ impl App {
             Panel::DAGRun => self.active_panel = Panel::Dag,
             Panel::TaskInstance => self.active_panel = Panel::DAGRun,
             Panel::Logs => self.active_panel = Panel::TaskInstance,
+        }
+    }
+
+    /// Route an event to the currently active panel's `update`.
+    ///
+    /// Taking `&mut self` lets the panel field and `nav_context` be borrowed as
+    /// disjoint fields, so the context does not need to be cloned per event.
+    pub fn update_active_panel(
+        &mut self,
+        event: &FlowrsEvent,
+    ) -> (Option<FlowrsEvent>, Vec<WorkerMessage>) {
+        match self.active_panel {
+            Panel::Config => self.configs.update(event, &self.nav_context),
+            Panel::Dag => self.dags.update(event, &self.nav_context),
+            Panel::DAGRun => self.dagruns.update(event, &self.nav_context),
+            Panel::TaskInstance => self.task_instances.update(event, &self.nav_context),
+            Panel::Logs => self.logs.update(event, &self.nav_context),
         }
     }
 


### PR DESCRIPTION
## Summary

The main event loop cloned `app.nav_context` on **every** event (every keypress and every tick) just to pass it to the active panel's `update()`:

```rust
let ctx = app.nav_context.clone();
match app.active_panel { Panel::Dag => app.dags.update(&event, &ctx), ... }
```

The clone was there to dodge the borrow checker — `update()` needs `&mut app.<panel>` and `&app.nav_context` at once.

## Change
Moved the panel dispatch into a new `App::update_active_panel(&mut self, event)` method. Inside a `&mut self` method the panel field and `nav_context` are naturally borrowable as **disjoint fields**, so no clone (and no `&mut *guard` reborrow trick at the call site) is needed. The event-loop call site becomes a plain:

```rust
let (fall_through_event, messages) = app.lock().unwrap().update_active_panel(&event);
```

`NavigationContext` holds `String`/`DagId`/`DagRunId`, so this drops a few allocations on every event, and the routing logic now lives with the other `App` panel methods (`next_panel`, `sync_panel`, …).

`cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, and the unit suite are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)