### PR TITLE
perf(conveyor): cache the auth token instead of running the CLI on every request

### DIFF
--- a/crates/flowrs-airflow/src/client/auth/mod.rs
+++ b/crates/flowrs-airflow/src/client/auth/mod.rs
@@ -44,7 +44,7 @@ pub fn create_auth_provider(auth: &AirflowAuth) -> Result<Box<dyn AuthProvider>>
             Ok(Box::new(CommandTokenProvider { cmd: cmd.clone() }))
         }
         #[cfg(feature = "conveyor")]
-        AirflowAuth::Conveyor => Ok(Box::new(ConveyorAuthProvider)),
+        AirflowAuth::Conveyor => Ok(Box::new(ConveyorAuthProvider::new())),
         #[cfg(not(feature = "conveyor"))]
         AirflowAuth::Conveyor => {
             anyhow::bail!("Conveyor support not compiled. Enable the 'conveyor' feature.")

--- a/crates/flowrs-airflow/src/managed_services/conveyor.rs
+++ b/crates/flowrs-airflow/src/managed_services/conveyor.rs
@@ -7,11 +7,12 @@ use dirs::home_dir;
 use log::info;
 use reqwest::RequestBuilder;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::io::Read;
 use std::process::{Child, Command, Stdio};
 use std::sync::mpsc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// Timeout in seconds for conveyor CLI commands.
 /// If the CLI hangs (e.g., waiting for input), the operation will fail after this duration.
@@ -90,14 +91,62 @@ impl ConveyorClient {
     }
 }
 
-#[derive(Debug)]
-pub struct ConveyorAuthProvider;
+/// How long a fetched Conveyor token is reused before the CLI is run again.
+///
+/// `conveyor auth get` spawns a process (and refreshes the token underneath),
+/// which previously happened on *every* API request. Conveyor tokens are valid
+/// for at least an hour, so a 5-minute window keeps a comfortable safety margin
+/// while eliminating the per-request process spawn.
+const TOKEN_TTL: Duration = Duration::from_secs(5 * 60);
+
+pub struct ConveyorAuthProvider {
+    /// Cached `(token, fetched_at)`, refreshed once `TOKEN_TTL` elapses. The
+    /// async mutex also single-flights concurrent refreshes, so a burst of
+    /// parallel requests triggers at most one `conveyor auth get`.
+    cached: tokio::sync::Mutex<Option<(String, Instant)>>,
+}
+
+impl ConveyorAuthProvider {
+    pub fn new() -> Self {
+        Self {
+            cached: tokio::sync::Mutex::new(None),
+        }
+    }
+}
+
+impl Default for ConveyorAuthProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for ConveyorAuthProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Never render the cached token.
+        f.debug_struct("ConveyorAuthProvider")
+            .finish_non_exhaustive()
+    }
+}
 
 #[async_trait]
 impl AuthProvider for ConveyorAuthProvider {
     async fn authenticate(&self, request: RequestBuilder) -> Result<RequestBuilder> {
-        info!("🔑 Conveyor Auth");
-        let token = ConveyorClient::get_token()?;
+        let mut cached = self.cached.lock().await;
+
+        let fresh = cached
+            .as_ref()
+            .is_some_and(|(_, fetched)| fetched.elapsed() < TOKEN_TTL);
+
+        if !fresh {
+            info!("🔑 Conveyor Auth: refreshing token");
+            // Run the blocking CLI off the async runtime.
+            let token = tokio::task::spawn_blocking(ConveyorClient::get_token)
+                .await
+                .context("Conveyor token task panicked")??;
+            *cached = Some((token, Instant::now()));
+        }
+
+        let (token, _) = cached.as_ref().expect("token cached above");
         Ok(request.bearer_auth(token))
     }
 }


### PR DESCRIPTION
## Summary

For Conveyor auth, `ConveyorAuthProvider::authenticate` ran `conveyor auth get` on **every** API request — and did so *synchronously inside the async fn*, blocking a runtime thread each time. With a 2s refresh firing DAG list + stats + runs + logs concurrently, that's several CLI spawns per poll; it's the dominant per-request cost for Conveyor users.

## Change
- Cache `(token, fetched_at)` behind a `tokio::sync::Mutex`, reusing it within a TTL and single-flighting concurrent refreshes (a burst of parallel requests triggers at most one `conveyor auth get`).
- Run the CLI via `spawn_blocking` so it no longer blocks the async runtime.
- Manual `Debug` that never renders the cached token.

## TTL choice
Conveyor tokens are valid for at least an hour, so a **5-minute** window keeps a comfortable (~12×) safety margin while cutting CLI spawns from ~per-request to ~1 per 5 minutes.

`cargo clippy --workspace --all-targets --all-features -- -D warnings` (incl. the `cargo-hack` feature powerset), `cargo fmt --all --check`, and the unit suite are clean.

> Note: touches the same `auth/mod.rs` provider-construction block as #688 (different line), so a trivial conflict is possible if both merge; resolves cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved Airflow authentication efficiency by reusing valid access tokens for up to five minutes.
  * Reduced unnecessary token requests while preserving automatic refresh when tokens expire.
  * Serialized token refreshes to prevent duplicate concurrent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->