### PR TITLE
Reset log selection at context boundaries instead of clamping on read

### DIFF
--- a/src/app/model/logs/mod.rs
+++ b/src/app/model/logs/mod.rs
@@ -78,26 +78,20 @@ impl LogModel {
         self.scroll_mode = ScrollMode::Following;
     }
 
-    /// Update the logs content. When in follow mode, the scroll position
-    /// will automatically track the bottom at render time.
+    /// Update the logs content, keeping the selected try in range.
+    ///
+    /// Clamping here rather than on every read means `current` is always a
+    /// valid index, so readers can use it directly. When in follow mode, the
+    /// scroll position tracks the bottom at render time.
     pub fn update_logs(&mut self, logs: Vec<Log>) {
         self.all = logs;
-    }
-
-    /// Index of the currently selected log (task try), wrapped into range.
-    ///
-    /// `current` can exceed `all.len()` after `update_logs` replaces the list
-    /// with fewer tries, so the selection is wrapped rather than assumed valid.
-    /// Returns 0 for an empty list; pair with [`current_log`](Self::current_log)
-    /// to distinguish "empty" from "first entry".
-    fn current_index(&self) -> usize {
-        self.current % self.all.len().max(1)
+        self.current = self.current.min(self.all.len().saturating_sub(1));
     }
 
     /// Returns the currently selected log (the task try being viewed), if any.
     /// `None` when no logs are loaded.
     fn current_log(&self) -> Option<&Log> {
-        self.all.get(self.current_index())
+        self.all.get(self.current)
     }
 
     /// Returns the total number of lines in the current log content
@@ -197,7 +191,7 @@ impl Model for LogModel {
                                             clippy::cast_possible_truncation,
                                             reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
                                         )]
-                                        task_try: (self.current_index() + 1) as u32,
+                                        task_try: (self.current + 1) as u32,
                                     })],
                                 );
                             }
@@ -275,16 +269,29 @@ mod tests {
     }
 
     #[test]
-    fn current_index_wraps_when_selection_exceeds_len() {
-        // After `update_logs` shrinks the list, a stale `current` must wrap into
-        // range rather than point past the end (or panic).
+    fn update_logs_clamps_selection_to_the_last_try() {
+        // A stale `current` is pulled back to the last try, not wrapped: after a
+        // shrink you want the newest try, not an arbitrary one modular arithmetic
+        // happens to land on.
+        let mut model = LogModel {
+            current: 4,
+            ..Default::default()
+        };
+        model.update_logs(vec![log("a"), log("b"), log("c")]);
+
+        assert_eq!(model.current, 2); // clamped to last; wrapping would give 1
+        assert!(model.current_log().is_some());
+    }
+
+    #[test]
+    fn update_logs_with_empty_list_resets_selection() {
         let mut model = LogModel {
             current: 3,
             ..Default::default()
         };
-        model.update_logs(vec![log("a"), log("b")]);
+        model.update_logs(vec![]);
 
-        assert_eq!(model.current_index(), 1); // 3 % 2
-        assert!(model.current_log().is_some());
+        assert_eq!(model.current, 0);
+        assert!(model.current_log().is_none());
     }
 }

--- a/src/app/model/logs/render.rs
+++ b/src/app/model/logs/render.rs
@@ -41,7 +41,7 @@ impl Widget for &mut LogModel {
                     .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
                     .border_style(t.border_style),
             )
-            .select(self.current_index())
+            .select(Some(self.current))
             .highlight_style(Style::default().fg(t.accent).add_modifier(Modifier::BOLD))
             .style(t.default_style);
 

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -156,5 +156,7 @@ impl App {
         self.dagruns.table = FilterableTable::new();
         self.task_instances.table = FilterableTable::new();
         self.logs.all.clear();
+        self.logs.current = 0;
+        self.logs.reset_scroll();
     }
 }


### PR DESCRIPTION
> **Stacked on #695.** Both touch `clear_state()`, so this targets that branch rather than `main`. GitHub will retarget it to `main` automatically once #695 merges. Review #695 first.

Two halves of the same problem: log view state outliving the context it belonged to.

## 1. `clear_state()` left log state behind

Switching environments cleared `logs.all` but left `logs.current` (which try is selected) and `logs.scroll_mode` pointing into the *previous* environment's tries. Land on a task with two tries carrying `current = 3` from before, and you open on try 2 instead of try 1; a deep `Manual { position }` scroll leaks into the next log you view.

The codebase already knew how to do this — `state/context.rs` does exactly the right thing when the task context changes:

```rust
if is_new_context {
    self.logs.current = 0;
    self.logs.reset_scroll();
}
```

`clear_state()` now uses the same two lines. `LogModel::reset_scroll()` is documented "used when navigating to a new context" and simply wasn't being called on the environment-switch path.

## 2. `current_index()` clamped on read instead of fixing the write

```rust
fn current_index(&self) -> usize {
    self.current % self.all.len().max(1)
}
```

This re-derived a valid index on every single read, papering over a stale `current` rather than correcting it. `update_logs` now clamps when it writes the list, so `current` is always valid and the three readers use it directly. `current_index()` is gone.

Clamping also beats wrapping on the merits: after the try list shrinks you want the **newest** try, not whichever one modular arithmetic happens to land on. With `current = 4` and three tries, wrapping gives try 2; clamping gives try 3.

## Test changes

`current_index_wraps_when_selection_exceeds_len` encoded the workaround as intended behavior, so it's replaced by two tests on the new contract — one for the clamp, one for the empty list. The existing `open_ui_with_empty_logs_does_not_panic` regression test still passes; with the modulo gone there is no division left to panic on.

## Verification

`cargo test --workspace --lib --bins` (95 passing), `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo fmt --all --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127jzUgqqy8JVX5RydfQxh8

---
_Generated by [Claude Code](https://claude.ai/code/session_0127jzUgqqy8JVX5RydfQxh8)_