### PR TITLE
Fix DAG list cursor carrying over between environments

### DIFF
--- a/src/app/model/filterable_table/mod.rs
+++ b/src/app/model/filterable_table/mod.rs
@@ -55,12 +55,6 @@ impl<T: Filterable + Clone> FilterableTable<T> {
         self.filtered.items = filtered;
     }
 
-    /// Activates filter mode
-    pub fn activate_filter(&mut self) {
-        self.filter.activate();
-        self.apply_filter();
-    }
-
     /// Handles a key event for the filter.
     /// This handles both:
     /// - `/` key when filter is inactive (activates filter)

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -12,7 +12,7 @@ use crate::app::model::dagruns::DagRunModel;
 use crate::app::model::dags::DagModel;
 use crate::app::model::popup::error::ErrorPopup;
 use crate::app::model::popup::warning::WarningPopup;
-use crate::app::model::Model;
+use crate::app::model::{FilterableTable, Model};
 use crate::app::worker::WorkerMessage;
 use environment_state::EnvironmentStateContainer;
 use flowrs_config::FlowrsConfig;
@@ -152,9 +152,9 @@ impl App {
     pub fn clear_state(&mut self) {
         self.loading = true;
         self.nav_context.reset_to_environment();
-        self.dags.table.all.clear();
-        self.dagruns.table.all.clear();
-        self.task_instances.table.all.clear();
+        self.dags.table = FilterableTable::new();
+        self.dagruns.table = FilterableTable::new();
+        self.task_instances.table = FilterableTable::new();
         self.logs.all.clear();
     }
 }


### PR DESCRIPTION
## Problem

Switching Airflow environments carried the DAG list cursor over from the previous environment. Landing in an environment with fewer DAGs parked the selection on the last row instead of the top, and the list rendered scrolled to the bottom.

## Cause

`clear_state()` resets the view when switching environments, but only cleared each table's underlying data (`table.all`). The filtered view and its `TableState` — which holds the selected index and scroll offset — survived the switch.

Ratatui clamps an out-of-range selection to the last row when it renders (`table.rs:757`) and clamps the offset likewise (`:998`), so nothing rendered incorrectly. The cursor simply ended up somewhere the user never chose.

## Fix

Reset the whole `FilterableTable` instead of just its data. `FilterableTable::new()` already clears items, filtered view, selection, scroll offset, filter and visual mode — so this is an assignment rather than a new helper.

```rust
self.dags.table = FilterableTable::new();
self.dagruns.table = FilterableTable::new();
self.task_instances.table = FilterableTable::new();
```

Note this also resets the **filter** on an environment switch, which the previous code preserved. That is intentional: a `dag_id=` filter written for one environment silently hides DAGs in the next, which is the same class of invisible stale state as the bug itself.

## Also included

Removes `FilterableTable::activate_filter`, which had no callers — filter activation happens inside `FilterStateMachine::update()` when it sees `/`, reached via `handle_filter_key()`.

## Verification

`cargo test --workspace --lib --bins` (94 passing), `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo fmt --all --check` all clean.

No regression test added: the fix is now an assignment to `FilterableTable::new()`, so a unit test would be exercising the language rather than the logic. A meaningful guard would need an `App` fixture at the `clear_state` level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127jzUgqqy8JVX5RydfQxh8

---
_Generated by [Claude Code](https://claude.ai/code/session_0127jzUgqqy8JVX5RydfQxh8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clearing application state now fully resets DAG, DAG run, and task instance tables.
  * Resolved stale table filters and state after clearing data.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->