### PR TITLE
chore: release flowrs-airflow v0.12.0, flowrs-config v0.13.0, flowrs-tui v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.14.2](https://github.com/jvanbuel/flowrs/compare/flowrs-tui-v0.14.1...flowrs-tui-v0.14.2) - 2026-09-02
+## [0.15.0](https://github.com/jvanbuel/flowrs/compare/flowrs-tui-v0.14.1...flowrs-tui-v0.15.0) - 2026-09-02
+
+### Added
+
+- Autocomplete for the free-text `owners`, `tags`, `operator` and `endpoint` filter fields
+- The error popup shows Airflow's own reason when a trigger, clear or mark request is rejected
+
+### Fixed
+
+- DAG list cursor and filter no longer carry over when switching environments
+- Log try selection and scroll position no longer carry over when switching environments
+- Optimistic mark updates on DAG runs and task instances are no longer reverted by the next refresh
+- Reverse-proxy path prefixes are preserved in API requests and "open in browser" URLs
+- Truncated text is measured in terminal columns, so wide characters no longer overflow their cell; breadcrumbs clip with `…`
 
 ### Other
+
+- Encapsulate `FilterableTable` behind an item-oriented API and stop cloning matched rows on every keystroke and refresh
+- Unify the two truncate helpers
 
 - Bound the body read on non-success responses
 - Tidy imports and docs after the trait-layer removal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2](https://github.com/jvanbuel/flowrs/compare/flowrs-tui-v0.14.1...flowrs-tui-v0.14.2) - 2026-09-02
+
+### Other
+
+- Bound the body read on non-success responses
+- Tidy imports and docs after the trait-layer removal
+- Remove re-export-only shim modules
+- Collapse single-implementation Airflow trait layer
+- Remove unreachable API operations and dead helpers
+- *(airflow)* give the library a canonical error type
+
 ## [0.14.1](https://github.com/jvanbuel/flowrs/compare/flowrs-tui-v0.14.0...flowrs-tui-v0.14.1) - 2026-08-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-airflow"
-version = "0.11.4"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-config"
-version = "0.12.4"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-tui"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-airflow"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-config"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "flowrs-tui"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -2296,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
 dependencies = [
  "libc",
 ]
@@ -3714,9 +3714,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ useless_let_if_seq = "allow"
 
 [package]
 name = "flowrs-tui"
-version = "0.14.2"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Flowrs is a Terminal User Interface (TUI) for Apache Airflow"
@@ -82,8 +82,8 @@ formula = "flowrs"
 ansi-to-tui = { version = "8.0.1" }
 anyhow = { workspace = true }
 catppuccin = { workspace = true }
-flowrs-config = { path = "crates/flowrs-config", version = "0.12.4" }
-flowrs-airflow = { path = "crates/flowrs-airflow", version = "0.11.4" }
+flowrs-config = { path = "crates/flowrs-config", version = "0.13.0" }
+flowrs-airflow = { path = "crates/flowrs-airflow", version = "0.12.0" }
 chrono = { workspace = true }
 clap = { workspace = true }
 crossterm = { version = "0.29.0", features = ["event-stream"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ useless_let_if_seq = "allow"
 
 [package]
 name = "flowrs-tui"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Flowrs is a Terminal User Interface (TUI) for Apache Airflow"
@@ -82,8 +82,8 @@ formula = "flowrs"
 ansi-to-tui = { version = "8.0.1" }
 anyhow = { workspace = true }
 catppuccin = { workspace = true }
-flowrs-config = { path = "crates/flowrs-config", version = "0.12.3" }
-flowrs-airflow = { path = "crates/flowrs-airflow", version = "0.11.3" }
+flowrs-config = { path = "crates/flowrs-config", version = "0.12.4" }
+flowrs-airflow = { path = "crates/flowrs-airflow", version = "0.11.4" }
 chrono = { workspace = true }
 clap = { workspace = true }
 crossterm = { version = "0.29.0", features = ["event-stream"] }

--- a/crates/flowrs-airflow/CHANGELOG.md
+++ b/crates/flowrs-airflow/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.11.4](https://github.com/jvanbuel/flowrs/compare/flowrs-airflow-v0.11.3...flowrs-airflow-v0.11.4) - 2026-09-02
+## [0.12.0](https://github.com/jvanbuel/flowrs/compare/flowrs-airflow-v0.11.3...flowrs-airflow-v0.12.0) - 2026-09-02
+
+### Changed
+
+- **Breaking:** every fallible operation returns `AirflowError` instead of `anyhow::Error`; non-success responses carry Airflow's response body and parse failures include a body snippet
+- **Breaking:** `endpoint()` returns the parsed `&Url`; `BaseClient` fields, `V1Client::base` / `V2Client::base` and `base_api` are no longer public
+- **Breaking:** removed the unused `AirflowApiClient`, `create_api_client`, `fetch_all_dagruns` and `fetch_all_task_instances`
 
 ### Fixed
 

--- a/crates/flowrs-airflow/CHANGELOG.md
+++ b/crates/flowrs-airflow/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.4](https://github.com/jvanbuel/flowrs/compare/flowrs-airflow-v0.11.3...flowrs-airflow-v0.11.4) - 2026-09-02
+
+### Fixed
+
+- *(airflow)* preserve proxy prefix and query string in the client
+
+### Other
+
+- Bound the body read on non-success responses
+- Remove re-export-only shim modules
+- Remove unreachable API operations and dead helpers
+- *(airflow)* give the library a canonical error type
+
 ## [0.11.3](https://github.com/jvanbuel/flowrs/compare/flowrs-airflow-v0.11.2...flowrs-airflow-v0.11.3) - 2026-08-30
 
 ### Other

--- a/crates/flowrs-airflow/Cargo.toml
+++ b/crates/flowrs-airflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-airflow"
-version = "0.11.4"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Airflow API client library"

--- a/crates/flowrs-airflow/Cargo.toml
+++ b/crates/flowrs-airflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-airflow"
-version = "0.11.3"
+version = "0.11.4"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Airflow API client library"

--- a/crates/flowrs-config/CHANGELOG.md
+++ b/crates/flowrs-config/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.12.4](https://github.com/jvanbuel/flowrs/compare/flowrs-config-v0.12.3...flowrs-config-v0.12.4) - 2026-09-02
+## [0.13.0](https://github.com/jvanbuel/flowrs/compare/flowrs-config-v0.12.3...flowrs-config-v0.13.0) - 2026-09-02
+
+### Changed
+
+- **Breaking:** removed the `auth` and `server` re-export modules; import the types from the crate root
+- **Breaking:** removed the unused `ConfigPaths::xdg_config_dir`
 
 ### Other
 

--- a/crates/flowrs-config/CHANGELOG.md
+++ b/crates/flowrs-config/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.4](https://github.com/jvanbuel/flowrs/compare/flowrs-config-v0.12.3...flowrs-config-v0.12.4) - 2026-09-02
+
+### Other
+
+- Remove re-export-only shim modules
+- Remove unreachable API operations and dead helpers
+
 ## [0.12.3](https://github.com/jvanbuel/flowrs/compare/flowrs-config-v0.12.2...flowrs-config-v0.12.3) - 2026-08-30
 
 ### Other

--- a/crates/flowrs-config/Cargo.toml
+++ b/crates/flowrs-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-config"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Configuration types for flowrs"
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/jvanbuel/flowrs"
 
 [dependencies]
-flowrs-airflow = { path = "../flowrs-airflow", version = "0.11.3", default-features = false }
+flowrs-airflow = { path = "../flowrs-airflow", version = "0.11.4", default-features = false }
 anyhow.workspace = true
 clap.workspace = true
 dirs.workspace = true

--- a/crates/flowrs-config/Cargo.toml
+++ b/crates/flowrs-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowrs-config"
-version = "0.12.4"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.87.0"
 description = "Configuration types for flowrs"
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/jvanbuel/flowrs"
 
 [dependencies]
-flowrs-airflow = { path = "../flowrs-airflow", version = "0.11.4", default-features = false }
+flowrs-airflow = { path = "../flowrs-airflow", version = "0.12.0", default-features = false }
 anyhow.workspace = true
 clap.workspace = true
 dirs.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `flowrs-airflow`: 0.11.3 -> 0.11.4
* `flowrs-config`: 0.12.3 -> 0.12.4
* `flowrs-tui`: 0.14.1 -> 0.14.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `flowrs-airflow`

<blockquote>

## [0.11.4](https://github.com/jvanbuel/flowrs/compare/flowrs-airflow-v0.11.3...flowrs-airflow-v0.11.4) - 2026-09-02

### Fixed

- *(airflow)* preserve proxy prefix and query string in the client

### Other

- Bound the body read on non-success responses
- Remove re-export-only shim modules
- Remove unreachable API operations and dead helpers
- *(airflow)* give the library a canonical error type
</blockquote>

## `flowrs-config`

<blockquote>

## [0.12.4](https://github.com/jvanbuel/flowrs/compare/flowrs-config-v0.12.3...flowrs-config-v0.12.4) - 2026-09-02

### Other

- Remove re-export-only shim modules
- Remove unreachable API operations and dead helpers
</blockquote>

## `flowrs-tui`

<blockquote>

## [0.14.2](https://github.com/jvanbuel/flowrs/compare/flowrs-tui-v0.14.1...flowrs-tui-v0.14.2) - 2026-09-02

### Other

- Bound the body read on non-success responses
- Tidy imports and docs after the trait-layer removal
- Remove re-export-only shim modules
- Collapse single-implementation Airflow trait layer
- Remove unreachable API operations and dead helpers
- *(airflow)* give the library a canonical error type
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).