### PR TITLE
fix(app): do not error-exit when the on-quit config save fails

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -140,7 +140,12 @@ where
                 // Handle other key events
                 match key.code {
                     KeyCode::Char('q') => {
-                        app.config.write_to_file(&CONFIG_PATHS)?;
+                        // Persist config (e.g. active-server selection) on exit, but
+                        // a save failure should not turn a normal quit into an error
+                        // exit.
+                        if let Err(e) = app.config.write_to_file(&CONFIG_PATHS) {
+                            log::error!("Failed to save config on exit: {e}");
+                        }
                         return Ok(());
                     }
                     KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') => {


### PR DESCRIPTION
## Summary

On `q`, the event loop saved the config (`write_to_file(&CONFIG_PATHS)?`) and propagated any error out of `run_app`, so a failed save turned a normal quit into a non-zero process exit. This was listed under Tier 3 perf, but the write only happens on quit (nothing periodic), so there's no hot-path/lock-contention angle — the only real issue is the fatal `?`.

## Change
Log the error and exit cleanly instead of propagating it. The config save on quit persists things like the active-server selection; if it fails, that's worth a log line, not an error exit.

`cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, and the unit suite are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)