### PR TITLE
Remove re-export-only shim modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,8 +59,7 @@ Self-contained Airflow API client library. Has no dependencies on other workspac
 TUI-specific configuration management. Depends on `flowrs-airflow` for auth/server types (re-exports them).
 - `src/lib.rs`: `FlowrsConfig` struct (servers, managed_services, poll_interval, etc.), TOML parsing/writing
 - `src/paths.rs`: `ConfigPaths` for XDG-compliant config file resolution
-- `src/auth.rs`: Re-exports auth types from `flowrs-airflow`
-- `src/server.rs`: Re-exports server config types from `flowrs-airflow`
+- Auth and server config types are owned by `flowrs-airflow` and re-exported from `src/lib.rs`
 
 ### flowrs-tui (root crate, `src/`)
 The TUI binary. Depends on both `flowrs-airflow` and `flowrs-config`.

--- a/crates/flowrs-airflow/src/managed_services/composer/auth.rs
+++ b/crates/flowrs-airflow/src/managed_services/composer/auth.rs
@@ -1,1 +1,0 @@
-pub use crate::auth::ComposerAuth;

--- a/crates/flowrs-airflow/src/managed_services/composer/client.rs
+++ b/crates/flowrs-airflow/src/managed_services/composer/client.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use crate::auth::AirflowAuth;
 use crate::config::{AirflowConfig, AirflowVersion, ManagedService};
 
-use super::auth::ComposerAuth;
+use super::ComposerAuth;
 
 const RESOURCE_MANAGER_URL: &str = "https://cloudresourcemanager.googleapis.com/v1/projects";
 const COMPOSER_API_URL: &str = "https://composer.googleapis.com/v1";

--- a/crates/flowrs-airflow/src/managed_services/composer/mod.rs
+++ b/crates/flowrs-airflow/src/managed_services/composer/mod.rs
@@ -1,9 +1,8 @@
-mod auth;
 mod client;
 mod provider;
 mod regions;
 
-pub use auth::ComposerAuth;
+pub use crate::auth::ComposerAuth;
 pub use client::{get_composer_environment_servers, ComposerClient};
 pub use provider::ComposerAuthProvider;
 pub use regions::{get_gcloud_default_region, GCP_REGIONS};

--- a/crates/flowrs-config/src/auth.rs
+++ b/crates/flowrs-config/src/auth.rs
@@ -1,4 +1,0 @@
-// Auth types are owned by flowrs-airflow. Re-exported here for backward compatibility.
-pub use flowrs_airflow::{
-    AirflowAuth, AstronomerAuth, BasicAuth, ComposerAuth, MwaaAuth, MwaaTokenType, TokenSource,
-};

--- a/crates/flowrs-config/src/lib.rs
+++ b/crates/flowrs-config/src/lib.rs
@@ -1,12 +1,12 @@
-pub mod auth;
 pub mod paths;
-pub mod server;
 pub mod theme;
 
-// Re-export all public types at crate root for ergonomic imports
-pub use auth::{AirflowAuth, BasicAuth, TokenSource};
+// Auth and server config types are owned by flowrs-airflow; re-export them at
+// the crate root so callers get one ergonomic import path.
+pub use flowrs_airflow::{
+    AirflowAuth, AirflowConfig, AirflowVersion, BasicAuth, GccConfig, ManagedService, TokenSource,
+};
 pub use paths::ConfigPaths;
-pub use server::{AirflowConfig, AirflowVersion, GccConfig, ManagedService};
 pub use theme::Theme;
 
 use std::fs::OpenOptions;
@@ -223,7 +223,7 @@ password = "airflow"
 
     #[test]
     fn test_write_config_conveyor() {
-        use server::default_timeout;
+        use flowrs_airflow::config::default_timeout;
 
         let config = FlowrsConfig {
             servers: vec![AirflowConfig {
@@ -316,7 +316,7 @@ password = "airflow"
             }),
             managed,
             version: AirflowVersion::V2,
-            timeout_secs: server::default_timeout(),
+            timeout_secs: flowrs_airflow::config::default_timeout(),
             insecure: false,
         }
     }

--- a/crates/flowrs-config/src/server.rs
+++ b/crates/flowrs-config/src/server.rs
@@ -1,4 +1,0 @@
-// Server config types are owned by flowrs-airflow. Re-exported here for backward compatibility.
-pub use flowrs_airflow::{AirflowConfig, AirflowVersion, GccConfig, ManagedService};
-
-pub use flowrs_airflow::config::default_timeout;


### PR DESCRIPTION
## What

Three modules whose entire body was `pub use`.

## `flowrs-config`: `auth.rs` and `server.rs`

Both re-exported types from `flowrs-airflow`, and `lib.rs` then re-exported them again:

```
flowrs_airflow::AirflowAuth → flowrs_config::auth::AirflowAuth → flowrs_config::AirflowAuth
```

Nothing in the workspace imports through `flowrs_config::auth::` or `flowrs_config::server::` — every caller uses the crate-root path. The middle hop was invisible to consumers, so `lib.rs` now re-exports from `flowrs_airflow` directly and both files are gone.

`auth.rs` also exported four types (`AstronomerAuth`, `ComposerAuth`, `MwaaAuth`, `MwaaTokenType`) that `lib.rs` never forwarded and nothing imported — reachable only via a path no one used.

The header comment called this "backward compatibility", but these are workspace-internal crates with no external consumers.

## `flowrs-airflow`: `managed_services/composer/auth.rs`

A one-line **private** module:

```rust
pub use crate::auth::ComposerAuth;
```

`composer/mod.rs` now re-exports `crate::auth::ComposerAuth` directly.

## Kept

`server.rs` also re-exported `default_timeout`, which `lib.rs` genuinely uses in three places. Those now import `flowrs_airflow::config::default_timeout` directly rather than losing the function.

## Also

Updates `CLAUDE.md`, which documented the two deleted `flowrs-config` files.

## Verification

`cargo test --workspace --lib --bins` (94 passing), `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo fmt --all --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127jzUgqqy8JVX5RydfQxh8

---
_Generated by [Claude Code](https://claude.ai/code/session_0127jzUgqqy8JVX5RydfQxh8)_