### PR TITLE
Wire up autocomplete for free-text filter fields

### DIFF
--- a/src/app/state/sync.rs
+++ b/src/app/state/sync.rs
@@ -1,5 +1,13 @@
 use super::{App, Panel};
 
+/// Collect autocomplete candidates: sorted, de-duplicated, blanks dropped.
+fn distinct(values: impl Iterator<Item = String>) -> Vec<String> {
+    let mut values: Vec<String> = values.filter(|v| !v.is_empty()).collect();
+    values.sort_unstable();
+    values.dedup();
+    values
+}
+
 impl App {
     /// Sync a specific panel's data from `environment_state`.
     pub fn sync_panel(&mut self, panel: &Panel) {
@@ -15,6 +23,23 @@ impl App {
                     .map(|d| d.dag_id.to_string())
                     .collect();
                 self.dags.table.filter.set_primary_values("dag_id", dag_ids);
+                // Free-text fields autocomplete from the values actually present.
+                let owners = distinct(
+                    self.dags
+                        .table
+                        .all
+                        .iter()
+                        .flat_map(|d| d.owners.iter().cloned()),
+                );
+                self.dags.table.filter.set_field_values("owners", owners);
+                let tags = distinct(
+                    self.dags
+                        .table
+                        .all
+                        .iter()
+                        .flat_map(|d| d.tags.iter().map(|t| t.name.clone())),
+                );
+                self.dags.table.filter.set_field_values("tags", tags);
                 self.dags.table.apply_filter();
             }
             Panel::DAGRun => {
@@ -57,6 +82,17 @@ impl App {
                         .table
                         .filter
                         .set_primary_values("task_id", task_ids);
+                    let operators = distinct(
+                        self.task_instances
+                            .table
+                            .all
+                            .iter()
+                            .filter_map(|ti| ti.operator.clone()),
+                    );
+                    self.task_instances
+                        .table
+                        .filter
+                        .set_field_values("operator", operators);
                     self.task_instances.table.apply_filter();
                 } else {
                     self.task_instances.table.all.clear();
@@ -88,7 +124,27 @@ impl App {
                     .table
                     .filter
                     .set_primary_values("name", config_names);
+                let endpoints = distinct(self.configs.table.all.iter().map(|c| c.endpoint.clone()));
+                self.configs
+                    .table
+                    .filter
+                    .set_field_values("endpoint", endpoints);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::distinct;
+
+    #[test]
+    fn distinct_sorts_dedups_and_drops_blanks() {
+        let got = distinct(
+            ["bob", "alice", "bob", "", "alice"]
+                .into_iter()
+                .map(str::to_string),
+        );
+        assert_eq!(got, vec!["alice", "bob"]);
     }
 }


### PR DESCRIPTION
## What

`FilterStateMachine` has carried the machinery for autocompleting non-primary free-text fields all along:

- a `field_values: HashMap<String, Vec<String>>` member
- a `set_field_values(field, values)` setter
- threading through `value_candidates_for_field` and `edit_condition_state` at six call sites

Nothing ever called the setter. The map was permanently empty, so `value_candidates_for_field`'s `FreeText` arm always returned `vec[]` and those fields silently offered no suggestions.

## Affected filters

Four real fields, all declared via `impl_filterable!` and all free-text:

| Type | Field |
|---|---|
| `Dag` | `owners`, `tags` |
| `TaskInstance` | `operator` |
| `AirflowConfig` | `endpoint` |

The primary fields (`dag_id`, `dag_run_id`, `task_id`, `name`) were never affected — they autocomplete from `primary_values`, which `sync_panel` has always populated.

## Change

Populate `field_values` in `sync_panel` right beside the existing `set_primary_values` calls, so candidates reflect the data currently loaded.

Candidates are the **individual** values rather than the joined display string, because that is what a user actually types: `owners` renders as `"alice, bob"` but you filter with `owners:alice`, and matching is substring-based.

A small `distinct()` helper (sort, dedup, drop blanks) is shared by all four sites.

## Alternative considered

The other way to resolve this was deleting the machinery (~25 lines). Wiring it up costs less code and turns four filters that quietly under-serve into working ones, so I went this way — but the delete is a clean revert of this PR plus removal of the plumbing if you'd rather not carry the feature.

## Verification

`cargo test --workspace --lib --bins` (95 passing, including a test for `distinct`), `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo fmt --all --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127jzUgqqy8JVX5RydfQxh8

---
_Generated by [Claude Code](https://claude.ai/code/session_0127jzUgqqy8JVX5RydfQxh8)_