### PR TITLE
Encapsulate FilterableTable and fix stale table and log state on environment switch

### DIFF
--- a/src/app/model/config/mod.rs
+++ b/src/app/model/config/mod.rs
@@ -31,7 +31,7 @@ impl ConfigModel {
         let mut table = FilterableTable::new();
         table.set_items(configs.to_vec());
         let config_names: Vec<String> = configs.iter().map(|c| c.name.clone()).collect();
-        table.filter.set_primary_values("name", config_names);
+        table.filter_mut().set_primary_values("name", config_names);
 
         Self {
             table,
@@ -52,12 +52,10 @@ impl ConfigModel {
     fn handle_keys(&mut self, key_event: &KeyEvent) -> KeyResult {
         match key_event.code {
             KeyCode::Char('o') => {
-                if let Some(idx) = self.table.filtered.state.selected() {
-                    if let Some(item) = self.table.filtered.items.get(idx) {
-                        return KeyResult::PassWith(vec![WorkerMessage::OpenItem(
-                            OpenItem::Config(item.endpoint.clone()),
-                        )]);
-                    }
+                if let Some(item) = self.table.current() {
+                    return KeyResult::PassWith(vec![WorkerMessage::OpenItem(OpenItem::Config(
+                        item.endpoint.clone(),
+                    ))]);
                 }
                 KeyResult::PassThrough
             }
@@ -66,8 +64,8 @@ impl ConfigModel {
                 KeyResult::Consumed
             }
             KeyCode::Enter => {
-                if let Some(idx) = self.table.filtered.state.selected() {
-                    if let Some(item) = self.table.filtered.items.get(idx) {
+                if let Some(idx) = self.table.selected_position() {
+                    if let Some(item) = self.table.item_at(idx) {
                         debug!("Selected config: {}", item.name);
                         return KeyResult::PassWith(vec![WorkerMessage::ConfigSelected(idx)]);
                     }
@@ -116,16 +114,14 @@ impl Widget for &mut ConfigModel {
         let header_row = create_headers(headers);
         let header = Row::new(header_row).style(t.table_header_style);
 
-        let rows = self
+        let rows: Vec<Row> = self
             .table
-            .filtered
-            .items
-            .iter()
+            .items()
             .enumerate()
             .map(|(idx, item)| {
                 Row::new(vec![
-                    Line::from(item.name.as_str()),
-                    Line::from(item.endpoint.as_str()),
+                    Line::from(item.name.clone()),
+                    Line::from(item.endpoint.clone()),
                     Line::from(
                         item.managed
                             .as_ref()
@@ -137,7 +133,8 @@ impl Widget for &mut ConfigModel {
                     }),
                 ])
                 .style(self.table.row_style(idx))
-            });
+            })
+            .collect();
 
         let t = Table::new(
             rows,
@@ -162,7 +159,7 @@ impl Widget for &mut ConfigModel {
             }
         })
         .row_highlight_style(t.selected_row_style);
-        StatefulWidget::render(t, content_area, buf, &mut self.table.filtered.state);
+        StatefulWidget::render(t, content_area, buf, self.table.state_mut());
 
         // Render any active popup (error or commands)
         (&self.popup).render(area, buf);

--- a/src/app/model/dagruns/mod.rs
+++ b/src/app/model/dagruns/mod.rs
@@ -98,7 +98,7 @@ impl DagRunModel {
     pub fn sort_dag_runs(&mut self) {
         // Sort by logical_date (execution date) descending, with fallback to start_date
         // This ensures queued runs (which have no start_date yet) appear in chronological order
-        self.table.filtered.items.sort_by(|a, b| {
+        self.table.sort_by(|a, b| {
             b.logical_date
                 .or(b.start_date)
                 .cmp(&a.logical_date.or(a.start_date))
@@ -117,15 +117,11 @@ impl DagRunModel {
 
     /// Mark a DAG run with a new status (optimistic update)
     pub fn mark_dag_run(&mut self, dag_run_id: &DagRunId, status: DagRunState) {
-        if let Some(dag_run) = self
-            .table
-            .filtered
-            .items
-            .iter_mut()
-            .find(|dr| dr.dag_run_id == *dag_run_id)
-        {
-            dag_run.state = status;
-        }
+        self.table.update_all(|all| {
+            if let Some(dag_run) = all.iter_mut().find(|dr| dr.dag_run_id == *dag_run_id) {
+                dag_run.state = status;
+            }
+        });
     }
 }
 
@@ -165,7 +161,7 @@ impl DagRunModel {
                     matches!(custom_popup, DagRunPopUp::Clear(_) | DagRunPopUp::Mark(_));
                 self.popup.close();
                 if exit_visual {
-                    self.table.visual_anchor = None;
+                    self.table.clear_visual_mode();
                 }
             }
         }
@@ -396,14 +392,16 @@ mod tests {
             ..Default::default()
         };
 
-        model.table.all = vec![oldest_run, newest_run, queued_run];
+        model
+            .table
+            .set_items(vec![oldest_run, newest_run, queued_run]);
         model.table.apply_filter();
         model.sort_dag_runs();
 
-        assert_eq!(model.table.filtered.items.len(), 3);
-        assert_eq!(model.table.filtered.items[0].dag_run_id, "run_3");
-        assert_eq!(model.table.filtered.items[1].dag_run_id, "run_2");
-        assert_eq!(model.table.filtered.items[2].dag_run_id, "run_1");
+        assert_eq!(model.table.len(), 3);
+        assert_eq!(model.table.items().next().unwrap().dag_run_id, "run_3");
+        assert_eq!(model.table.items().nth(1).unwrap().dag_run_id, "run_2");
+        assert_eq!(model.table.items().nth(2).unwrap().dag_run_id, "run_1");
     }
 
     #[test]
@@ -430,13 +428,13 @@ mod tests {
             ..Default::default()
         };
 
-        model.table.all = vec![run_with_both, run_with_start];
+        model.table.set_items(vec![run_with_both, run_with_start]);
         model.table.apply_filter();
         model.sort_dag_runs();
 
-        assert_eq!(model.table.filtered.items.len(), 2);
-        assert_eq!(model.table.filtered.items[0].dag_run_id, "run_1");
-        assert_eq!(model.table.filtered.items[1].dag_run_id, "run_2");
+        assert_eq!(model.table.len(), 2);
+        assert_eq!(model.table.items().next().unwrap().dag_run_id, "run_1");
+        assert_eq!(model.table.items().nth(1).unwrap().dag_run_id, "run_2");
     }
 
     #[test]
@@ -461,11 +459,11 @@ mod tests {
             ..Default::default()
         };
 
-        model.table.all = vec![run_manual, run_scheduled];
+        model.table.set_items(vec![run_manual, run_scheduled]);
 
-        model.table.filter.activate();
+        model.table.filter_mut().activate();
         for c in "manual".chars() {
-            model.table.filter.update(
+            model.table.filter_mut().update(
                 &KeyEvent::new(crossterm::event::KeyCode::Char(c), KeyModifiers::empty()),
                 &DagRun::filterable_fields(),
             );
@@ -473,7 +471,10 @@ mod tests {
         model.table.apply_filter();
         model.sort_dag_runs();
 
-        assert_eq!(model.table.filtered.items.len(), 1);
-        assert_eq!(model.table.filtered.items[0].dag_run_id, "manual_run_1");
+        assert_eq!(model.table.len(), 1);
+        assert_eq!(
+            model.table.items().next().unwrap().dag_run_id,
+            "manual_run_1"
+        );
     }
 }

--- a/src/app/model/dagruns/popup/trigger/table.rs
+++ b/src/app/model/dagruns/popup/trigger/table.rs
@@ -8,8 +8,9 @@ use ratatui::{
 use crate::ui::theme::theme;
 
 use super::params::{ParamEntry, ParamKind};
-use super::text::{truncate_cols, value_window, wrap_text};
+use super::text::{value_window, wrap_text};
 use super::TriggerDagRunPopUp;
+use crate::ui::common::truncate_cols;
 
 /// Total inter-column padding the table reserves (1 col between each of 3 columns).
 const COLUMN_GAPS: usize = 2;

--- a/src/app/model/dagruns/popup/trigger/text.rs
+++ b/src/app/model/dagruns/popup/trigger/text.rs
@@ -63,21 +63,9 @@ pub(super) fn value_window(value: &str, cursor_pos: usize, width: usize) -> (Str
     (before, cursor_char, after)
 }
 
-/// Truncate a string to at most `max_cols` columns, appending `…` if clipped.
-pub(super) fn truncate_cols(s: &str, max_cols: usize) -> String {
-    if s.chars().count() <= max_cols {
-        return s.to_string();
-    }
-    if max_cols == 0 {
-        return String::new();
-    }
-    let kept: String = s.chars().take(max_cols - 1).collect();
-    format!("{kept}…")
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{truncate_cols, value_window, wrap_text};
+    use super::{value_window, wrap_text};
 
     #[test]
     fn wrap_text_breaks_on_word_boundaries() {
@@ -86,13 +74,6 @@ mod tests {
         assert!(wrap_text("", 10).is_empty());
         // A word wider than the column is hard-split.
         assert_eq!(wrap_text("abcdefgh", 3), vec!["abc", "def", "gh"]);
-    }
-
-    #[test]
-    fn truncate_appends_ellipsis_when_clipped() {
-        assert_eq!(truncate_cols("hello", 10), "hello");
-        assert_eq!(truncate_cols("hello world", 5), "hell…");
-        assert_eq!(truncate_cols("hello", 0), "");
     }
 
     #[test]

--- a/src/app/model/dagruns/render.rs
+++ b/src/app/model/dagruns/render.rs
@@ -40,9 +40,7 @@ impl Widget for &mut DagRunModel {
         // Calculate max duration for normalization
         let max_duration = self
             .table
-            .filtered
-            .items
-            .iter()
+            .items()
             .filter_map(calculate_duration)
             .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
             .unwrap_or(1.0);
@@ -56,11 +54,9 @@ impl Widget for &mut DagRunModel {
             .saturating_sub(fixed_columns_width + dag_run_id_width)
             .max(10) as usize;
 
-        let rows = self
+        let rows: Vec<Row> = self
             .table
-            .filtered
-            .items
-            .iter()
+            .items()
             .enumerate()
             .map(|(idx, item)| {
                 let state_color: Color = AirflowStateColor::from(&item.state).into();
@@ -82,7 +78,7 @@ impl Widget for &mut DagRunModel {
                 Row::new(vec![
                     Line::from(Span::styled("■", Style::default().fg(state_color))),
                     Line::from(Span::styled(
-                        &*item.dag_run_id,
+                        item.dag_run_id.to_string(),
                         Style::default().add_modifier(Modifier::BOLD),
                     )),
                     Line::from(if let Some(date) = item.logical_date {
@@ -96,7 +92,8 @@ impl Widget for &mut DagRunModel {
                     time_cell,
                 ])
                 .style(self.table.row_style(idx))
-            });
+            })
+            .collect();
         let t = Table::new(
             rows,
             &[
@@ -122,7 +119,7 @@ impl Widget for &mut DagRunModel {
             }
         })
         .row_highlight_style(t.selected_row_style);
-        StatefulWidget::render(t, content_area, buf, &mut self.table.filtered.state);
+        StatefulWidget::render(t, content_area, buf, self.table.state_mut());
 
         if let Some(view) = &mut self.dag_code {
             view.render(area, buf);

--- a/src/app/model/dags/render.rs
+++ b/src/app/model/dags/render.rs
@@ -20,11 +20,9 @@ impl Widget for &mut DagModel {
         let headers = ["Active", "Name", "Owners", "Schedule", "Next Run", "Stats"];
         let header_row = create_headers(headers);
         let header = Row::new(header_row).style(theme.table_header_style);
-        let rows = self
+        let rows: Vec<Row> = self
             .table
-            .filtered
-            .items
-            .iter()
+            .items()
             .enumerate()
             .map(|(idx, item)| {
                 Row::new(vec![
@@ -34,12 +32,16 @@ impl Widget for &mut DagModel {
                         Line::from(Span::styled("𖣘", Style::default().fg(theme.dag_active)))
                     },
                     Line::from(Span::styled(
-                        &*item.dag_id,
+                        item.dag_id.to_string(),
                         Style::default().add_modifier(Modifier::BOLD),
                     )),
                     Line::from(item.owners.join(", ")),
-                    Line::from(item.timetable_description.as_deref().unwrap_or("None"))
-                        .style(Style::default().fg(theme.schedule_fg)),
+                    Line::from(
+                        item.timetable_description
+                            .clone()
+                            .unwrap_or_else(|| "None".to_string()),
+                    )
+                    .style(Style::default().fg(theme.schedule_fg)),
                     Line::from(item.next_dagrun_create_after.map_or_else(
                         || "None".to_string(),
                         convert_datetimeoffset_to_human_readable_remaining_time,
@@ -66,7 +68,8 @@ impl Widget for &mut DagModel {
                     )),
                 ])
                 .style(self.table.row_style(idx))
-            });
+            })
+            .collect();
         let table = Table::new(
             rows,
             &[
@@ -93,7 +96,7 @@ impl Widget for &mut DagModel {
         })
         .row_highlight_style(theme.selected_row_style);
 
-        StatefulWidget::render(table, content_area, buf, &mut self.table.filtered.state);
+        StatefulWidget::render(table, content_area, buf, self.table.state_mut());
 
         if let Some(view) = &mut self.dag_code {
             view.render(area, buf);

--- a/src/app/model/filter/matching.rs
+++ b/src/app/model/filter/matching.rs
@@ -21,16 +21,18 @@ pub fn matches<T: Filterable>(item: &T, conditions: &[FilterCondition]) -> bool 
     item_matches(item, conditions)
 }
 
-/// Filter a collection of items by conditions
-pub fn filter_items<T: Filterable + Clone>(items: &[T], conditions: &[FilterCondition]) -> Vec<T> {
+/// Filter a collection of items by conditions, returning the indices of the
+/// matches so callers can reference the originals instead of cloning them.
+pub fn filter_items<T: Filterable>(items: &[T], conditions: &[FilterCondition]) -> Vec<usize> {
     if conditions.is_empty() {
-        return items.to_vec();
+        return (0..items.len()).collect();
     }
 
     items
         .iter()
-        .filter(|item| item_matches(*item, conditions))
-        .cloned()
+        .enumerate()
+        .filter(|&(_, item)| item_matches(item, conditions))
+        .map(|(i, _)| i)
         .collect()
 }
 
@@ -149,7 +151,7 @@ mod tests {
         ];
         let filtered = filter_items(&items, &conditions);
         assert_eq!(filtered.len(), 1);
-        assert_eq!(filtered[0].id, "item_1");
+        assert_eq!(items[filtered[0]].id, "item_1");
     }
 
     #[test]

--- a/src/app/model/filterable_table/mod.rs
+++ b/src/app/model/filterable_table/mod.rs
@@ -55,12 +55,6 @@ impl<T: Filterable + Clone> FilterableTable<T> {
         self.filtered.items = filtered;
     }
 
-    /// Activates filter mode
-    pub fn activate_filter(&mut self) {
-        self.filter.activate();
-        self.apply_filter();
-    }
-
     /// Handles a key event for the filter.
     /// This handles both:
     /// - `/` key when filter is inactive (activates filter)

--- a/src/app/model/filterable_table/mod.rs
+++ b/src/app/model/filterable_table/mod.rs
@@ -69,10 +69,12 @@ impl<T: Filterable> FilterableTable<T> {
         self.update_all(|all| all.sort_by(cmp));
     }
 
-    /// Remove all items (and any selection).
+    /// Remove all items, along with the selection and any visual-mode anchor
+    /// that pointed into them. The filter text is kept.
     pub fn clear(&mut self) {
         self.all.clear();
-        self.apply_filter();
+        self.view = StatefulTable::new(Vec::new());
+        self.visual_anchor = None;
     }
 
     /// Read-only access to the canonical items.
@@ -286,6 +288,32 @@ mod tests {
         assert!(table.view.items.is_empty());
         assert_eq!(table.view.items.len(), 0);
         assert!(table.current().is_none());
+    }
+
+    #[test]
+    fn clear_drops_the_selection_and_visual_anchor() {
+        let mut table: FilterableTable<TestItem> = FilterableTable::new();
+        table.set_items(vec![
+            TestItem {
+                id: "1".to_string(),
+                status: "running".to_string(),
+            },
+            TestItem {
+                id: "2".to_string(),
+                status: "success".to_string(),
+            },
+        ]);
+        table.view.next();
+        table.view.next();
+        table.visual_anchor = Some(0);
+        assert_eq!(table.selected_position(), Some(1));
+
+        table.clear();
+
+        assert!(table.is_empty());
+        assert!(table.current().is_none());
+        assert_eq!(table.selected_position(), None);
+        assert!(table.visual_anchor.is_none());
     }
 
     #[test]

--- a/src/app/model/filterable_table/mod.rs
+++ b/src/app/model/filterable_table/mod.rs
@@ -9,50 +9,136 @@
 
 mod render;
 
+use std::cmp::Ordering;
 use std::ops::RangeInclusive;
 
 use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::widgets::TableState;
 
 use super::filter::{filter_items, FilterStateMachine, Filterable};
 use super::{KeyResult, StatefulTable};
 
-/// A generic filterable table that combines data storage, filtering, and visual selection.
+/// A generic filterable, selectable table shared by the Dags, `DagRuns`, and
+/// `TaskInstances` panels.
 ///
-/// This widget is designed to work with any type that implements `Filterable + Clone`.
+/// It owns the canonical `all` items and derives a filtered, ordered *view* of
+/// indices into them, so matched items are never cloned. Callers interact
+/// through the item-oriented API (`items`, `current`, `sort_by`, ...) and never
+/// see the index representation, which is free to change (e.g. to shared `Arc`
+/// data) without touching them.
 #[derive(Debug, Clone, Default)]
 pub struct FilterableTable<T> {
-    /// All items from the API (unfiltered)
-    pub all: Vec<T>,
-    /// Filtered items with table state for rendering
-    pub filtered: StatefulTable<T>,
-    /// Filter state machine with autocomplete
-    pub filter: FilterStateMachine,
-    /// Anchor index for visual selection; `Some` means visual mode is active
-    pub visual_anchor: Option<usize>,
+    /// Canonical items, kept in display/sort order.
+    all: Vec<T>,
+    /// Indices into `all` that pass the filter, with the table selection state.
+    view: StatefulTable<usize>,
+    /// Filter state machine with autocomplete.
+    filter: FilterStateMachine,
+    /// Anchor position for visual selection; `Some` means visual mode is active.
+    visual_anchor: Option<usize>,
 }
 
-impl<T: Filterable + Clone> FilterableTable<T> {
+impl<T: Filterable> FilterableTable<T> {
     /// Creates a new empty filterable table
     pub fn new() -> Self {
         Self {
             all: Vec::new(),
-            filtered: StatefulTable::new(Vec::new()),
+            view: StatefulTable::new(Vec::new()),
             filter: FilterStateMachine::default(),
             visual_anchor: None,
         }
     }
 
-    /// Sets the items and applies the current filter
+    // ── Data ────────────────────────────────────────────────
+
+    /// Replace all items and recompute the filtered view.
     pub fn set_items(&mut self, items: Vec<T>) {
         self.all = items;
         self.apply_filter();
     }
 
-    /// Applies the current filter conditions to the items
+    /// Reorder or mutate the canonical items in place, then refresh the view.
+    /// Used for sorting and optimistic updates; the view stays in `all`'s order.
+    pub fn update_all(&mut self, f: impl FnOnce(&mut Vec<T>)) {
+        f(&mut self.all);
+        self.apply_filter();
+    }
+
+    /// Sort the items with `cmp` and refresh the view.
+    pub fn sort_by(&mut self, cmp: impl FnMut(&T, &T) -> Ordering) {
+        self.update_all(|all| all.sort_by(cmp));
+    }
+
+    /// Remove all items (and any selection).
+    pub fn clear(&mut self) {
+        self.all.clear();
+        self.apply_filter();
+    }
+
+    /// Read-only access to the canonical items.
+    pub fn all(&self) -> &[T] {
+        &self.all
+    }
+
+    /// Recompute the filtered view from the current filter conditions.
     pub fn apply_filter(&mut self) {
         let conditions = self.filter.active_conditions();
-        let filtered = filter_items(&self.all, &conditions);
-        self.filtered.items = filtered;
+        self.view.items = filter_items(&self.all, &conditions);
+    }
+
+    // ── The filtered view ───────────────────────────────────
+
+    /// Iterate the filtered items in display order.
+    pub fn items(&self) -> impl Iterator<Item = &T> {
+        self.view.items.iter().filter_map(|&i| self.all.get(i))
+    }
+
+    /// Number of items in the filtered view.
+    pub fn len(&self) -> usize {
+        self.view.items.len()
+    }
+
+    /// Whether the filtered view is empty.
+    pub fn is_empty(&self) -> bool {
+        self.view.items.is_empty()
+    }
+
+    /// Resolve a position in the filtered view to its item.
+    pub fn item_at(&self, pos: usize) -> Option<&T> {
+        self.all.get(*self.view.items.get(pos)?)
+    }
+
+    /// The currently selected item, if any.
+    pub fn current(&self) -> Option<&T> {
+        self.item_at(self.view.state.selected()?)
+    }
+
+    /// The currently selected item, mutably.
+    pub fn current_mut(&mut self) -> Option<&mut T> {
+        let index = *self.view.items.get(self.view.state.selected()?)?;
+        self.all.get_mut(index)
+    }
+
+    /// The selected position within the filtered view.
+    pub fn selected_position(&self) -> Option<usize> {
+        self.view.state.selected()
+    }
+
+    /// Mutable table state, for driving the ratatui `StatefulWidget` render.
+    pub fn state_mut(&mut self) -> &mut TableState {
+        &mut self.view.state
+    }
+
+    // ── Filter ──────────────────────────────────────────────
+
+    /// Read-only access to the filter state (active flag, cursor, display).
+    pub fn filter(&self) -> &FilterStateMachine {
+        &self.filter
+    }
+
+    /// Mutable access to the filter state (e.g. to set autocomplete values).
+    pub fn filter_mut(&mut self) -> &mut FilterStateMachine {
+        &mut self.filter
     }
 
     /// Handles a key event for the filter.
@@ -68,32 +154,18 @@ impl<T: Filterable + Clone> FilterableTable<T> {
         }
     }
 
-    /// Returns the currently selected item
-    pub fn current(&self) -> Option<&T> {
-        self.filtered
-            .state
-            .selected()
-            .and_then(|i| self.filtered.items.get(i))
-    }
+    // ── Selection / visual mode ─────────────────────────────
 
-    /// Returns the currently selected item mutably
-    pub fn current_mut(&mut self) -> Option<&mut T> {
-        self.filtered
-            .state
-            .selected()
-            .and_then(|i| self.filtered.items.get_mut(i))
-    }
-
-    /// Returns the inclusive range of selected indices, if in visual mode
+    /// Returns the inclusive range of selected positions, if in visual mode
     pub fn visual_selection(&self) -> Option<RangeInclusive<usize>> {
         let anchor = self.visual_anchor?;
-        let cursor = self.filtered.state.selected()?;
-        let (start, end) = if anchor <= cursor {
-            (anchor, cursor)
-        } else {
-            (cursor, anchor)
-        };
-        Some(start..=end)
+        let cursor = self.view.state.selected()?;
+        Some(anchor.min(cursor)..=anchor.max(cursor))
+    }
+
+    /// Exit visual selection mode.
+    pub fn clear_visual_mode(&mut self) {
+        self.visual_anchor = None;
     }
 
     /// Returns count of selected items (for bottom border display)
@@ -110,14 +182,11 @@ impl<T: Filterable + Clone> FilterableTable<T> {
     {
         match self.visual_selection() {
             Some(range) => range
-                .filter_map(|i| self.filtered.items.get(i))
+                .filter_map(|pos| self.item_at(pos))
                 .map(&key_fn)
                 .collect(),
             None => self
-                .filtered
-                .state
-                .selected()
-                .and_then(|i| self.filtered.items.get(i))
+                .current()
                 .map(|item| vec![key_fn(item)])
                 .unwrap_or_default(),
         }
@@ -131,25 +200,23 @@ impl<T: Filterable + Clone> FilterableTable<T> {
     ) -> KeyResult {
         match key_code {
             KeyCode::Down | KeyCode::Char('j') => {
-                self.filtered.next();
+                self.view.next();
                 KeyResult::Consumed
             }
             KeyCode::Up | KeyCode::Char('k') => {
-                self.filtered.previous();
+                self.view.previous();
                 KeyResult::Consumed
             }
             KeyCode::Char('G') => {
-                if !self.filtered.items.is_empty() {
-                    self.filtered
-                        .state
-                        .select(Some(self.filtered.items.len() - 1));
+                if !self.view.items.is_empty() {
+                    self.view.state.select(Some(self.view.items.len() - 1));
                 }
                 KeyResult::Consumed
             }
             KeyCode::Char('g') => {
                 if let Some(last_key) = event_buffer.pop() {
                     if last_key == KeyCode::Char('g') {
-                        self.filtered.state.select_first();
+                        self.view.state.select_first();
                     } else {
                         event_buffer.push(last_key);
                         event_buffer.push(key_code);
@@ -167,7 +234,7 @@ impl<T: Filterable + Clone> FilterableTable<T> {
     pub fn handle_visual_mode_key(&mut self, key_code: KeyCode) -> KeyResult {
         match key_code {
             KeyCode::Char('V') => {
-                if let Some(cursor) = self.filtered.state.selected() {
+                if let Some(cursor) = self.view.state.selected() {
                     self.visual_anchor = Some(cursor);
                 }
                 KeyResult::Consumed
@@ -216,8 +283,8 @@ mod tests {
     #[test]
     fn test_new_table_is_empty() {
         let table: FilterableTable<TestItem> = FilterableTable::new();
-        assert!(table.filtered.items.is_empty());
-        assert_eq!(table.filtered.items.len(), 0);
+        assert!(table.view.items.is_empty());
+        assert_eq!(table.view.items.len(), 0);
         assert!(table.current().is_none());
     }
 
@@ -235,8 +302,8 @@ mod tests {
             },
         ];
         table.set_items(items);
-        assert_eq!(table.filtered.items.len(), 2);
-        assert!(!table.filtered.items.is_empty());
+        assert_eq!(table.view.items.len(), 2);
+        assert!(!table.view.items.is_empty());
     }
 
     #[test]
@@ -261,22 +328,19 @@ mod tests {
         assert!(table.current().is_none());
 
         // Move next, should select first
-        table.filtered.next();
+        table.view.next();
         assert_eq!(table.current().map(|i| i.id.as_str()), Some("1"));
 
         // Move next
-        table.filtered.next();
+        table.view.next();
         assert_eq!(table.current().map(|i| i.id.as_str()), Some("2"));
 
         // Select last
-        table
-            .filtered
-            .state
-            .select(Some(table.filtered.items.len() - 1));
+        table.view.state.select(Some(table.view.items.len() - 1));
         assert_eq!(table.current().map(|i| i.id.as_str()), Some("3"));
 
         // Select first
-        table.filtered.state.select_first();
+        table.view.state.select_first();
         assert_eq!(table.current().map(|i| i.id.as_str()), Some("1"));
     }
 
@@ -299,18 +363,18 @@ mod tests {
         ]);
 
         // Select first item
-        table.filtered.next();
+        table.view.next();
         assert!(table.visual_selection().is_none());
 
         // Enter visual mode
-        table.visual_anchor = table.filtered.state.selected();
+        table.visual_anchor = table.view.state.selected();
         assert!(table.visual_anchor.is_some());
         assert_eq!(table.visual_anchor, Some(0));
         assert_eq!(table.visual_selection_count(), 1);
 
         // Move down to expand selection
-        table.filtered.next();
-        table.filtered.next();
+        table.view.next();
+        table.view.next();
         assert_eq!(table.visual_selection_count(), 3);
 
         // Get selected IDs
@@ -341,7 +405,7 @@ mod tests {
         assert!(table.selected_ids(|item| item.id.clone()).is_empty());
 
         // Select first item
-        table.filtered.next();
+        table.view.next();
         let ids = table.selected_ids(|item| item.id.clone());
         assert_eq!(ids, vec!["1"]);
     }
@@ -415,7 +479,7 @@ mod tests {
         ]);
 
         // Select first item
-        table.filtered.next();
+        table.view.next();
         assert!(table.visual_anchor.is_none());
 
         // V key enters visual mode

--- a/src/app/model/filterable_table/render.rs
+++ b/src/app/model/filterable_table/render.rs
@@ -8,7 +8,7 @@ use crate::ui::theme::theme;
 
 use super::FilterableTable;
 
-impl<T: Filterable + Clone> FilterableTable<T> {
+impl<T: Filterable> FilterableTable<T> {
     /// Renders the filter widget if active and returns the content area.
     ///
     /// This handles the common pattern of splitting the area for filter input.

--- a/src/app/model/logs/mod.rs
+++ b/src/app/model/logs/mod.rs
@@ -93,27 +93,21 @@ impl LogModel {
         self.scroll_mode = ScrollMode::Following;
     }
 
-    /// Update the logs content. When in follow mode, the scroll position
-    /// will automatically track the bottom at render time.
+    /// Update the logs content, keeping the selected try in range.
+    ///
+    /// Clamping here rather than on every read means `current` is always a
+    /// valid index, so readers can use it directly. When in follow mode, the
+    /// scroll position tracks the bottom at render time.
     pub fn update_logs(&mut self, logs: Vec<Log>) {
         self.all = logs;
+        self.current = self.current.min(self.all.len().saturating_sub(1));
         self.refresh_search();
-    }
-
-    /// Index of the currently selected log (task try), wrapped into range.
-    ///
-    /// `current` can exceed `all.len()` after `update_logs` replaces the list
-    /// with fewer tries, so the selection is wrapped rather than assumed valid.
-    /// Returns 0 for an empty list; pair with [`current_log`](Self::current_log)
-    /// to distinguish "empty" from "first entry".
-    fn current_index(&self) -> usize {
-        self.current % self.all.len().max(1)
     }
 
     /// Returns the currently selected log (the task try being viewed), if any.
     /// `None` when no logs are loaded.
     fn current_log(&self) -> Option<&Log> {
-        self.all.get(self.current_index())
+        self.all.get(self.current)
     }
 
     /// Returns the total number of lines in the current log content
@@ -124,12 +118,11 @@ impl LogModel {
 
     /// Recompute search matches against the current log tab's content.
     fn refresh_search(&mut self) {
-        if self.all.is_empty() {
-            self.search.refresh("");
-        } else {
-            let idx = self.current % self.all.len();
-            self.search.refresh(&self.all[idx].content);
-        }
+        let content = self
+            .all
+            .get(self.current)
+            .map_or("", |log| log.content.as_str());
+        self.search.refresh(content);
     }
 
     /// Apply an edit to the query while the search bar is open, then jump to
@@ -284,7 +277,7 @@ impl Model for LogModel {
                                             clippy::cast_possible_truncation,
                                             reason = "value is bounded by terminal/layout dimensions and stays well within the target integer range"
                                         )]
-                                        task_try: (self.current_index() + 1) as u32,
+                                        task_try: (self.current + 1) as u32,
                                     })],
                                 );
                             }
@@ -509,16 +502,29 @@ mod tests {
     }
 
     #[test]
-    fn current_index_wraps_when_selection_exceeds_len() {
-        // After `update_logs` shrinks the list, a stale `current` must wrap into
-        // range rather than point past the end (or panic).
+    fn update_logs_clamps_selection_to_the_last_try() {
+        // A stale `current` is pulled back to the last try, not wrapped: after a
+        // shrink you want the newest try, not an arbitrary one modular arithmetic
+        // happens to land on.
+        let mut model = LogModel {
+            current: 4,
+            ..Default::default()
+        };
+        model.update_logs(vec![log("a"), log("b"), log("c")]);
+
+        assert_eq!(model.current, 2); // clamped to last; wrapping would give 1
+        assert!(model.current_log().is_some());
+    }
+
+    #[test]
+    fn update_logs_with_empty_list_resets_selection() {
         let mut model = LogModel {
             current: 3,
             ..Default::default()
         };
-        model.update_logs(vec![log("a"), log("b")]);
+        model.update_logs(vec![]);
 
-        assert_eq!(model.current_index(), 1); // 3 % 2
-        assert!(model.current_log().is_some());
+        assert_eq!(model.current, 0);
+        assert!(model.current_log().is_none());
     }
 }

--- a/src/app/model/logs/render.rs
+++ b/src/app/model/logs/render.rs
@@ -48,7 +48,7 @@ impl Widget for &mut LogModel {
                     .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
                     .border_style(t.border_style),
             )
-            .select(self.current_index())
+            .select(self.current)
             .highlight_style(Style::default().fg(t.accent).add_modifier(Modifier::BOLD))
             .style(t.default_style);
 
@@ -72,8 +72,7 @@ impl Widget for &mut LogModel {
                 .split(area)
         };
 
-        let index = self.current_index();
-        if let Some(log) = self.all.get(index) {
+        if let Some(log) = self.all.get(self.current) {
             let content = match self.search.data() {
                 Some(data) if !data.matches.is_empty() => highlighted_content(&log.content, data),
                 _ => log.content.lines().map(Line::raw).collect(),

--- a/src/app/model/taskinstances/mod.rs
+++ b/src/app/model/taskinstances/mod.rs
@@ -73,21 +73,17 @@ impl TaskInstanceModel {
     /// Sort task instances by topological order (or timestamp fallback)
     pub fn sort_task_instances(&mut self) {
         if let Some(graph) = &self.task_graph {
-            sort_task_instances(&mut self.table.all, graph);
+            self.table.update_all(|all| sort_task_instances(all, graph));
         }
     }
 
     /// Mark a task instance with a new status (optimistic update)
     pub fn mark_task_instance(&mut self, task_id: &TaskId, status: TaskInstanceState) {
-        if let Some(task_instance) = self
-            .table
-            .filtered
-            .items
-            .iter_mut()
-            .find(|ti| ti.task_id == *task_id)
-        {
-            task_instance.state = Some(status);
-        }
+        self.table.update_all(|all| {
+            if let Some(task_instance) = all.iter_mut().find(|ti| ti.task_id == *task_id) {
+                task_instance.state = Some(status);
+            }
+        });
     }
 
     /// Returns selected task IDs for passing to mark/clear popups
@@ -117,7 +113,7 @@ impl TaskInstanceModel {
                 KeyCode::Enter | KeyCode::Esc | KeyCode::Char('q')
             ) {
                 self.popup.close();
-                self.table.visual_anchor = None;
+                self.table.clear_visual_mode();
             }
         }
         Some(messages)
@@ -171,7 +167,7 @@ impl TaskInstanceModel {
             KeyCode::Char('d') => {
                 if let Some(graph) = &self.task_graph {
                     if !graph.is_empty() {
-                        let popup = DagGraphPopup::new(graph, &self.table.all);
+                        let popup = DagGraphPopup::new(graph, self.table.all());
                         self.popup.show_custom(TaskInstancePopUp::Graph(popup));
                     }
                 }

--- a/src/app/model/taskinstances/render.rs
+++ b/src/app/model/taskinstances/render.rs
@@ -42,15 +42,13 @@ impl Widget for &mut TaskInstanceModel {
         let table_inner_width = content_area.width.saturating_sub(2); // Subtract borders
         let gantt_width = (table_inner_width / 2).max(10);
 
-        let rows = self
+        let rows: Vec<Row> = self
             .table
-            .filtered
-            .items
-            .iter()
+            .items()
             .enumerate()
             .map(|(idx, item)| {
                 Row::new(vec![
-                    Line::from(item.task_id.as_ref()),
+                    Line::from(item.task_id.to_string()),
                     Line::from(
                         calculate_duration(item).map_or_else(|| "-".to_string(), format_duration),
                     ),
@@ -63,7 +61,8 @@ impl Widget for &mut TaskInstanceModel {
                     create_gantt_bar(&self.gantt_data, &item.task_id, gantt_width.into()),
                 ])
                 .style(self.table.row_style(idx))
-            });
+            })
+            .collect();
         let t = Table::new(
             rows,
             &[
@@ -89,7 +88,7 @@ impl Widget for &mut TaskInstanceModel {
         })
         .row_highlight_style(t.selected_row_style);
 
-        StatefulWidget::render(t, content_area, buffer, &mut self.table.filtered.state);
+        StatefulWidget::render(t, content_area, buffer, self.table.state_mut());
 
         legend.render(legend_area, buffer);
 

--- a/src/app/state/breadcrumb.rs
+++ b/src/app/state/breadcrumb.rs
@@ -26,7 +26,7 @@ impl App {
         }
 
         if self.active_panel == Panel::TaskInstance || self.active_panel == Panel::Logs {
-            if let Some(task_instance) = self.task_instances.table.filtered.items.first() {
+            if let Some(task_instance) = self.task_instances.table.items().next() {
                 if let Some(logical_date) = task_instance.logical_date {
                     let formatted = logical_date
                         .format(&BREADCRUMB_DATE_FORMAT)

--- a/src/app/state/breadcrumb.rs
+++ b/src/app/state/breadcrumb.rs
@@ -3,6 +3,7 @@ use std::sync::LazyLock;
 use time::format_description::BorrowedFormatItem;
 
 use super::{App, Panel};
+use crate::ui::common::truncate_cols;
 
 /// Cached date format for breadcrumb display (YYYY-MM-DD)
 static BREADCRUMB_DATE_FORMAT: LazyLock<Vec<BorrowedFormatItem<'static>>> = LazyLock::new(|| {
@@ -20,7 +21,7 @@ impl App {
 
         if self.active_panel != Panel::Config && self.active_panel != Panel::Dag {
             if let Some(dag_id) = self.nav_context.dag_id() {
-                let truncated = Self::truncate_breadcrumb_part(dag_id, 25);
+                let truncated = truncate_cols(dag_id, 25);
                 parts.push(truncated);
             }
         }
@@ -33,18 +34,18 @@ impl App {
                         .unwrap_or_else(|_| "unknown".to_string());
                     parts.push(formatted);
                 } else if let Some(dag_run_id) = self.nav_context.dag_run_id() {
-                    let truncated = Self::truncate_breadcrumb_part(dag_run_id, 20);
+                    let truncated = truncate_cols(dag_run_id, 20);
                     parts.push(truncated);
                 }
             } else if let Some(dag_run_id) = self.nav_context.dag_run_id() {
-                let truncated = Self::truncate_breadcrumb_part(dag_run_id, 20);
+                let truncated = truncate_cols(dag_run_id, 20);
                 parts.push(truncated);
             }
         }
 
         if self.active_panel == Panel::Logs {
             if let Some(task_id) = self.nav_context.task_id() {
-                let truncated = Self::truncate_breadcrumb_part(task_id, 20);
+                let truncated = truncate_cols(task_id, 20);
                 parts.push(truncated);
             }
         }
@@ -55,20 +56,6 @@ impl App {
             Some(parts[0].clone())
         } else {
             None
-        }
-    }
-
-    fn truncate_breadcrumb_part(s: &str, max_chars: usize) -> String {
-        let char_count = s.chars().count();
-        if char_count <= max_chars {
-            s.to_string()
-        } else {
-            let truncate_at = max_chars.saturating_sub(3);
-            let byte_index = s
-                .char_indices()
-                .nth(truncate_at)
-                .map_or(s.len(), |(idx, _)| idx);
-            format!("{}...", &s[..byte_index])
         }
     }
 }

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -12,7 +12,7 @@ use crate::app::model::dagruns::DagRunModel;
 use crate::app::model::dags::DagModel;
 use crate::app::model::popup::error::ErrorPopup;
 use crate::app::model::popup::warning::WarningPopup;
-use crate::app::model::Model;
+use crate::app::model::{FilterableTable, Model};
 use crate::app::worker::WorkerMessage;
 use environment_state::EnvironmentStateContainer;
 use flowrs_config::FlowrsConfig;
@@ -152,9 +152,9 @@ impl App {
     pub fn clear_state(&mut self) {
         self.loading = true;
         self.nav_context.reset_to_environment();
-        self.dags.table.all.clear();
-        self.dagruns.table.all.clear();
-        self.task_instances.table.all.clear();
+        self.dags.table = FilterableTable::new();
+        self.dagruns.table = FilterableTable::new();
+        self.task_instances.table = FilterableTable::new();
         self.logs.all.clear();
     }
 }

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -156,5 +156,7 @@ impl App {
         self.dagruns.table = FilterableTable::new();
         self.task_instances.table = FilterableTable::new();
         self.logs.all.clear();
+        self.logs.current = 0;
+        self.logs.reset_scroll();
     }
 }

--- a/src/app/state/sync.rs
+++ b/src/app/state/sync.rs
@@ -5,36 +5,41 @@ impl App {
     pub fn sync_panel(&mut self, panel: &Panel) {
         match panel {
             Panel::Dag => {
-                self.dags.table.all = self.environment_state.get_active_dags();
+                self.dags
+                    .table
+                    .set_items(self.environment_state.get_active_dags());
                 self.dags.dag_stats = self.environment_state.get_active_dag_stats();
                 let dag_ids: Vec<String> = self
                     .dags
                     .table
-                    .all
+                    .all()
                     .iter()
                     .map(|d| d.dag_id.to_string())
                     .collect();
-                self.dags.table.filter.set_primary_values("dag_id", dag_ids);
-                self.dags.table.apply_filter();
+                self.dags
+                    .table
+                    .filter_mut()
+                    .set_primary_values("dag_id", dag_ids);
             }
             Panel::DAGRun => {
                 if let Some(dag_id) = self.nav_context.dag_id() {
-                    self.dagruns.table.all = self.environment_state.get_active_dag_runs(dag_id);
+                    self.dagruns
+                        .table
+                        .set_items(self.environment_state.get_active_dag_runs(dag_id));
                     let dag_run_ids: Vec<String> = self
                         .dagruns
                         .table
-                        .all
+                        .all()
                         .iter()
                         .map(|dr| dr.dag_run_id.to_string())
                         .collect();
                     self.dagruns
                         .table
-                        .filter
+                        .filter_mut()
                         .set_primary_values("dag_run_id", dag_run_ids);
-                    self.dagruns.table.apply_filter();
                     self.dagruns.sort_dag_runs();
                 } else {
-                    self.dagruns.table.all.clear();
+                    self.dagruns.table.clear();
                 }
             }
             Panel::TaskInstance => {
@@ -42,24 +47,24 @@ impl App {
                     (self.nav_context.dag_id(), self.nav_context.dag_run_id())
                 {
                     self.task_instances.set_gantt_context(dag_id, dag_run_id);
-                    self.task_instances.table.all = self
-                        .environment_state
-                        .get_active_task_instances(dag_id, dag_run_id);
+                    self.task_instances.table.set_items(
+                        self.environment_state
+                            .get_active_task_instances(dag_id, dag_run_id),
+                    );
                     self.task_instances.sort_task_instances();
                     let task_ids: Vec<String> = self
                         .task_instances
                         .table
-                        .all
+                        .all()
                         .iter()
                         .map(|ti| ti.task_id.to_string())
                         .collect();
                     self.task_instances
                         .table
-                        .filter
+                        .filter_mut()
                         .set_primary_values("task_id", task_ids);
-                    self.task_instances.table.apply_filter();
                 } else {
-                    self.task_instances.table.all.clear();
+                    self.task_instances.table.clear();
                 }
             }
             Panel::Logs => {
@@ -80,13 +85,13 @@ impl App {
                 let config_names: Vec<String> = self
                     .configs
                     .table
-                    .all
+                    .all()
                     .iter()
                     .map(|c| c.name.clone())
                     .collect();
                 self.configs
                     .table
-                    .filter
+                    .filter_mut()
                     .set_primary_values("name", config_names);
             }
         }

--- a/src/app/state/sync.rs
+++ b/src/app/state/sync.rs
@@ -117,7 +117,9 @@ impl App {
                             .get_active_task_logs(dag_id, dag_run_id, task_id),
                     );
                 } else {
-                    self.logs.all.clear();
+                    // Go through update_logs so the selected try is clamped and
+                    // the search matches are refreshed, like any other update.
+                    self.logs.update_logs(Vec::new());
                 }
             }
             Panel::Config => {

--- a/src/app/state/sync.rs
+++ b/src/app/state/sync.rs
@@ -36,7 +36,10 @@ impl App {
                         .iter()
                         .flat_map(|d| d.owners.iter().cloned()),
                 );
-                self.dags.table.filter_mut().set_field_values("owners", owners);
+                self.dags
+                    .table
+                    .filter_mut()
+                    .set_field_values("owners", owners);
                 let tags = distinct(
                     self.dags
                         .table
@@ -129,7 +132,8 @@ impl App {
                     .table
                     .filter_mut()
                     .set_primary_values("name", config_names);
-                let endpoints = distinct(self.configs.table.all().iter().map(|c| c.endpoint.clone()));
+                let endpoints =
+                    distinct(self.configs.table.all().iter().map(|c| c.endpoint.clone()));
                 self.configs
                     .table
                     .filter_mut()

--- a/src/app/state/sync.rs
+++ b/src/app/state/sync.rs
@@ -1,5 +1,13 @@
 use super::{App, Panel};
 
+/// Collect autocomplete candidates: sorted, de-duplicated, blanks dropped.
+fn distinct(values: impl Iterator<Item = String>) -> Vec<String> {
+    let mut values: Vec<String> = values.filter(|v| !v.is_empty()).collect();
+    values.sort_unstable();
+    values.dedup();
+    values
+}
+
 impl App {
     /// Sync a specific panel's data from `environment_state`.
     pub fn sync_panel(&mut self, panel: &Panel) {
@@ -20,6 +28,23 @@ impl App {
                     .table
                     .filter_mut()
                     .set_primary_values("dag_id", dag_ids);
+                // Free-text fields autocomplete from the values actually present.
+                let owners = distinct(
+                    self.dags
+                        .table
+                        .all()
+                        .iter()
+                        .flat_map(|d| d.owners.iter().cloned()),
+                );
+                self.dags.table.filter_mut().set_field_values("owners", owners);
+                let tags = distinct(
+                    self.dags
+                        .table
+                        .all()
+                        .iter()
+                        .flat_map(|d| d.tags.iter().map(|t| t.name.clone())),
+                );
+                self.dags.table.filter_mut().set_field_values("tags", tags);
             }
             Panel::DAGRun => {
                 if let Some(dag_id) = self.nav_context.dag_id() {
@@ -63,6 +88,17 @@ impl App {
                         .table
                         .filter_mut()
                         .set_primary_values("task_id", task_ids);
+                    let operators = distinct(
+                        self.task_instances
+                            .table
+                            .all()
+                            .iter()
+                            .filter_map(|ti| ti.operator.clone()),
+                    );
+                    self.task_instances
+                        .table
+                        .filter_mut()
+                        .set_field_values("operator", operators);
                 } else {
                     self.task_instances.table.clear();
                 }
@@ -93,7 +129,27 @@ impl App {
                     .table
                     .filter_mut()
                     .set_primary_values("name", config_names);
+                let endpoints = distinct(self.configs.table.all().iter().map(|c| c.endpoint.clone()));
+                self.configs
+                    .table
+                    .filter_mut()
+                    .set_field_values("endpoint", endpoints);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::distinct;
+
+    #[test]
+    fn distinct_sorts_dedups_and_drops_blanks() {
+        let got = distinct(
+            ["bob", "alice", "bob", "", "alice"]
+                .into_iter()
+                .map(str::to_string),
+        );
+        assert_eq!(got, vec!["alice", "bob"]);
     }
 }

--- a/src/app/worker/config.rs
+++ b/src/app/worker/config.rs
@@ -14,10 +14,10 @@ pub fn handle_config_selected(app: &Arc<Mutex<App>>, idx: usize) -> Result<()> {
         .lock()
         .map_err(|_| anyhow::anyhow!("Failed to acquire app lock"))?;
 
-    let Some(selected_config) = app.configs.table.filtered.items.get(idx).cloned() else {
+    let Some(selected_config) = app.configs.table.item_at(idx).cloned() else {
         log::error!(
             "Config index {idx} out of bounds (total: {})",
-            app.configs.table.filtered.items.len()
+            app.configs.table.len()
         );
         app.configs
             .popup

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -98,26 +98,26 @@ pub fn draw_ui(f: &mut Frame, app: &Arc<Mutex<App>>) {
     match app.active_panel {
         Panel::Config => {
             app.configs.render(panel_area, f.buffer_mut());
-            if app.configs.table.filter.is_active() {
-                f.set_cursor_position(app.configs.table.filter.cursor_position);
+            if app.configs.table.filter().is_active() {
+                f.set_cursor_position(app.configs.table.filter().cursor_position);
             }
         }
         Panel::Dag => {
             app.dags.render(panel_area, f.buffer_mut());
-            if app.dags.table.filter.is_active() {
-                f.set_cursor_position(app.dags.table.filter.cursor_position);
+            if app.dags.table.filter().is_active() {
+                f.set_cursor_position(app.dags.table.filter().cursor_position);
             }
         }
         Panel::DAGRun => {
             app.dagruns.render(panel_area, f.buffer_mut());
-            if app.dagruns.table.filter.is_active() {
-                f.set_cursor_position(app.dagruns.table.filter.cursor_position);
+            if app.dagruns.table.filter().is_active() {
+                f.set_cursor_position(app.dagruns.table.filter().cursor_position);
             }
         }
         Panel::TaskInstance => {
             app.task_instances.render(panel_area, f.buffer_mut());
-            if app.task_instances.table.filter.is_active() {
-                f.set_cursor_position(app.task_instances.table.filter.cursor_position);
+            if app.task_instances.table.filter().is_active() {
+                f.set_cursor_position(app.task_instances.table.filter().cursor_position);
             }
         }
         Panel::Logs => {

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -3,9 +3,37 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, BorderType, Borders},
 };
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use super::constants::AirflowStateColor;
 use super::theme::theme;
+
+/// Truncate `s` to at most `max_cols` terminal columns, appending `…` if clipped.
+///
+/// Measures display width rather than counting `char`s, so wide characters
+/// (CJK, emoji) cannot overflow the cell they are rendered into.
+pub fn truncate_cols(s: &str, max_cols: usize) -> String {
+    if s.width() <= max_cols {
+        return s.to_string();
+    }
+    if max_cols == 0 {
+        return String::new();
+    }
+    // Reserve one column for the ellipsis.
+    let budget = max_cols - 1;
+    let mut out = String::new();
+    let mut used = 0;
+    for ch in s.chars() {
+        let w = ch.width().unwrap_or(0);
+        if used + w > budget {
+            break;
+        }
+        out.push(ch);
+        used += w;
+    }
+    out.push('…');
+    out
+}
 
 /// Builds a modal popup `Block` with the shared popup chrome: rounded, fully
 /// bordered, themed border and background, and a title padded with a single
@@ -35,4 +63,26 @@ pub fn create_headers<'a>(
 
 pub fn state_to_colored_square<'a>(color: AirflowStateColor) -> Span<'a> {
     Span::styled("■", Style::default().fg(color.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_cols;
+
+    #[test]
+    fn truncate_appends_ellipsis_when_clipped() {
+        assert_eq!(truncate_cols("hello", 10), "hello");
+        assert_eq!(truncate_cols("hello world", 5), "hell…");
+        assert_eq!(truncate_cols("hello", 0), "");
+    }
+
+    #[test]
+    fn truncate_measures_display_width_not_char_count() {
+        // Each CJK glyph occupies two columns, so only two fit alongside the
+        // ellipsis in a six-column cell. Counting chars would have kept five
+        // and overflowed to ten columns.
+        assert_eq!(truncate_cols("日本語テスト", 6), "日本…");
+        // A string of wide chars that exactly fills the cell is left alone.
+        assert_eq!(truncate_cols("日本語", 6), "日本語");
+    }
 }

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -3,7 +3,7 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, BorderType, Borders},
 };
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_width::UnicodeWidthStr;
 
 use super::constants::AirflowStateColor;
 use super::theme::theme;
@@ -19,17 +19,18 @@ pub fn truncate_cols(s: &str, max_cols: usize) -> String {
     if max_cols == 0 {
         return String::new();
     }
-    // Reserve one column for the ellipsis.
+    // Reserve one column for the ellipsis. The prefix is measured as a string
+    // after each append rather than by summing per-char widths, because a
+    // sequence such as an emoji presentation selector can widen the preceding
+    // char without carrying any width of its own.
     let budget = max_cols - 1;
     let mut out = String::new();
-    let mut used = 0;
     for ch in s.chars() {
-        let w = ch.width().unwrap_or(0);
-        if used + w > budget {
+        out.push(ch);
+        if out.as_str().width() > budget {
+            out.pop();
             break;
         }
-        out.push(ch);
-        used += w;
     }
     out.push('…');
     out
@@ -68,6 +69,7 @@ pub fn state_to_colored_square<'a>(color: AirflowStateColor) -> Span<'a> {
 #[cfg(test)]
 mod tests {
     use super::truncate_cols;
+    use unicode_width::UnicodeWidthStr;
 
     #[test]
     fn truncate_appends_ellipsis_when_clipped() {
@@ -84,5 +86,19 @@ mod tests {
         assert_eq!(truncate_cols("日本語テスト", 6), "日本…");
         // A string of wide chars that exactly fills the cell is left alone.
         assert_eq!(truncate_cols("日本語", 6), "日本語");
+    }
+
+    #[test]
+    fn truncate_bounds_grapheme_sequences_by_string_width() {
+        // U+2639 is one column on its own, but the U+FE0F presentation selector
+        // after it makes the pair render as a two-column emoji. Summing per-char
+        // widths would have kept both and overflowed a two-column cell.
+        let out = truncate_cols("\u{2639}\u{FE0F}x", 2);
+        assert!(
+            out.as_str().width() <= 2,
+            "got {out:?} at width {}",
+            out.as_str().width()
+        );
+        assert!(out.ends_with('…'));
     }
 }


### PR DESCRIPTION
Consolidates #692, #695, #698, #700 and #701 into one PR, rebased onto current `main`. They all touch `FilterableTable`, `App::clear_state` and `sync_panel`, and #700 had a real conflict with the log search that landed in #600. Each original commit is preserved; #700 is re-applied as a fresh commit on top of the search code.

## What's in here

**Fix DAG list cursor carrying over between environments** (#695)
- `clear_state()` only cleared each table's items; the filtered view and its `TableState` (selected index, scroll offset) survived an environment switch, so landing in a smaller environment parked the cursor on the last row. The tables are now reset wholesale, which also drops a filter written for the previous environment. Also removes the uncalled `FilterableTable::activate_filter`.

**Encapsulate `FilterableTable` behind an item-oriented API** (#692)
- `all`, `filtered`, `filter` and `visual_anchor` are private. Callers go through `items()`, `current()`, `item_at()`, `sort_by()`, `update_all()`, `set_items()`, `clear()`, `filter()` / `filter_mut()` and `state_mut()`.
- The filtered view holds indices into `all` instead of cloned items, so the per-keystroke and per-refresh clone of every matched row is gone.
- Sorting and optimistic `mark_*` updates now write to the canonical items. Before, `mark_dag_run` / `mark_task_instance` mutated the cloned `filtered` copy, which the next 2s refresh silently reverted.
- `clear()` also drops the selection and visual anchor, which pointed into the items just removed. As written in #692 it kept them, which would have reintroduced the #695 bug on the `sync_panel` paths.

**Wire up autocomplete for free-text filter fields** (#701)
- `FilterStateMachine::set_field_values` existed but was never called, so `owners`, `tags`, `operator` and `endpoint` never offered suggestions. `sync_panel` now populates them from the loaded data, on top of #692's accessors.

**Unify the two truncate helpers and measure display width** (#698)
- One `ui::common::truncate_cols` replaces `trigger/text.rs::truncate_cols` and `breadcrumb.rs::truncate_breadcrumb_part`, and measures terminal columns via `unicode-width` instead of counting chars, so CJK and emoji ids no longer overflow their cell. Breadcrumbs now clip with `…` like everything else.

**Reset log selection at context boundaries instead of clamping on read** (#700, re-applied)
- `clear_state()` now resets `logs.current` and the scroll mode, the same way `state/context.rs` does on a task-context change. Before, a `current = 3` from the previous environment opened a two-try task on try 2.
- `update_logs` clamps `current` when it writes the list, so readers use it directly and `current_index()` is gone. `refresh_search` from #600 now reads the clamped index as well instead of doing its own modulo.

## Conflict resolutions

- #692 vs #695 in `clear_state`: kept #695's `FilterableTable::new()` reset (which also clears the filter) over #692's `clear()`.
- #701 vs #692 in `sync.rs`: #701's additions rewritten on the `all()` / `filter_mut()` accessors.
- #700 vs `main` in `logs/mod.rs`: re-applied by hand around `refresh_search`.

## Verification

- `cargo fmt --all --check` clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo test --workspace --lib --bins`: all passing, including a new regression test that `clear()` drops the selection and visual anchor, and the two `update_logs` clamp tests from #700

Supersedes #692, #695, #698, #700 and #701.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVavx7CTnHC3sYnG7ZJpwk

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVavx7CTnHC3sYnG7ZJpwk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added autocomplete suggestions for DAG owners, tags, task operators, and configuration endpoints.
  * Improved text truncation based on terminal display width, including wide characters.

* **Bug Fixes**
  * Prevented invalid log selection after refreshing or clearing logs.
  * Improved state resets when switching or clearing panels.
  * Ensured filtered and selected items remain consistent during sorting, marking, and navigation.

* **Refactor**
  * Improved table filtering, selection, sorting, and rendering consistency across panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->