### PR TITLE
perf: use mimalloc as the global allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,7 @@ dependencies = [
  "futures",
  "inquire",
  "log",
+ "mimalloc",
  "ratatui",
  "reqwest 0.12.28",
  "serde",
@@ -2181,6 +2182,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2281,6 +2291,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ dirs = { workspace = true }
 futures = "0.3.32"
 inquire = "0.9.3"
 log = { workspace = true }
+mimalloc = "0.1"
 ratatui = { version = "0.30.0", features = [
     "unstable-widget-ref",
     "unstable-rendered-line-info",

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,12 @@ use std::sync::LazyLock;
 use clap::Parser;
 use ui::constants::ASCII_LOGO;
 
+// mimalloc handles this application's many short-lived allocations (per-poll
+// clones, log/format strings, render buffers) more efficiently than the system
+// allocator (M-MIMALLOC-APPS).
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 mod airflow;
 mod app;
 mod commands;


### PR DESCRIPTION
## Summary

Sets `mimalloc` as the global allocator (M-MIMALLOC-APPS). The app does a lot of short-lived allocation — per-poll collection clones, `format!`/log strings, ratatui render buffers rebuilt every frame — which mimalloc handles more efficiently than the system allocator.

## Change
- Add the `mimalloc` dependency.
- `#[global_allocator] static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;` in `main.rs`.

## Tradeoff
mimalloc vendors and compiles a small C library, so it adds a C toolchain requirement and a bit of build time. It's widely used, low-risk, and trivially reversible (delete the two additions). Flagged here so it's a conscious choice.

`cargo build`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, and the unit suite are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)