### PR TITLE
feat: publish flowrs to PyPI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -16,9 +16,9 @@ name: PyPI
 # version tag ever uploads.
 #
 # The wheel matrix mirrors the platforms cargo-dist already releases binaries
-# for (see dist-workspace.toml). Windows, musl and linux aarch64 are left out:
-# flowrs ships no binaries for them today, and reqwest's default-tls pulls in
-# OpenSSL, which has no headers to link against in the manylinux cross images.
+# for (see dist-workspace.toml). Windows, musl and linux aarch64 are left out
+# because flowrs ships no binaries for them today; nothing in the build blocks
+# them, so they can be added here whenever those targets are supported.
 
 on:
   push:
@@ -48,10 +48,9 @@ jobs:
         with:
           target: x86_64
           args: --release --out dist
-          # manylinux_2_28 rather than the default manylinux2014: reqwest's
-          # default-tls links OpenSSL, and 2_28 carries OpenSSL 1.1 headers
-          # instead of 1.0.2. glibc 2.28 is still an older baseline than the
-          # ubuntu-22.04 the cargo-dist binaries are built on.
+          # glibc 2.28 (AlmaLinux 8) is still an older baseline than the
+          # ubuntu-22.04 the cargo-dist binaries are built on, and the build
+          # links no system libraries beyond libc, so the wheel bundles nothing.
           manylinux: '2_28'
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,160 @@
+name: PyPI
+
+# Builds platform wheels that ship the `flowrs` binary, so it can be installed
+# with `uv tool install flowrs` / `pipx install flowrs`.
+#
+# Publishes on the same `flowrs-tui-v*` tags that trigger the cargo-dist
+# release workflow, so a release-plz tag ships crates.io, GitHub Releases,
+# Homebrew and PyPI together. The wheel version is read from Cargo.toml, so
+# nothing needs bumping here. The `flowrs-airflow-*` and `flowrs-config-*`
+# library tags are deliberately not matched: only the binary crate is shipped
+# to PyPI.
+#
+# Running this workflow manually builds everything and exercises the PyPI
+# trusted-publishing OIDC exchange in --dry-run mode, without uploading. Use
+# that to validate the publisher setup before the first real release. Only a
+# version tag ever uploads.
+#
+# The wheel matrix mirrors the platforms cargo-dist already releases binaries
+# for (see dist-workspace.toml). Windows, musl and linux aarch64 are left out:
+# flowrs ships no binaries for them today, and reqwest's default-tls pulls in
+# OpenSSL, which has no headers to link against in the manylinux cross images.
+
+on:
+  push:
+    tags:
+      - 'flowrs-tui-v[0-9]+.[0-9]+.[0-9]+*'
+  # Verify the packaging still builds when it changes, without publishing.
+  pull_request:
+    paths:
+      - pyproject.toml
+      - .github/workflows/pypi.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  linux:
+    name: Wheel (manylinux x86_64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: x86_64
+          args: --release --out dist
+          # manylinux_2_28 rather than the default manylinux2014: reqwest's
+          # default-tls links OpenSSL, and 2_28 carries OpenSSL 1.1 headers
+          # instead of 1.0.2. glibc 2.28 is still an older baseline than the
+          # ubuntu-22.04 the cargo-dist binaries are built on.
+          manylinux: '2_28'
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-manylinux-x86_64
+          path: dist
+
+  macos:
+    name: Wheel (macOS ${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-latest
+            target: aarch64
+          - runner: macos-15-intel
+            target: x86_64
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-${{ matrix.target }}
+          path: dist
+
+  sdist:
+    name: Source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-sdist
+          path: dist
+
+  smoke-test:
+    name: Smoke test (${{ matrix.os }})
+    needs: [linux, macos]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    env:
+      UV_TOOL_BIN_DIR: ${{ github.workspace }}/tool-bin
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist
+      - uses: astral-sh/setup-uv@v7
+      - name: Install from the built wheel and run it
+        shell: bash
+        # --no-build asserts a matching wheel exists for this platform rather
+        # than silently falling back to compiling the sdist.
+        run: |
+          uv tool install --no-index --no-build --find-links dist flowrs
+          "${UV_TOOL_BIN_DIR}/flowrs" --version
+
+  publish:
+    name: Publish to PyPI
+    needs: [linux, macos, sdist, smoke-test]
+    # Tags upload for real; a manual run only dry-runs (see the step below).
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/flowrs
+    permissions:
+      contents: read
+      # Required for PyPI Trusted Publishing (OIDC). No API token needed.
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist
+      - uses: astral-sh/setup-uv@v7
+      - name: Publish
+        # `--trusted-publishing always` fails loudly if the OIDC exchange is
+        # not configured, rather than silently falling back to looking for a
+        # token. `--check-url` makes a re-run skip already-uploaded files.
+        #
+        # A manual run adds --dry-run, which still performs the full OIDC
+        # exchange but uploads nothing, so the publisher setup can be verified
+        # without burning a version number. Uploads are therefore reachable
+        # only from a version tag.
+        run: >-
+          uv publish
+          --trusted-publishing always
+          --check-url https://pypi.org/simple/flowrs/
+          ${{ github.event_name == 'workflow_dispatch' && '--dry-run' || '' }}
+          'dist/*'

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ flowrs-debug*
 
 .terraform
 *.tfstate
+
+# Python packaging (maturin / uv)
+dist
+.venv
+uv.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1398,21 +1398,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1886,22 +1871,6 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.11.0",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -2463,23 +2432,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2644,47 +2596,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -3283,12 +3198,10 @@ dependencies = [
  "http-body-util",
  "hyper 1.11.0",
  "hyper-rustls 0.27.9",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3300,7 +3213,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.26.4",
  "tower",
  "tower-http",
@@ -3958,19 +3870,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.3",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "termina"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4212,16 +4111,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.4",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -4467,12 +4356,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,11 @@ chrono = "0.4.43"
 clap = { version = "^4.5", features = ["derive", "env"] }
 dirs = "6.0.0"
 log = { version = "0.4.32", features = ["std"] }
-reqwest = { version = "0.12.28", features = ["json", "rustls-tls", "rustls-tls-native-roots"] }
+# `default-features = false` drops only reqwest's `default-tls`, which pulls in
+# native-tls/openssl-sys. The clients already select rustls explicitly, and
+# OpenSSL has no headers to link against in the manylinux images used to build
+# the PyPI wheels. The other three reqwest defaults are re-added by hand.
+reqwest = { version = "0.12.28", default-features = false, features = ["charset", "http2", "json", "macos-system-configuration", "rustls-tls", "rustls-tls-native-roots"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 strum = { version = "0.28.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ or with `uv` on macOS (Apple silicon and Intel) and Linux x86_64:
 uv tool install flowrs
 ```
 
-The wheel ships the same prebuilt binary as every other install method — Python is only used to deliver it, not to run it. `pipx install flowrs` works the same way. Prebuilt wheels are published for those platforms only; on any other platform, install with `cargo` instead.
-
 You can also download the binary directly from GitHub:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ You can install `flowrs` via Homebrew if you're on macOS / Linux / WSL2:
 brew install flowrs
 ```
 
-or with `uv` on macOS / Linux:
+or with `uv` on macOS (Apple silicon and Intel) and Linux x86_64:
 
 ```bash
 uv tool install flowrs
 ```
 
-The wheel ships the same prebuilt binary as every other install method — Python is only used to deliver it, not to run it. `pipx install flowrs` works the same way.
+The wheel ships the same prebuilt binary as every other install method — Python is only used to deliver it, not to run it. `pipx install flowrs` works the same way. Prebuilt wheels are published for those platforms only; on any other platform, install with `cargo` instead.
 
 You can also download the binary directly from GitHub:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![flowrs_logo](./image/README/1683789045509.png)
+![flowrs_logo](https://raw.githubusercontent.com/jvanbuel/flowrs/main/image/README/1683789045509.png)
 
 [![CI](https://github.com/jvanbuel/flowrs/actions/workflows/ci.yml/badge.svg)](https://github.com/jvanbuel/flowrs/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/flowrs-tui.svg)](https://crates.io/crates/flowrs-tui)
@@ -9,7 +9,7 @@
 
 Flowrs is a TUI application for [Apache Airflow](https://airflow.apache.org/). It allows you to monitor, inspect and manage Airflow DAGs from the comforts of your terminal. It is build with the [ratatui](https://ratatui.rs/) library.
 
-![flowrs demo](./vhs/flowrs.gif)
+![flowrs demo](https://raw.githubusercontent.com/jvanbuel/flowrs/main/vhs/flowrs.gif)
 
 ## Installation
 
@@ -19,7 +19,15 @@ You can install `flowrs` via Homebrew if you're on macOS / Linux / WSL2:
 brew install flowrs
 ```
 
-or by downloading the binary directly from GitHub:
+or with `uv` on macOS / Linux:
+
+```bash
+uv tool install flowrs
+```
+
+The wheel ships the same prebuilt binary as every other install method — Python is only used to deliver it, not to run it. `pipx install flowrs` works the same way.
+
+You can also download the binary directly from GitHub:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/jvanbuel/flowrs/releases/latest/download/flowrs-tui-installer.sh | sh
@@ -50,7 +58,7 @@ Note that for Astronomer, you need to set the `ASTRO_API_TOKEN` environment vari
 
 If you're self-hosting an Airflow instance, or your favorite managed service is not yet supported, you can register an Airflow server instance with the `flowrs config add` command:
 
-![flowrs config add demo](./vhs/add_config.gif)
+![flowrs config add demo](https://raw.githubusercontent.com/jvanbuel/flowrs/main/vhs/add_config.gif)
 
 This creates an entry in your configuration file at `$XDG_CONFIG_HOME/flowrs/config.toml` (following the XDG Base Directory Specification, which defaults to `~/.config/flowrs/config.toml`). For backwards compatibility, flowrs also reads from `~/.flowrs` if the XDG location doesn't exist. If you have multiple Airflow servers configured, you can easily switch between them in `flowrs` configuration screen.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["maturin>=1.9,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "flowrs"
+description = "A Terminal User Interface (TUI) for Apache Airflow"
+readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
+requires-python = ">=3.9"
+keywords = ["airflow", "tui", "terminal", "dag", "ratatui"]
+authors = [{ name = "Jan Vanbuel", email = "jan@lightcone.be" }]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Programming Language :: Rust",
+    "Topic :: System :: Monitoring",
+    "Topic :: Utilities",
+]
+# Read from Cargo.toml by maturin, so release-plz version bumps carry through
+# without a second bump here.
+dynamic = ["version"]
+
+[project.urls]
+Homepage = "https://github.com/jvanbuel/flowrs"
+Repository = "https://github.com/jvanbuel/flowrs"
+Changelog = "https://github.com/jvanbuel/flowrs/blob/main/CHANGELOG.md"
+Issues = "https://github.com/jvanbuel/flowrs/issues"
+
+[tool.maturin]
+# Ship the `flowrs` binary itself; there is no Python extension module here.
+bindings = "bin"
+manifest-path = "Cargo.toml"
+strip = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
-requires = ["maturin>=1.9,<2.0"]
+# >=1.9.3: 1.9.2 fixed PEP 639 `License-Expression`, 1.9.3 fixed
+# `project.license-files` being dropped from source distributions.
+requires = ["maturin>=1.9.3,<2.0"]
 build-backend = "maturin"
 
 [project]


### PR DESCRIPTION
Package the TUI as maturin `bindings = "bin"` wheels so it can be
installed with `uv tool install flowrs` or `pipx install flowrs`. The
wheel carries the same prebuilt binary as the other install paths —
Python only delivers it, it is not a runtime dependency.

- pyproject.toml: maturin backend over the workspace root package, with
  the version read dynamically from Cargo.toml so release-plz bumps
  carry through without a second bump.
- .github/workflows/pypi.yml: builds a manylinux_2_28 x86_64 wheel, both
  macOS wheels and an sdist, smoke-tests that a real wheel installs and
  runs on Linux and macOS, then publishes via PyPI Trusted Publishing on
  the same `flowrs-tui-v*` tags that drive the cargo-dist release. A
  manual run dry-runs the OIDC exchange without uploading, so the
  publisher setup can be validated before the first release.
- README: document the uv install path, and make the image links
  absolute so they render on PyPI.

The wheel matrix matches the targets dist-workspace.toml already
releases. Linux aarch64 and musl are left out because reqwest's
default-tls links OpenSSL, which does not cross-compile in the manylinux
cross images.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W8MG9ZgMAozRiixoG73oPi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for installing the project as a Python package with a bundled prebuilt binary.
  * Added `uv` installation instructions for supported macOS and Linux platforms.

* **Documentation**
  * Updated installation and download instructions.
  * Fixed README links for the logo and demonstration images.
  * Removed outdated guidance about using `cargo` on other platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->