### PR TITLE
perf(auth): cache command-token auth instead of running the helper on every request

### DIFF
--- a/crates/flowrs-airflow/src/client/auth/command.rs
+++ b/crates/flowrs-airflow/src/client/auth/command.rs
@@ -1,3 +1,6 @@
+use std::fmt;
+use std::time::{Duration, Instant};
+
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use log::info;
@@ -5,15 +8,31 @@ use reqwest::RequestBuilder;
 
 use super::AuthProvider;
 
-#[derive(Debug)]
+/// How long a fetched token is reused before the helper command is run again.
+///
+/// The command's token lifetime is unknown (it is user-defined), so this uses a
+/// short, conservative window: long enough to eliminate the per-request process
+/// spawn, short enough to stay safe for typical (minutes-to-hours) token
+/// lifetimes.
+const TOKEN_TTL: Duration = Duration::from_secs(60);
+
 pub struct CommandTokenProvider {
-    pub(super) cmd: String,
+    cmd: String,
+    /// Cached `(token, fetched_at)`, refreshed once `TOKEN_TTL` elapses. The
+    /// async mutex also single-flights concurrent refreshes.
+    cached: tokio::sync::Mutex<Option<(String, Instant)>>,
 }
 
-#[async_trait]
-impl AuthProvider for CommandTokenProvider {
-    async fn authenticate(&self, request: RequestBuilder) -> Result<RequestBuilder> {
-        info!("🔑 Token Auth (command): {}", self.cmd);
+impl CommandTokenProvider {
+    pub fn new(cmd: String) -> Self {
+        Self {
+            cmd,
+            cached: tokio::sync::Mutex::new(None),
+        }
+    }
+
+    /// Run the helper command and return its trimmed token output.
+    async fn fetch_token(&self) -> Result<String> {
         let cmd = self.cmd.clone();
         let output = tokio::task::spawn_blocking(move || {
             std::process::Command::new("sh")
@@ -38,7 +57,35 @@ impl AuthProvider for CommandTokenProvider {
 
         let token =
             String::from_utf8(output.stdout).context("Token helper returned invalid UTF-8")?;
-        let token = token.trim().trim_matches('"');
+        Ok(token.trim().trim_matches('"').to_string())
+    }
+}
+
+impl fmt::Debug for CommandTokenProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Show the configured command, never the cached token.
+        f.debug_struct("CommandTokenProvider")
+            .field("cmd", &self.cmd)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl AuthProvider for CommandTokenProvider {
+    async fn authenticate(&self, request: RequestBuilder) -> Result<RequestBuilder> {
+        let mut cached = self.cached.lock().await;
+
+        let fresh = cached
+            .as_ref()
+            .is_some_and(|(_, fetched)| fetched.elapsed() < TOKEN_TTL);
+
+        if !fresh {
+            info!("🔑 Token Auth (command): refreshing via {}", self.cmd);
+            let token = self.fetch_token().await?;
+            *cached = Some((token, Instant::now()));
+        }
+
+        let (token, _) = cached.as_ref().expect("token cached above");
         Ok(request.bearer_auth(token))
     }
 }
@@ -47,37 +94,64 @@ impl AuthProvider for CommandTokenProvider {
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    async fn test_command_token_provider() {
-        let provider = CommandTokenProvider {
-            cmd: "echo test-token".to_string(),
-        };
-        let request = provider
-            .authenticate(reqwest::Client::new().get("http://localhost:8080/api/v1/dags"))
-            .await
-            .unwrap();
-        let built = request.build().unwrap();
-        let auth_header = built
+    fn bearer(request: reqwest::RequestBuilder) -> String {
+        request
+            .build()
+            .unwrap()
             .headers()
             .get("authorization")
             .unwrap()
             .to_str()
-            .unwrap();
-        assert_eq!(auth_header, "Bearer test-token");
+            .unwrap()
+            .to_string()
+    }
+
+    fn get() -> reqwest::RequestBuilder {
+        reqwest::Client::new().get("http://localhost:8080/api/v1/dags")
+    }
+
+    #[tokio::test]
+    async fn test_command_token_provider() {
+        let provider = CommandTokenProvider::new("echo test-token".to_string());
+        let request = provider.authenticate(get()).await.unwrap();
+        assert_eq!(bearer(request), "Bearer test-token");
     }
 
     #[tokio::test]
     async fn test_command_token_provider_failure() {
-        let provider = CommandTokenProvider {
-            cmd: "false".to_string(),
-        };
-        let result = provider
-            .authenticate(reqwest::Client::new().get("http://localhost:8080/api/v1/dags"))
-            .await;
+        let provider = CommandTokenProvider::new("false".to_string());
+        let result = provider.authenticate(get()).await;
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
             .to_string()
             .contains("Token helper command failed"));
+    }
+
+    #[tokio::test]
+    async fn caches_token_and_runs_command_only_once() {
+        // The command appends a line each time it runs, so we can count runs.
+        let marker = std::env::temp_dir().join(format!(
+            "flowrs-cmd-cache-{}-{}",
+            std::process::id(),
+            "once"
+        ));
+        let _ = std::fs::remove_file(&marker);
+        let cmd = format!("echo run >> {}; echo tok", marker.display());
+        let provider = CommandTokenProvider::new(cmd);
+
+        // Two authentications within the TTL should reuse the first token.
+        assert_eq!(
+            bearer(provider.authenticate(get()).await.unwrap()),
+            "Bearer tok"
+        );
+        assert_eq!(
+            bearer(provider.authenticate(get()).await.unwrap()),
+            "Bearer tok"
+        );
+
+        let runs = std::fs::read_to_string(&marker).unwrap().lines().count();
+        let _ = std::fs::remove_file(&marker);
+        assert_eq!(runs, 1, "helper command should run once, not per request");
     }
 }

--- a/crates/flowrs-airflow/src/client/auth/mod.rs
+++ b/crates/flowrs-airflow/src/client/auth/mod.rs
@@ -41,7 +41,7 @@ pub fn create_auth_provider(auth: &AirflowAuth) -> Result<Box<dyn AuthProvider>>
             token: token.clone(),
         })),
         AirflowAuth::Token(TokenSource::Command { cmd }) => {
-            Ok(Box::new(CommandTokenProvider { cmd: cmd.clone() }))
+            Ok(Box::new(CommandTokenProvider::new(cmd.clone())))
         }
         #[cfg(feature = "conveyor")]
         AirflowAuth::Conveyor => Ok(Box::new(ConveyorAuthProvider)),


### PR DESCRIPTION
## Summary

Same fix as the Conveyor token cache (#688), for `Token`-command auth. `CommandTokenProvider::authenticate` ran the configured `sh -c <cmd>` helper on **every** API request (via `spawn_blocking`), so — like Conveyor — every DAG list / stats / runs / logs request paid a process spawn.

## Change
- Cache `(token, fetched_at)` behind a `tokio::sync::Mutex`, reusing it within a TTL and single-flighting concurrent refreshes (only one helper run per burst).
- Extracted the command-run into `fetch_token()`; `authenticate` now only runs it on a cache miss.
- Manual `Debug` that shows the configured `cmd` but **never** the cached token.

## TTL choice
Unlike Conveyor (≥1h validity), a command helper's token lifetime is user-defined and unknown, so this uses a conservative **60s** window — still eliminates ~99% of the per-request spawns while staying safe for typical (minutes-to-hours) token lifetimes.

## Test
`caches_token_and_runs_command_only_once` — the helper appends a line per run to a temp file; after two `authenticate` calls it asserts the command ran **once** (and both requests carry the same bearer token). Existing success/failure tests retained.

`cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, and the unit suite are clean.

> Note: touches the same `auth/mod.rs` provider-construction block as #688 (different line), so a trivial conflict is possible if both merge; resolves cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command-based authentication now reuses tokens during a short validity period, reducing repeated command executions.
  * Retrieved tokens are cleaned and validated before use.

* **Security**
  * Debug output no longer exposes cached authentication tokens.

* **Bug Fixes**
  * Improved handling of command failures, invalid output, and authentication requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->